### PR TITLE
contrib: add mock wallet-balance, transaction-history, payment-reques…

### DIFF
--- a/contrib/routes/issue-25-wallet-balance/README.md
+++ b/contrib/routes/issue-25-wallet-balance/README.md
@@ -1,0 +1,34 @@
+# Mock route: wallet balance (Issue #25)
+
+Standalone mock GET route returning a fixed, hardcoded wallet balance. No real
+chain or database access — for local UI/dev testing only.
+
+## Run
+
+```sh
+node route.mjs
+# wallet-balance mock listening on http://localhost:4025/wallet-balance
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /wallet-balance
+```
+
+Response:
+
+```json
+{
+  "balance": "1250.5000000",
+  "assetCode": "XLM"
+}
+```

--- a/contrib/routes/issue-25-wallet-balance/route.mjs
+++ b/contrib/routes/issue-25-wallet-balance/route.mjs
@@ -1,0 +1,29 @@
+// Mock GET route returning a static wallet balance. No chain or DB access.
+import http from "node:http";
+
+const MOCK_BALANCE = {
+  balance: "1250.5000000",
+  assetCode: "XLM",
+};
+
+export function handleRequest() {
+  return { status: 200, body: MOCK_BALANCE };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/wallet-balance") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4025;
+  server.listen(port, () => {
+    console.log(`wallet-balance mock listening on http://localhost:${port}/wallet-balance`);
+  });
+}

--- a/contrib/routes/issue-25-wallet-balance/route.test.mjs
+++ b/contrib/routes/issue-25-wallet-balance/route.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const { status, body } = handleRequest();
+
+assert.equal(status, 200);
+assert.equal(typeof body.balance, "string");
+assert.equal(typeof body.assetCode, "string");
+assert.equal(body.assetCode, "XLM");
+
+console.log("PASS: /wallet-balance returns balance + assetCode");

--- a/contrib/routes/issue-26-transaction-history/README.md
+++ b/contrib/routes/issue-26-transaction-history/README.md
@@ -1,0 +1,44 @@
+# Mock route: transaction history (Issue #26)
+
+Standalone mock GET route returning a fixed array of sample transaction
+records. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# transaction-history mock listening on http://localhost:4026/transactions
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /transactions?limit=2
+```
+
+Response:
+
+```json
+[
+  {
+    "hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "amount": "50.0000000",
+    "timestamp": "2026-07-20T09:15:00Z"
+  },
+  {
+    "hash": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+    "amount": "12.5000000",
+    "timestamp": "2026-07-21T14:32:00Z"
+  }
+]
+```
+
+Omit `limit` (or pass an invalid value) to get the full 5-item sample set.

--- a/contrib/routes/issue-26-transaction-history/route.mjs
+++ b/contrib/routes/issue-26-transaction-history/route.mjs
@@ -1,0 +1,64 @@
+// Mock GET route listing sample transaction history. No chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+
+const MOCK_TRANSACTIONS = [
+  {
+    hash: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    amount: "50.0000000",
+    timestamp: "2026-07-20T09:15:00Z",
+  },
+  {
+    hash: "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+    amount: "12.5000000",
+    timestamp: "2026-07-21T14:32:00Z",
+  },
+  {
+    hash: "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    amount: "200.0000000",
+    timestamp: "2026-07-23T02:47:00Z",
+  },
+  {
+    hash: "d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5",
+    amount: "3.2500000",
+    timestamp: "2026-07-25T18:03:00Z",
+  },
+  {
+    hash: "e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6",
+    amount: "75.0000000",
+    timestamp: "2026-07-27T11:59:00Z",
+  },
+];
+
+function parseLimit(rawLimit) {
+  if (rawLimit === undefined || rawLimit === null || rawLimit === "") return undefined;
+  const parsed = Number(rawLimit);
+  if (!Number.isInteger(parsed) || parsed < 0) return undefined;
+  return parsed;
+}
+
+export function handleRequest({ query = {} } = {}) {
+  const limit = parseLimit(query.limit);
+  const transactions = limit === undefined ? MOCK_TRANSACTIONS : MOCK_TRANSACTIONS.slice(0, limit);
+  return { status: 200, body: transactions };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/transactions") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleRequest({ query });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4026;
+  server.listen(port, () => {
+    console.log(`transaction-history mock listening on http://localhost:${port}/transactions`);
+  });
+}

--- a/contrib/routes/issue-26-transaction-history/route.test.mjs
+++ b/contrib/routes/issue-26-transaction-history/route.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// No limit: returns the full sample set.
+const full = handleRequest({ query: {} });
+assert.equal(full.status, 200);
+assert.ok(Array.isArray(full.body));
+assert.equal(full.body.length, 5);
+for (const tx of full.body) {
+  assert.equal(typeof tx.hash, "string");
+  assert.equal(typeof tx.amount, "string");
+  assert.equal(typeof tx.timestamp, "string");
+}
+
+// limit=2: trims to the first 2 records.
+const limited = handleRequest({ query: { limit: "2" } });
+assert.equal(limited.body.length, 2);
+assert.deepEqual(limited.body, full.body.slice(0, 2));
+
+// limit larger than the sample set: returns everything, no padding.
+const overLimit = handleRequest({ query: { limit: "100" } });
+assert.equal(overLimit.body.length, 5);
+
+// invalid limit: falls back to the full set.
+const invalidLimit = handleRequest({ query: { limit: "not-a-number" } });
+assert.equal(invalidLimit.body.length, 5);
+
+console.log("PASS: /transactions honors the limit query parameter");

--- a/contrib/routes/issue-27-payment-request/README.md
+++ b/contrib/routes/issue-27-payment-request/README.md
@@ -1,0 +1,69 @@
+# Mock route: payment request (Issue #27)
+
+Standalone mock POST route that accepts a payment request payload and echoes
+back a validation result. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# payment-request mock listening on http://localhost:4027/payment-request
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+### Success
+
+Request:
+
+```
+POST /payment-request
+Content-Type: application/json
+
+{
+  "recipient": "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH",
+  "amount": "25.0000000",
+  "asset": "XLM"
+}
+```
+
+Response (`200`):
+
+```json
+{
+  "valid": true,
+  "recipient": "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH",
+  "amount": "25.0000000",
+  "asset": "XLM"
+}
+```
+
+### Error (missing field)
+
+Request:
+
+```
+POST /payment-request
+Content-Type: application/json
+
+{
+  "recipient": "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH",
+  "asset": "XLM"
+}
+```
+
+Response (`400`):
+
+```json
+{
+  "error": "invalid_request",
+  "message": "Missing required field(s): amount",
+  "missingFields": ["amount"]
+}
+```

--- a/contrib/routes/issue-27-payment-request/route.mjs
+++ b/contrib/routes/issue-27-payment-request/route.mjs
@@ -1,0 +1,64 @@
+// Mock POST route accepting a payment request payload and echoing back a
+// validation result. No chain or DB access.
+import http from "node:http";
+
+const REQUIRED_FIELDS = ["recipient", "amount", "asset"];
+
+export function handleRequest({ body = {} } = {}) {
+  const missingFields = REQUIRED_FIELDS.filter(
+    (field) => body[field] === undefined || body[field] === null || body[field] === "",
+  );
+
+  if (missingFields.length > 0) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_request",
+        message: `Missing required field(s): ${missingFields.join(", ")}`,
+        missingFields,
+      },
+    };
+  }
+
+  return {
+    status: 200,
+    body: {
+      valid: true,
+      recipient: body.recipient,
+      amount: body.amount,
+      asset: body.asset,
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/payment-request") {
+      let raw = "";
+      req.on("data", (chunk) => (raw += chunk));
+      req.on("end", () => {
+        let body = {};
+        try {
+          body = raw ? JSON.parse(raw) : {};
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ error: "invalid_json", message: "Request body must be valid JSON" }),
+          );
+          return;
+        }
+        const { status, body: responseBody } = handleRequest({ body });
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(responseBody));
+      });
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4027;
+  server.listen(port, () => {
+    console.log(`payment-request mock listening on http://localhost:${port}/payment-request`);
+  });
+}

--- a/contrib/routes/issue-27-payment-request/route.test.mjs
+++ b/contrib/routes/issue-27-payment-request/route.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// Success case: all required fields present.
+const success = handleRequest({
+  body: {
+    recipient: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH",
+    amount: "25.0000000",
+    asset: "XLM",
+  },
+});
+assert.equal(success.status, 200);
+assert.equal(success.body.valid, true);
+assert.equal(success.body.recipient, "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH");
+
+// Error case: missing "amount".
+const missingAmount = handleRequest({
+  body: { recipient: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH", asset: "XLM" },
+});
+assert.equal(missingAmount.status, 400);
+assert.equal(missingAmount.body.error, "invalid_request");
+assert.deepEqual(missingAmount.body.missingFields, ["amount"]);
+
+// Error case: empty body, all fields missing.
+const emptyBody = handleRequest({ body: {} });
+assert.equal(emptyBody.status, 400);
+assert.deepEqual(emptyBody.body.missingFields, ["recipient", "amount", "asset"]);
+
+console.log("PASS: /payment-request validates recipient, amount, asset");

--- a/contrib/routes/issue-28-account-status/README.md
+++ b/contrib/routes/issue-28-account-status/README.md
@@ -1,0 +1,36 @@
+# Mock route: account status (Issue #28)
+
+Standalone mock GET route returning a fixed account status payload for a
+given account id path parameter. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# account-status mock listening on http://localhost:4028/account-status/:accountId
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /account-status/GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH
+```
+
+Response:
+
+```json
+{
+  "accountId": "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH",
+  "exists": true,
+  "funded": true,
+  "sequence": "123456789012345"
+}
+```

--- a/contrib/routes/issue-28-account-status/route.mjs
+++ b/contrib/routes/issue-28-account-status/route.mjs
@@ -1,0 +1,48 @@
+// Mock GET route returning a fake account status. No chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+
+export function handleRequest({ params = {} } = {}) {
+  const { accountId } = params;
+
+  if (!accountId) {
+    return {
+      status: 400,
+      body: { error: "invalid_request", message: "accountId path parameter is required" },
+    };
+  }
+
+  return {
+    status: 200,
+    body: {
+      accountId,
+      exists: true,
+      funded: true,
+      sequence: "123456789012345",
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    const match = url.pathname.match(/^\/account-status\/([^/]+)$/);
+    if (req.method === "GET" && match) {
+      const { status, body } = handleRequest({
+        params: { accountId: decodeURIComponent(match[1]) },
+      });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4028;
+  server.listen(port, () => {
+    console.log(
+      `account-status mock listening on http://localhost:${port}/account-status/:accountId`,
+    );
+  });
+}

--- a/contrib/routes/issue-28-account-status/route.test.mjs
+++ b/contrib/routes/issue-28-account-status/route.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// The account id path parameter is echoed back correctly.
+const accountId = "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH";
+const { status, body } = handleRequest({ params: { accountId } });
+
+assert.equal(status, 200);
+assert.equal(body.accountId, accountId);
+assert.equal(typeof body.exists, "boolean");
+assert.equal(typeof body.funded, "boolean");
+assert.equal(typeof body.sequence, "string");
+
+// A different account id is reflected back as-is, not hardcoded.
+const otherId = "GXYZ999999999999999999999999999999999999999999999999999999";
+const other = handleRequest({ params: { accountId: otherId } });
+assert.equal(other.body.accountId, otherId);
+
+// Missing account id is rejected.
+const missing = handleRequest({ params: {} });
+assert.equal(missing.status, 400);
+
+console.log("PASS: /account-status/:accountId echoes the requested account id");


### PR DESCRIPTION
  ## Summary
  Adds four standalone mock route handlers under `contrib/routes/`, each self-contained with a
  README, a runnable example server, and a test script. No changes outside `contrib/`.

  - `contrib/routes/issue-25-wallet-balance/` — GET route returning a fixed wallet balance
  (`balance`, `assetCode`)
  - `contrib/routes/issue-26-transaction-history/` — GET route returning sample transactions
  (`hash`, `amount`, `timestamp`), with a `limit` query param
  - `contrib/routes/issue-27-payment-request/` — POST route validating
  `recipient`/`amount`/`asset`, returning a 400-style error object on missing fields
  - `contrib/routes/issue-28-account-status/` — GET route returning `exists`/`funded`/`sequence`
  for an account id path parameter, echoed back in the response

  ## Test plan
  - [x] `node route.test.mjs` passes in each of the 4 folders
  - [x] Manually started each `route.mjs` server and curled it, confirming the example
  request/response in each README
  - [x] `prettier --check` passes on all added files
  - [x] Change is entirely inside `contrib/`

  Closes #25
  Closes #26
  Closes #27
  Closes #28