### PR TITLE
Add mock route handlers for exchange rates, transactions, memo validation, and trustlines

### DIFF
--- a/contrib/routes/issue-40-exchange-rates/README.md
+++ b/contrib/routes/issue-40-exchange-rates/README.md
@@ -1,0 +1,36 @@
+# Mock route: exchange rates (Issue #40)
+
+Standalone mock GET route returning a fixed set of sample asset exchange rates.
+Supports a `base` query parameter to filter rates for a single base asset.
+
+## Run
+
+```sh
+node route.mjs
+# exchange-rates mock listening on http://localhost:4040/exchange-rates
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /exchange-rates?base=XLM
+```
+
+Response:
+
+```json
+{
+  "rates": [
+    { "base": "XLM", "quote": "USD", "rate": "0.12" },
+    { "base": "XLM", "quote": "EUR", "rate": "0.11" }
+  ]
+}
+```

--- a/contrib/routes/issue-40-exchange-rates/route.mjs
+++ b/contrib/routes/issue-40-exchange-rates/route.mjs
@@ -1,0 +1,45 @@
+import http from "node:http";
+import { URL } from "node:url";
+
+const MOCK_RATES = [
+  { base: "XLM", quote: "USD", rate: "0.12" },
+  { base: "XLM", quote: "EUR", rate: "0.11" },
+  { base: "BTC", quote: "USD", rate: "68500.00" },
+  { base: "BTC", quote: "XLM", rate: "570833.33" },
+  { base: "ETH", quote: "USD", rate: "3450.00" },
+  { base: "ETH", quote: "XLM", rate: "28750.00" },
+];
+
+export function handleRequest(reqUrl) {
+  if (!reqUrl) return { status: 200, body: { rates: MOCK_RATES } };
+
+  const parsed = new URL(reqUrl, "http://localhost");
+  const base = parsed.searchParams.get("base");
+  if (base) {
+    const filtered = MOCK_RATES.filter(
+      (r) => r.base.toUpperCase() === base.toUpperCase(),
+    );
+    return { status: 200, body: { rates: filtered } };
+  }
+  return { status: 200, body: { rates: MOCK_RATES } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url.startsWith("/exchange-rates")) {
+      const { status, body } = handleRequest(req.url);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4040;
+  server.listen(port, () => {
+    console.log(
+      `exchange-rates mock listening on http://localhost:${port}/exchange-rates`,
+    );
+  });
+}

--- a/contrib/routes/issue-40-exchange-rates/route.test.mjs
+++ b/contrib/routes/issue-40-exchange-rates/route.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+let { status, body } = handleRequest();
+assert.equal(status, 200);
+assert.ok(Array.isArray(body.rates));
+assert.ok(body.rates.length >= 4);
+for (const r of body.rates) {
+  assert.equal(typeof r.base, "string");
+  assert.equal(typeof r.quote, "string");
+  assert.equal(typeof r.rate, "string");
+}
+
+({ status, body } = handleRequest("/exchange-rates?base=XLM"));
+assert.equal(status, 200);
+assert.ok(body.rates.every((r) => r.base === "XLM"));
+assert.ok(body.rates.length >= 2);
+
+({ status, body } = handleRequest("/exchange-rates?base=BTC"));
+assert.equal(status, 200);
+assert.ok(body.rates.every((r) => r.base === "BTC"));
+
+console.log("PASS: /exchange-rates returns rates and filters by base");

--- a/contrib/routes/issue-41-transaction-detail/README.md
+++ b/contrib/routes/issue-41-transaction-detail/README.md
@@ -1,0 +1,39 @@
+# Mock route: transaction detail (Issue #41)
+
+Standalone mock GET route returning a single sample transaction record looked up
+by a path parameter hash. Returns a 404 payload when the hash is not found.
+
+## Run
+
+```sh
+node route.mjs
+# transaction-detail mock listening on http://localhost:4041/transaction/<hash>
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /transaction/abc123def456
+```
+
+Response:
+
+```json
+{
+  "hash": "abc123def456",
+  "amount": "100.0000000",
+  "assetCode": "XLM",
+  "from": "GCKFBEIYV2V5BVZ6Q7V7QV7QV7QV7QV7QV7QV7QV7QV7QV7QV7",
+  "to": "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+  "timestamp": "2026-07-27T12:00:00Z",
+  "memo": "payment for services"
+}
+```

--- a/contrib/routes/issue-41-transaction-detail/route.mjs
+++ b/contrib/routes/issue-41-transaction-detail/route.mjs
@@ -1,0 +1,54 @@
+import http from "node:http";
+
+const MOCK_TRANSACTIONS = {
+  "abc123def456": {
+    hash: "abc123def456",
+    amount: "100.0000000",
+    assetCode: "XLM",
+    from: "GCKFBEIYV2V5BVZ6Q7V7QV7QV7QV7QV7QV7QV7QV7QV7QV7QV7",
+    to: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+    timestamp: "2026-07-27T12:00:00Z",
+    memo: "payment for services",
+  },
+  "xyz789ghi012": {
+    hash: "xyz789ghi012",
+    amount: "500.5000000",
+    assetCode: "USDC",
+    from: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+    to: "GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+    timestamp: "2026-07-27T13:30:00Z",
+    memo: "invoice #1234",
+  },
+};
+
+export function handleRequest(hash) {
+  if (!hash) {
+    return { status: 400, body: { error: "hash_required" } };
+  }
+  const tx = MOCK_TRANSACTIONS[hash];
+  if (!tx) {
+    return { status: 404, body: { error: "transaction_not_found" } };
+  }
+  return { status: 200, body: tx };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const match = req.url.match(/^\/transaction\/([a-zA-Z0-9]+)$/);
+    if (req.method === "GET" && match) {
+      const { status, body } = handleRequest(match[1]);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4041;
+  server.listen(port, () => {
+    console.log(
+      `transaction-detail mock listening on http://localhost:${port}/transaction/<hash>`,
+    );
+  });
+}

--- a/contrib/routes/issue-41-transaction-detail/route.test.mjs
+++ b/contrib/routes/issue-41-transaction-detail/route.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+let { status, body } = handleRequest("abc123def456");
+assert.equal(status, 200);
+assert.equal(body.hash, "abc123def456");
+assert.equal(typeof body.amount, "string");
+assert.equal(typeof body.timestamp, "string");
+
+({ status, body } = handleRequest("nonexistent"));
+assert.equal(status, 404);
+assert.equal(body.error, "transaction_not_found");
+
+({ status, body } = handleRequest());
+assert.equal(status, 400);
+assert.equal(body.error, "hash_required");
+
+console.log("PASS: /transaction handles found, not found, and missing hash");

--- a/contrib/routes/issue-42-memo-validate/README.md
+++ b/contrib/routes/issue-42-memo-validate/README.md
@@ -1,0 +1,39 @@
+# Mock route: memo validate (Issue #42)
+
+Standalone mock POST route that accepts a memo string and validates its length
+and type. Rejects memo text longer than 28 bytes and validates memo type
+against allowed values: `text`, `id`, or `hash`.
+
+## Run
+
+```sh
+node route.mjs
+# memo-validate mock listening on http://localhost:4042/memo-validate
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+POST /memo-validate
+Content-Type: application/json
+
+{ "memo": "hello", "type": "text" }
+```
+
+Response:
+
+```json
+{
+  "valid": true,
+  "memo": "hello",
+  "type": "text"
+}
+```

--- a/contrib/routes/issue-42-memo-validate/route.mjs
+++ b/contrib/routes/issue-42-memo-validate/route.mjs
@@ -1,0 +1,69 @@
+import http from "node:http";
+
+const VALID_MEMO_TYPES = ["text", "id", "hash"];
+const MAX_MEMO_BYTES = 28;
+
+export function handleRequest(body) {
+  if (!body || typeof body.memo === "undefined") {
+    return { status: 400, body: { error: "memo_required" } };
+  }
+
+  const { memo, type } = body;
+
+  if (typeof memo !== "string") {
+    return { status: 400, body: { error: "memo_must_be_string" } };
+  }
+
+  const memoBytes = Buffer.byteLength(memo, "utf-8");
+  if (memoBytes > MAX_MEMO_BYTES) {
+    return {
+      status: 400,
+      body: {
+        error: "memo_too_long",
+        message: `Memo exceeds ${MAX_MEMO_BYTES} bytes (${memoBytes} bytes provided)`,
+      },
+    };
+  }
+
+  if (type && !VALID_MEMO_TYPES.includes(type)) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_memo_type",
+        message: `Must be one of: ${VALID_MEMO_TYPES.join(", ")}`,
+      },
+    };
+  }
+
+  return { status: 200, body: { valid: true, memo, type: type || "text" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/memo-validate") {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data);
+          const { status, body: resp } = handleRequest(body);
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(resp));
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "invalid_json" }));
+        }
+      });
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4042;
+  server.listen(port, () => {
+    console.log(
+      `memo-validate mock listening on http://localhost:${port}/memo-validate`,
+    );
+  });
+}

--- a/contrib/routes/issue-42-memo-validate/route.test.mjs
+++ b/contrib/routes/issue-42-memo-validate/route.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+let { status, body } = handleRequest({ memo: "hello", type: "text" });
+assert.equal(status, 200);
+assert.equal(body.valid, true);
+
+({ status, body } = handleRequest({ memo: "a".repeat(29) }));
+assert.equal(status, 400);
+assert.equal(body.error, "memo_too_long");
+
+({ status, body } = handleRequest({ memo: "test", type: "invalid" }));
+assert.equal(status, 400);
+assert.equal(body.error, "invalid_memo_type");
+
+({ status, body } = handleRequest());
+assert.equal(status, 400);
+assert.equal(body.error, "memo_required");
+
+console.log("PASS: /memo-validate handles valid, too long, bad type, and missing");

--- a/contrib/routes/issue-43-trustline-list/README.md
+++ b/contrib/routes/issue-43-trustline-list/README.md
@@ -1,0 +1,44 @@
+# Mock route: trustline list (Issue #43)
+
+Standalone mock GET route returning a fixed array of sample trustline records
+for an account. Each entry includes an asset code, issuer, and balance.
+
+## Run
+
+```sh
+node route.mjs
+# trustline-list mock listening on http://localhost:4043/trustline-list
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /trustline-list
+```
+
+Response:
+
+```json
+{
+  "trustlines": [
+    {
+      "assetCode": "XLM",
+      "issuer": "GCKFBEIYV2V5BVZ6Q7V7QV7QV7QV7QV7QV7QV7QV7QV7QV7QV7",
+      "balance": "1250.5000000"
+    },
+    {
+      "assetCode": "USDC",
+      "issuer": "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+      "balance": "500.0000000"
+    }
+  ]
+}
+```

--- a/contrib/routes/issue-43-trustline-list/route.mjs
+++ b/contrib/routes/issue-43-trustline-list/route.mjs
@@ -1,0 +1,48 @@
+import http from "node:http";
+
+const MOCK_TRUSTLINES = [
+  {
+    assetCode: "XLM",
+    issuer: "GCKFBEIYV2V5BVZ6Q7V7QV7QV7QV7QV7QV7QV7QV7QV7QV7QV7",
+    balance: "1250.5000000",
+  },
+  {
+    assetCode: "USDC",
+    issuer: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+    balance: "500.0000000",
+  },
+  {
+    assetCode: "EURC",
+    issuer: "GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+    balance: "320.7500000",
+  },
+  {
+    assetCode: "BTC",
+    issuer: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+    balance: "0.0500000",
+  },
+];
+
+export function handleRequest() {
+  return { status: 200, body: { trustlines: MOCK_TRUSTLINES } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/trustline-list") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4043;
+  server.listen(port, () => {
+    console.log(
+      `trustline-list mock listening on http://localhost:${port}/trustline-list`,
+    );
+  });
+}

--- a/contrib/routes/issue-43-trustline-list/route.test.mjs
+++ b/contrib/routes/issue-43-trustline-list/route.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const { status, body } = handleRequest();
+
+assert.equal(status, 200);
+assert.ok(Array.isArray(body.trustlines));
+assert.ok(body.trustlines.length >= 3);
+for (const t of body.trustlines) {
+  assert.equal(typeof t.assetCode, "string");
+  assert.equal(typeof t.issuer, "string");
+  assert.equal(typeof t.balance, "string");
+}
+
+console.log("PASS: /trustline-list returns array of trustlines");


### PR DESCRIPTION
Closes #40 , Closes #41, Closes #42, Closes #43

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Summary

Adds four standalone mock route handlers under contrib/routes/ for local UI and dev testing. Each route includes a runnable server, test suite, and README.

- **#40 Exchange Rates**: GET route returning sample asset exchange rates with base query parameter filtering.
- **#41 Transaction Detail**: GET route returning a single transaction record by hash path parameter, with 404 for unknown hashes.
- **#42 Memo Validate**: POST route that validates memo length (max 28 bytes) and type (text, id, hash).
- **#43 Trustline List**: GET route returning a fixed array of sample trustline records with asset code, issuer, and balance.

## Motivation / Context

Closes #40, Closes #41, Closes #42, Closes #43