### PR TITLE
feat: add mock POST route for policy creation

### DIFF
--- a/contrib/routes/issue-35-policy-create/README.md
+++ b/contrib/routes/issue-35-policy-create/README.md
@@ -1,0 +1,87 @@
+# Mock route: policy creation (Issue #35)
+
+Standalone mock POST route that accepts a policy creation payload, validates it,
+and echoes back the created record with a generated id.
+
+This is a **mock**. Nothing is persisted, no chain or database is touched, and the
+generated ids come from an in-memory counter that resets when the process restarts.
+
+## Run
+
+```sh
+node route.mjs
+# policy-create mock listening on http://localhost:4035/policies
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Request
+
+```
+POST /policies
+Content-Type: application/json
+```
+
+| Field           | Required | Notes                                            |
+| --------------- | -------- | ------------------------------------------------ |
+| `limit`         | yes      | Positive JSON number                             |
+| `windowSeconds` | yes      | Positive JSON number                             |
+| `type`          | no       | One of `spending-limit`, `allowlist`, `velocity` |
+| `label`         | no       | Free-form string, defaults to `null`             |
+
+Numeric strings such as `"500"` are rejected — send real JSON numbers.
+
+## Example
+
+Request:
+
+```json
+{
+  "limit": 500,
+  "windowSeconds": 86400,
+  "type": "spending-limit",
+  "label": "daily cap"
+}
+```
+
+Response `201`:
+
+```json
+{
+  "id": "pol_0001",
+  "type": "spending-limit",
+  "label": "daily cap",
+  "limit": 500,
+  "windowSeconds": 86400,
+  "status": "active",
+  "createdAt": "2026-07-28T12:00:00.000Z"
+}
+```
+
+## Validation errors
+
+All validation failures return `400` with an `error` code and a human-readable
+`message`:
+
+| `error`                  | Cause                                       |
+| ------------------------ | ------------------------------------------- |
+| `invalid_body`           | Body missing, or not a JSON object          |
+| `limit_required`         | `limit` absent or `null`                    |
+| `limit_invalid`          | `limit` not a number, or not greater than 0 |
+| `windowSeconds_required` | `windowSeconds` absent or `null`            |
+| `windowSeconds_invalid`  | `windowSeconds` not a number, or not > 0    |
+| `invalid_type`           | `type` supplied but not a recognised value  |
+| `invalid_json`           | Request body was not parseable JSON         |
+
+Example `400`:
+
+```json
+{
+  "error": "limit_invalid",
+  "message": "\"limit\" must be greater than 0, received 0"
+}
+```

--- a/contrib/routes/issue-35-policy-create/route.mjs
+++ b/contrib/routes/issue-35-policy-create/route.mjs
@@ -1,0 +1,104 @@
+// Mock POST route accepting a policy creation payload and echoing back the created
+// record with a generated id. No chain or DB access — nothing is persisted.
+import http from "node:http";
+
+const VALID_TYPES = ["spending-limit", "allowlist", "velocity"];
+const DEFAULT_TYPE = "spending-limit";
+
+// Simple in-memory counter standing in for a database sequence. It resets every
+// time the process restarts, which is fine for a mock.
+let idCounter = 0;
+
+function nextId() {
+  idCounter += 1;
+  return `pol_${String(idCounter).padStart(4, "0")}`;
+}
+
+// A field is valid when it is a finite number strictly greater than zero. Numeric
+// strings are rejected on purpose so callers send real JSON numbers.
+function validatePositiveNumber(value, field) {
+  if (typeof value === "undefined" || value === null) {
+    return { error: `${field}_required`, message: `"${field}" is required` };
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return {
+      error: `${field}_invalid`,
+      message: `"${field}" must be a number, received ${typeof value}`,
+    };
+  }
+  if (value <= 0) {
+    return {
+      error: `${field}_invalid`,
+      message: `"${field}" must be greater than 0, received ${value}`,
+    };
+  }
+  return null;
+}
+
+export function handleRequest(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { status: 400, body: { error: "invalid_body", message: "Expected a JSON object" } };
+  }
+
+  const { limit, windowSeconds, type, label } = body;
+
+  const failure =
+    validatePositiveNumber(limit, "limit") ??
+    validatePositiveNumber(windowSeconds, "windowSeconds");
+  if (failure) {
+    return { status: 400, body: failure };
+  }
+
+  if (typeof type !== "undefined" && !VALID_TYPES.includes(type)) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_type",
+        message: `"type" must be one of: ${VALID_TYPES.join(", ")}`,
+      },
+    };
+  }
+
+  return {
+    status: 201,
+    body: {
+      id: nextId(),
+      type: type ?? DEFAULT_TYPE,
+      label: label ?? null,
+      limit,
+      windowSeconds,
+      status: "active",
+      createdAt: new Date().toISOString(),
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/policies") {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        let parsed;
+        try {
+          parsed = JSON.parse(data);
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "invalid_json" }));
+          return;
+        }
+        const { status, body } = handleRequest(parsed);
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(body));
+      });
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4035;
+  server.listen(port, () => {
+    console.log(`policy-create mock listening on http://localhost:${port}/policies`);
+  });
+}

--- a/contrib/routes/issue-35-policy-create/route.test.mjs
+++ b/contrib/routes/issue-35-policy-create/route.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// Success: a valid payload is echoed back with a generated id.
+const created = handleRequest({ limit: 500, windowSeconds: 86400 });
+assert.equal(created.status, 201);
+assert.match(created.body.id, /^pol_\d{4,}$/);
+assert.equal(created.body.limit, 500);
+assert.equal(created.body.windowSeconds, 86400);
+assert.equal(created.body.type, "spending-limit");
+assert.equal(created.body.label, null);
+assert.equal(created.body.status, "active");
+assert.equal(Number.isNaN(Date.parse(created.body.createdAt)), false);
+
+// Optional fields are honoured when supplied.
+const withOptionals = handleRequest({
+  limit: 25.5,
+  windowSeconds: 3600,
+  type: "velocity",
+  label: "hourly cap",
+});
+assert.equal(withOptionals.status, 201);
+assert.equal(withOptionals.body.type, "velocity");
+assert.equal(withOptionals.body.label, "hourly cap");
+assert.equal(withOptionals.body.limit, 25.5);
+
+// Each created policy gets a distinct id.
+assert.notEqual(created.body.id, withOptionals.body.id);
+
+// Validation failure: missing fields are reported per field.
+assert.equal(handleRequest({ windowSeconds: 60 }).status, 400);
+assert.equal(handleRequest({ windowSeconds: 60 }).body.error, "limit_required");
+assert.equal(handleRequest({ limit: 10 }).body.error, "windowSeconds_required");
+
+// Validation failure: zero and negative values are rejected.
+assert.equal(handleRequest({ limit: 0, windowSeconds: 60 }).body.error, "limit_invalid");
+assert.equal(handleRequest({ limit: 10, windowSeconds: -1 }).body.error, "windowSeconds_invalid");
+
+// Validation failure: non-numeric values (including numeric strings) are rejected.
+assert.equal(handleRequest({ limit: "500", windowSeconds: 60 }).body.error, "limit_invalid");
+assert.equal(
+  handleRequest({ limit: 10, windowSeconds: Number.NaN }).body.error,
+  "windowSeconds_invalid",
+);
+
+// Validation failure: an unknown policy type is rejected.
+const badType = handleRequest({ limit: 10, windowSeconds: 60, type: "nope" });
+assert.equal(badType.status, 400);
+assert.equal(badType.body.error, "invalid_type");
+
+// Validation failure: a missing or non-object body is rejected rather than throwing.
+assert.equal(handleRequest().body.error, "invalid_body");
+assert.equal(handleRequest([]).body.error, "invalid_body");
+
+console.log("PASS: POST /policies creates a record on valid input and 400s on invalid input");


### PR DESCRIPTION
closes #35

## Summary

Adds a standalone mock POST route under `contrib/routes/issue-35-policy-create/` that accepts a policy creation payload, validates it, and echoes back the created record with a generated id.

Everything is inside `contrib/`, and the layout follows the existing mock routes on `drips` (`route.mjs` exporting a pure `handleRequest`, `route.test.mjs`, and a `README.md`).

## Files

- `contrib/routes/issue-35-policy-create/route.mjs`
- `contrib/routes/issue-35-policy-create/route.test.mjs`
- `contrib/routes/issue-35-policy-create/README.md`

## Behaviour

`POST /policies`

| Field | Required | Notes |
| --- | --- | --- |
| `limit` | yes | Positive JSON number |
| `windowSeconds` | yes | Positive JSON number |
| `type` | no | One of `spending-limit`, `allowlist`, `velocity` |
| `label` | no | Free-form string, defaults to `null` |

Success returns `201` with a generated id from a simple in-memory counter:

```json
{
  "id": "pol_0001",
  "type": "spending-limit",
  "label": "daily cap",
  "limit": 500,
  "windowSeconds": 86400,
  "status": "active",
  "createdAt": "2026-07-28T17:24:06.313Z"
}
```

Validation failures return `400` with an `error` code and a readable `message`:

| `error` | Cause |
| --- | --- |
| `invalid_body` | Body missing, or not a JSON object |
| `limit_required` | `limit` absent or `null` |
| `limit_invalid` | `limit` not a number, or not greater than 0 |
| `windowSeconds_required` | `windowSeconds` absent or `null` |
| `windowSeconds_invalid` | `windowSeconds` not a number, or not greater than 0 |
| `invalid_type` | `type` supplied but not a recognised value |
| `invalid_json` | Request body was not parseable JSON |

## Notes on the implementation

- `handleRequest` is pure apart from the id counter, so it can be tested without starting a server, matching the sibling routes.
- Numeric strings such as `"500"` are rejected rather than coerced, so a caller sending form-encoded values gets a clear error instead of a silently accepted policy.
- `Number.isFinite` is used so `NaN` and `Infinity` are rejected too.
- Nothing is persisted; the counter resets with the process. This is a mock, as stated in the README.

## Testing

```sh
node contrib/routes/issue-35-policy-create/route.test.mjs
# PASS: POST /policies creates a record on valid input and 400s on invalid input
```

The test covers the success case, optional field handling, distinct ids across calls, and every validation failure branch.

The route was also smoke-tested over real HTTP (`node route.mjs`, then `curl`): valid payload returns `201`, `{"limit":0,...}` returns `400 limit_invalid`, malformed JSON returns `400 invalid_json`, and an unknown path returns `404`.

Formatting was checked with the repo's Prettier config (`npx prettier --check`).

## Checklist

- [x] Change is entirely inside `contrib/`
- [x] Base branch is `drips`
- [x] Work saved under `contrib/routes/` named after the issue
- [x] Includes a test covering the success and validation failure cases
