### PR TITLE
feat: add mock GET route for supported asset codes

### DIFF
--- a/contrib/routes/issue-37-supported-assets/README.md
+++ b/contrib/routes/issue-37-supported-assets/README.md
@@ -1,0 +1,76 @@
+# Mock route: supported assets (Issue #37)
+
+Standalone mock GET route returning a fixed list of supported asset codes and
+their display names, with an optional prefix search.
+
+This is a **mock**. The list is hard-coded in `route.mjs` — it is not fetched from
+Horizon, a token registry, or any database.
+
+## Run
+
+```sh
+node route.mjs
+# supported-assets mock listening on http://localhost:4037/supported-assets?search=
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Request
+
+```
+GET /supported-assets?search=<prefix>
+```
+
+| Query    | Required | Notes                                                    |
+| -------- | -------- | -------------------------------------------------------- |
+| `search` | no       | Case-insensitive prefix match against the asset **code** |
+
+`search` matches code prefixes only — it does not match display names, and it does
+not match substrings (`XLM` matches `XLM` but not `yXLM`). An empty or
+whitespace-only `search` returns the full list.
+
+## Example
+
+Request:
+
+```
+GET /supported-assets?search=us
+```
+
+Response `200`:
+
+```json
+{
+  "items": [
+    { "code": "USDC", "name": "USD Coin" },
+    { "code": "USDT", "name": "Tether USD" }
+  ],
+  "total": 2,
+  "search": "us"
+}
+```
+
+An unmatched prefix returns an empty list rather than an error:
+
+```json
+{ "items": [], "total": 0, "search": "zzz" }
+```
+
+## Sample data
+
+| Code   | Display name         |
+| ------ | -------------------- |
+| `XLM`  | Stellar Lumens       |
+| `USDC` | USD Coin             |
+| `USDT` | Tether USD           |
+| `EURC` | Euro Coin            |
+| `AQUA` | Aquarius             |
+| `yXLM` | Yield XLM            |
+| `BTC`  | Bitcoin              |
+| `ETH`  | Ethereum             |
+| `SHX`  | Stronghold Token     |
+| `NGNT` | Nigerian Naira Token |

--- a/contrib/routes/issue-37-supported-assets/route.mjs
+++ b/contrib/routes/issue-37-supported-assets/route.mjs
@@ -1,0 +1,61 @@
+// Mock GET route returning a fixed list of supported asset codes and their
+// display names. No chain or DB access — the list is hard-coded.
+import http from "node:http";
+import { URL } from "node:url";
+
+const SUPPORTED_ASSETS = [
+  { code: "XLM", name: "Stellar Lumens" },
+  { code: "USDC", name: "USD Coin" },
+  { code: "USDT", name: "Tether USD" },
+  { code: "EURC", name: "Euro Coin" },
+  { code: "AQUA", name: "Aquarius" },
+  { code: "yXLM", name: "Yield XLM" },
+  { code: "BTC", name: "Bitcoin" },
+  { code: "ETH", name: "Ethereum" },
+  { code: "SHX", name: "Stronghold Token" },
+  { code: "NGNT", name: "Nigerian Naira Token" },
+];
+
+// Case-insensitive prefix match against the asset code. A missing, empty or
+// whitespace-only search returns the full list rather than an empty one.
+function filterByCodePrefix(assets, search) {
+  if (typeof search !== "string") return assets;
+  const prefix = search.trim().toLowerCase();
+  if (prefix === "") return assets;
+  return assets.filter((asset) => asset.code.toLowerCase().startsWith(prefix));
+}
+
+export function handleRequest({ query = {} } = {}) {
+  const items = filterByCodePrefix(SUPPORTED_ASSETS, query.search);
+
+  return {
+    status: 200,
+    body: {
+      items,
+      total: items.length,
+      search: typeof query.search === "string" ? query.search : null,
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/supported-assets") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleRequest({ query });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4037;
+  server.listen(port, () => {
+    console.log(
+      `supported-assets mock listening on http://localhost:${port}/supported-assets?search=`,
+    );
+  });
+}

--- a/contrib/routes/issue-37-supported-assets/route.test.mjs
+++ b/contrib/routes/issue-37-supported-assets/route.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// No search: the full list comes back, and every entry has a code and a name.
+const all = handleRequest();
+assert.equal(all.status, 200);
+assert.equal(all.body.total, all.body.items.length);
+assert.ok(all.body.items.length >= 6, "expected at least 6 sample assets");
+assert.equal(all.body.search, null);
+for (const asset of all.body.items) {
+  assert.equal(typeof asset.code, "string");
+  assert.equal(typeof asset.name, "string");
+  assert.ok(asset.code.length > 0 && asset.name.length > 0);
+}
+
+// Asset codes are unique.
+const codes = all.body.items.map((asset) => asset.code);
+assert.equal(new Set(codes).size, codes.length);
+
+// Search filters by code prefix, not by substring or display name.
+const us = handleRequest({ query: { search: "US" } });
+assert.deepEqual(
+  us.body.items.map((asset) => asset.code),
+  ["USDC", "USDT"],
+);
+assert.equal(us.body.total, 2);
+assert.equal(us.body.search, "US");
+
+// The prefix match is case-insensitive in both directions.
+assert.deepEqual(handleRequest({ query: { search: "usd" } }).body.items, us.body.items);
+assert.deepEqual(
+  handleRequest({ query: { search: "YXLM" } }).body.items.map((asset) => asset.code),
+  ["yXLM"],
+);
+
+// A full code matches exactly one asset.
+const exact = handleRequest({ query: { search: "XLM" } });
+assert.deepEqual(
+  exact.body.items.map((asset) => asset.code),
+  ["XLM"],
+);
+
+// Substring matches that are not prefixes are excluded ("XLM" is inside "yXLM").
+assert.equal(
+  exact.body.items.some((asset) => asset.code === "yXLM"),
+  false,
+);
+
+// Matching against a display name rather than a code returns nothing.
+assert.equal(handleRequest({ query: { search: "Bitcoin" } }).body.total, 0);
+
+// An unknown prefix returns an empty list, not an error.
+const none = handleRequest({ query: { search: "zzz" } });
+assert.equal(none.status, 200);
+assert.deepEqual(none.body.items, []);
+assert.equal(none.body.total, 0);
+
+// Empty and whitespace-only searches fall back to the full list.
+assert.equal(handleRequest({ query: { search: "" } }).body.total, all.body.total);
+assert.equal(handleRequest({ query: { search: "   " } }).body.total, all.body.total);
+
+console.log("PASS: /supported-assets lists assets and filters by code prefix");


### PR DESCRIPTION
closes #37

## Summary

Adds a standalone mock GET route under `contrib/routes/issue-37-supported-assets/` that returns a fixed list of supported asset codes with their display names, plus an optional prefix search.

Everything is inside `contrib/`, and the layout follows the existing mock routes on `drips` (`route.mjs` exporting a pure `handleRequest`, `route.test.mjs`, and a `README.md`).

## Files

- `contrib/routes/issue-37-supported-assets/route.mjs`
- `contrib/routes/issue-37-supported-assets/route.test.mjs`
- `contrib/routes/issue-37-supported-assets/README.md`

## Behaviour

`GET /supported-assets?search=<prefix>`

Ten sample assets are included, each with a `code` and a display `name`: `XLM`, `USDC`, `USDT`, `EURC`, `AQUA`, `yXLM`, `BTC`, `ETH`, `SHX`, `NGNT`.

```json
{
  "items": [
    { "code": "USDC", "name": "USD Coin" },
    { "code": "USDT", "name": "Tether USD" }
  ],
  "total": 2,
  "search": "us"
}
```

## Search semantics

The `search` parameter is optional. The rules it follows are spelled out in the README and pinned by the test:

- Case-insensitive match on the asset **code**.
- **Prefix** match, not substring: `search=XLM` returns `XLM` but not `yXLM`.
- Display names are not searched, so `search=Bitcoin` returns nothing.
- An empty or whitespace-only `search` returns the full list rather than an empty one.
- An unmatched prefix returns `200` with an empty `items` array, not an error.

The `search` value is echoed back in the response so a caller can tell a filtered empty result from an unfiltered one.

## Testing

```sh
node contrib/routes/issue-37-supported-assets/route.test.mjs
# PASS: /supported-assets lists assets and filters by code prefix
```

The test covers the filter behaviour specifically: prefix matching, case-insensitivity in both directions, exact-code matches, the prefix-vs-substring distinction, display names not matching, the unmatched prefix case, and the empty/whitespace fallbacks. It also asserts the list has at least 6 entries, that every entry carries both fields, and that codes are unique.

The route was also smoke-tested over real HTTP (`node route.mjs`, then `curl`): `?search=us` returns the two USD assets, no search returns all ten, and `?search=zzz` returns an empty list with `total: 0`.

Formatting was checked with the repo's Prettier config (`npx prettier --check`).

## Checklist

- [x] Change is entirely inside `contrib/`
- [x] Base branch is `drips`
- [x] Work saved under `contrib/routes/` named after the issue
- [x] At least 6 sample assets, each with a code and a display name
- [x] Includes a test covering the search filter behaviour
