### PR TITLE
contrib: add four mock GET routes for asset, policy, and session data

### DIFF
--- a/contrib/routes/issue-30-asset-list/README.md
+++ b/contrib/routes/issue-30-asset-list/README.md
@@ -1,0 +1,65 @@
+# Mock route: paginated asset list (Issue #30)
+
+Standalone mock GET route returning a paginated list of sample asset
+entries. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# asset-list mock listening on http://localhost:4030/assets?page=&pageSize=
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /assets?page=2&pageSize=5
+```
+
+Response:
+
+```json
+{
+  "items": [
+    {
+      "code": "SHX",
+      "issuer": "GDSTRSHXHGJ7ZIVRBXEYE5Q74XUVCUSEKEBR7UCHEUUJK6PPZOD4KEUY",
+      "balance": "12000.0000000"
+    },
+    {
+      "code": "USDT",
+      "issuer": "GCQTGZQQ5G4PTM2GL7CDIFKUBIPEC52BROAQIAPW53XBRJVN6ZJVTG6V",
+      "balance": "999.9900000"
+    },
+    {
+      "code": "MOBI",
+      "issuer": "GA6HCMBLTZS5VYYBCATRBRZ3BZJMAFUDKYYF6AH6MVCMGWMRDNSWJPIH",
+      "balance": "42.0000000"
+    },
+    {
+      "code": "RIO",
+      "issuer": "GCFVEHW5VXTQCLXIN2CGKGMKZOUQOMOQ5PL22F5C6HG5CY73GYYZ6RIO",
+      "balance": "1500.0000000"
+    },
+    {
+      "code": "SLT",
+      "issuer": "GCKA6K5PCQ6PNF5RQBF7PQDJWRHOKUJT5IWEG7NRZDGCQNK7PGYQHYCE",
+      "balance": "300.7500000"
+    }
+  ],
+  "total": 12,
+  "page": 2,
+  "pageSize": 5
+}
+```
+
+`page` defaults to `1` and `pageSize` defaults to `10`. Invalid or missing
+values fall back to their defaults instead of erroring.

--- a/contrib/routes/issue-30-asset-list/route.mjs
+++ b/contrib/routes/issue-30-asset-list/route.mjs
@@ -1,0 +1,109 @@
+// Mock GET route returning a paginated list of sample assets. No chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
+
+const ASSETS = [
+  { code: "XLM", issuer: "native", balance: "10000.0000000" },
+  {
+    code: "USDC",
+    issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    balance: "2500.5000000",
+  },
+  {
+    code: "AQUA",
+    issuer: "GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA",
+    balance: "50000.0000000",
+  },
+  {
+    code: "yXLM",
+    issuer: "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PIGZC2JCLQFXWKW",
+    balance: "875.2500000",
+  },
+  {
+    code: "BTC",
+    issuer: "GDPJALI4AZKUU2W426U5WKMAT6CN3AJRPIIRYQV7WHB2Z3RNBH3AVR2X",
+    balance: "0.1500000",
+  },
+  {
+    code: "ETH",
+    issuer: "GBFXOHVAS43OIWNJDFTNY6L3JETQXHVXNXXTHIYWZR4EWZURPMU7Z9M2",
+    balance: "3.2000000",
+  },
+  {
+    code: "SHX",
+    issuer: "GDSTRSHXHGJ7ZIVRBXEYE5Q74XUVCUSEKEBR7UCHEUUJK6PPZOD4KEUY",
+    balance: "12000.0000000",
+  },
+  {
+    code: "USDT",
+    issuer: "GCQTGZQQ5G4PTM2GL7CDIFKUBIPEC52BROAQIAPW53XBRJVN6ZJVTG6V",
+    balance: "999.9900000",
+  },
+  {
+    code: "MOBI",
+    issuer: "GA6HCMBLTZS5VYYBCATRBRZ3BZJMAFUDKYYF6AH6MVCMGWMRDNSWJPIH",
+    balance: "42.0000000",
+  },
+  {
+    code: "RIO",
+    issuer: "GCFVEHW5VXTQCLXIN2CGKGMKZOUQOMOQ5PL22F5C6HG5CY73GYYZ6RIO",
+    balance: "1500.0000000",
+  },
+  {
+    code: "SLT",
+    issuer: "GCKA6K5PCQ6PNF5RQBF7PQDJWRHOKUJT5IWEG7NRZDGCQNK7PGYQHYCE",
+    balance: "300.7500000",
+  },
+  {
+    code: "VELO",
+    issuer: "GDM4RQUQQUVSKQA7S6EM7XBZP3FCGH4Q7CL6TABQ7B2BEJ5ERASQXVEL",
+    balance: "60.1000000",
+  },
+];
+
+function parsePositiveInt(raw, fallback) {
+  if (raw === undefined || raw === null || raw === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) return fallback;
+  return parsed;
+}
+
+export function handleRequest({ query = {} } = {}) {
+  const page = parsePositiveInt(query.page, DEFAULT_PAGE);
+  const pageSize = parsePositiveInt(query.pageSize, DEFAULT_PAGE_SIZE);
+  const start = (page - 1) * pageSize;
+  const items = ASSETS.slice(start, start + pageSize);
+
+  return {
+    status: 200,
+    body: {
+      items,
+      total: ASSETS.length,
+      page,
+      pageSize,
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/assets") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleRequest({ query });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4030;
+  server.listen(port, () => {
+    console.log(`asset-list mock listening on http://localhost:${port}/assets?page=&pageSize=`);
+  });
+}

--- a/contrib/routes/issue-30-asset-list/route.test.mjs
+++ b/contrib/routes/issue-30-asset-list/route.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// Defaults: page 1, pageSize 10, out of 12 sample assets.
+const defaults = handleRequest();
+assert.equal(defaults.status, 200);
+assert.equal(defaults.body.total, 12);
+assert.equal(defaults.body.page, 1);
+assert.equal(defaults.body.pageSize, 10);
+assert.equal(defaults.body.items.length, 10);
+assert.equal(defaults.body.items[0].code, "XLM");
+
+// Second page returns the remainder.
+const page2 = handleRequest({ query: { page: "2" } });
+assert.equal(page2.body.page, 2);
+assert.equal(page2.body.items.length, 2);
+assert.equal(page2.body.total, 12);
+
+// Custom pageSize changes how many pages are needed and slices accordingly.
+const all = handleRequest({ query: { page: "1", pageSize: "12" } }).body.items;
+const custom = handleRequest({ query: { page: "3", pageSize: "5" } });
+assert.equal(custom.body.pageSize, 5);
+assert.equal(custom.body.items.length, 2); // items 11-12 of 12
+assert.deepEqual(custom.body.items, all.slice(10, 12));
+
+// A page past the end returns an empty items array but preserves total.
+const overflow = handleRequest({ query: { page: "99" } });
+assert.equal(overflow.body.items.length, 0);
+assert.equal(overflow.body.total, 12);
+
+// Invalid page/pageSize values fall back to defaults instead of throwing.
+const invalid = handleRequest({ query: { page: "0", pageSize: "-5" } });
+assert.equal(invalid.body.page, 1);
+assert.equal(invalid.body.pageSize, 10);
+
+console.log("PASS: /assets paginates the sample asset list correctly");

--- a/contrib/routes/issue-33-policy-list/README.md
+++ b/contrib/routes/issue-33-policy-list/README.md
@@ -1,0 +1,37 @@
+# Mock route: policy list (Issue #33)
+
+Standalone mock GET route returning a fixed array of sample account policy
+summaries. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# policy-list mock listening on http://localhost:4033/policies
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /policies
+```
+
+Response:
+
+```json
+[
+  { "id": "pol_1001", "type": "spending-limit", "status": "active" },
+  { "id": "pol_1002", "type": "spending-limit", "status": "paused" },
+  { "id": "pol_1003", "type": "allowlist", "status": "active" },
+  { "id": "pol_1004", "type": "time-lock", "status": "active" },
+  { "id": "pol_1005", "type": "multi-sig", "status": "revoked" }
+]
+```

--- a/contrib/routes/issue-33-policy-list/route.mjs
+++ b/contrib/routes/issue-33-policy-list/route.mjs
@@ -1,0 +1,33 @@
+// Mock GET route returning a fixed list of sample account policy summaries.
+// No chain or DB access.
+import http from "node:http";
+
+const POLICIES = [
+  { id: "pol_1001", type: "spending-limit", status: "active" },
+  { id: "pol_1002", type: "spending-limit", status: "paused" },
+  { id: "pol_1003", type: "allowlist", status: "active" },
+  { id: "pol_1004", type: "time-lock", status: "active" },
+  { id: "pol_1005", type: "multi-sig", status: "revoked" },
+];
+
+export function handleRequest() {
+  return { status: 200, body: POLICIES };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/policies") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4033;
+  server.listen(port, () => {
+    console.log(`policy-list mock listening on http://localhost:${port}/policies`);
+  });
+}

--- a/contrib/routes/issue-33-policy-list/route.test.mjs
+++ b/contrib/routes/issue-33-policy-list/route.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const { status, body } = handleRequest();
+
+assert.equal(status, 200);
+assert.ok(Array.isArray(body));
+assert.ok(body.length >= 5, "expected at least 5 sample policies");
+
+for (const policy of body) {
+  assert.equal(typeof policy.id, "string");
+  assert.equal(typeof policy.type, "string");
+  assert.equal(typeof policy.status, "string");
+}
+
+// The sample data varies both type and status, not just id.
+const types = new Set(body.map((p) => p.type));
+const statuses = new Set(body.map((p) => p.status));
+assert.ok(types.size > 1, "expected varied policy types");
+assert.ok(statuses.size > 1, "expected varied policy statuses");
+assert.ok(types.has("spending-limit"));
+
+console.log("PASS: /policies returns a varied array of policy summaries");

--- a/contrib/routes/issue-34-policy-detail/README.md
+++ b/contrib/routes/issue-34-policy-detail/README.md
@@ -1,0 +1,50 @@
+# Mock route: policy detail (Issue #34)
+
+Standalone mock GET route returning a single sample policy record looked up
+by a path parameter id. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# policy-detail mock listening on http://localhost:4034/policies/:id
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /policies/pol_1001
+```
+
+Response:
+
+```json
+{
+  "id": "pol_1001",
+  "type": "spending-limit",
+  "status": "active",
+  "limit": "500.0000000",
+  "window": "daily"
+}
+```
+
+An id that isn't in the sample dataset returns a 404-style payload:
+
+```
+GET /policies/pol_9999
+```
+
+```json
+{
+  "error": "not_found",
+  "message": "No policy found for id \"pol_9999\""
+}
+```

--- a/contrib/routes/issue-34-policy-detail/route.mjs
+++ b/contrib/routes/issue-34-policy-detail/route.mjs
@@ -1,0 +1,60 @@
+// Mock GET route returning a single sample policy record by id. No chain or
+// DB access.
+import http from "node:http";
+
+const POLICIES = {
+  pol_1001: {
+    id: "pol_1001",
+    type: "spending-limit",
+    status: "active",
+    limit: "500.0000000",
+    window: "daily",
+  },
+  pol_1002: {
+    id: "pol_1002",
+    type: "spending-limit",
+    status: "paused",
+    limit: "2000.0000000",
+    window: "monthly",
+  },
+  pol_1003: {
+    id: "pol_1003",
+    type: "allowlist",
+    status: "active",
+    limit: null,
+    window: null,
+  },
+};
+
+export function handleRequest({ params = {} } = {}) {
+  const { id } = params;
+  const policy = id ? POLICIES[id] : undefined;
+
+  if (!policy) {
+    return {
+      status: 404,
+      body: { error: "not_found", message: `No policy found for id "${id ?? ""}"` },
+    };
+  }
+
+  return { status: 200, body: policy };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const match = req.url.match(/^\/policies\/([^/]+)$/);
+    if (req.method === "GET" && match) {
+      const { status, body } = handleRequest({ params: { id: decodeURIComponent(match[1]) } });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4034;
+  server.listen(port, () => {
+    console.log(`policy-detail mock listening on http://localhost:${port}/policies/:id`);
+  });
+}

--- a/contrib/routes/issue-34-policy-detail/route.test.mjs
+++ b/contrib/routes/issue-34-policy-detail/route.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// A known id returns the full record, including limit and window.
+const hit = handleRequest({ params: { id: "pol_1001" } });
+assert.equal(hit.status, 200);
+assert.equal(hit.body.id, "pol_1001");
+assert.equal(hit.body.type, "spending-limit");
+assert.equal(hit.body.limit, "500.0000000");
+assert.equal(hit.body.window, "daily");
+
+// An unknown id returns a 404-style payload.
+const miss = handleRequest({ params: { id: "pol_9999" } });
+assert.equal(miss.status, 404);
+assert.equal(miss.body.error, "not_found");
+
+// A missing id is also treated as not found.
+const noId = handleRequest({});
+assert.equal(noId.status, 404);
+
+console.log("PASS: /policies/:id returns the record on a hit and 404 on a miss");

--- a/contrib/routes/issue-36-session-expiry/README.md
+++ b/contrib/routes/issue-36-session-expiry/README.md
@@ -1,0 +1,41 @@
+# Mock route: session expiry (Issue #36)
+
+Standalone mock GET route returning a fixed session record including an
+expiry timestamp and a derived `expired` flag. No real chain or database
+access.
+
+## Run
+
+```sh
+node route.mjs
+# session-expiry mock listening on http://localhost:4036/session-expiry
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /session-expiry
+```
+
+Response:
+
+```json
+{
+  "sessionId": "sess_7f3a9c2e1b4d",
+  "issuedAt": "2026-07-27T10:00:00.000Z",
+  "expiresAt": "2026-07-27T22:00:00.000Z",
+  "expired": true
+}
+```
+
+`expired` is derived by comparing `expiresAt` to the current time. For
+deterministic testing, an optional `now` query parameter (ISO timestamp)
+overrides what "current time" is used for the comparison.

--- a/contrib/routes/issue-36-session-expiry/route.mjs
+++ b/contrib/routes/issue-36-session-expiry/route.mjs
@@ -1,0 +1,46 @@
+// Mock GET route returning a fixed session record with a derived expiry
+// flag. No chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+
+const SESSION = {
+  sessionId: "sess_7f3a9c2e1b4d",
+  issuedAt: "2026-07-27T10:00:00.000Z",
+  expiresAt: "2026-07-27T22:00:00.000Z",
+};
+
+function isExpired(expiresAt, now) {
+  return new Date(now).getTime() >= new Date(expiresAt).getTime();
+}
+
+export function handleRequest({ query = {} } = {}) {
+  const now = query.now || new Date().toISOString();
+
+  return {
+    status: 200,
+    body: {
+      ...SESSION,
+      expired: isExpired(SESSION.expiresAt, now),
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/session-expiry") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleRequest({ query });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4036;
+  server.listen(port, () => {
+    console.log(`session-expiry mock listening on http://localhost:${port}/session-expiry`);
+  });
+}

--- a/contrib/routes/issue-36-session-expiry/route.test.mjs
+++ b/contrib/routes/issue-36-session-expiry/route.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const base = handleRequest({ query: { now: "2026-07-27T10:00:00.000Z" } });
+assert.equal(base.status, 200);
+assert.equal(typeof base.body.issuedAt, "string");
+assert.equal(typeof base.body.expiresAt, "string");
+
+// Before expiresAt, the session is not expired.
+const before = handleRequest({ query: { now: "2026-07-27T12:00:00.000Z" } });
+assert.equal(before.body.expired, false);
+
+// At expiresAt, the session is considered expired.
+const atExpiry = handleRequest({ query: { now: base.body.expiresAt } });
+assert.equal(atExpiry.body.expired, true);
+
+// Well after expiresAt, the session is still expired.
+const after = handleRequest({ query: { now: "2026-07-28T00:00:00.000Z" } });
+assert.equal(after.body.expired, true);
+
+console.log("PASS: /session-expiry derives the expired flag from the current time");


### PR DESCRIPTION
## Summary

Adds four standalone mock GET route handlers under `contrib/routes/`, each
scoped to its own folder with a README, an implementation, and a test —
following the existing pattern in `contrib/routes/`.

- `contrib/routes/issue-30-asset-list/` — paginated sample asset list,
  supports `page`/`pageSize` query params with defaults, response includes
  `items`, `total`, and `page`.
- `contrib/routes/issue-33-policy-list/` — fixed array of 5 sample account
  policy summaries with varied `type` and `status` values.
- `contrib/routes/issue-34-policy-detail/` — single policy lookup by path
  parameter id, returns the full record (including `limit`/`window`) on a
  hit, 404-style payload on a miss.
- `contrib/routes/issue-36-session-expiry/` — fixed session record with
  `issuedAt`/`expiresAt` ISO timestamps and a derived `expired` boolean.

All changes are contained entirely within `contrib/`.

Closes #30
Closes #33
Closes #34
Closes #36

## Test plan

- [x] `node route.test.mjs` passes for all four routes
- [x] `prettier --check` passes on all new files
- [x] No files outside `contrib/` are touched