### PR TITLE
feat: add mock DELETE route for device session revocation

### DIFF
--- a/contrib/routes/issue-38-device-revoke/README.md
+++ b/contrib/routes/issue-38-device-revoke/README.md
@@ -1,0 +1,75 @@
+# Mock route: device session revoke (Issue #38)
+
+Standalone mock DELETE route that revokes a device session by id and echoes the
+revoked id back.
+
+This is a **mock**. No session store, chain or database is touched. The sample
+dataset is read-only, so nothing is actually invalidated and revoking the same id
+twice returns the same success payload both times.
+
+## Run
+
+```sh
+node route.mjs
+# device-revoke mock listening on http://localhost:4038/device-sessions/:id
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Request
+
+```
+DELETE /device-sessions/<id>
+```
+
+## Example — found
+
+Request:
+
+```
+DELETE /device-sessions/ses_a1b2c3
+```
+
+Response `200`:
+
+```json
+{
+  "revoked": true,
+  "id": "ses_a1b2c3",
+  "device": "iPhone 15 Pro",
+  "platform": "ios",
+  "revokedAt": "2026-07-28T12:00:00.000Z"
+}
+```
+
+## Example — not found
+
+Request:
+
+```
+DELETE /device-sessions/ses_missing
+```
+
+Response `404`:
+
+```json
+{
+  "error": "not_found",
+  "message": "No device session found for id \"ses_missing\""
+}
+```
+
+A missing or empty id is treated the same way as an unknown one.
+
+## Sample data
+
+| Session id   | Device           | Platform    |
+| ------------ | ---------------- | ----------- |
+| `ses_a1b2c3` | iPhone 15 Pro    | `ios`       |
+| `ses_d4e5f6` | Pixel 8          | `android`   |
+| `ses_g7h8i9` | MacBook Pro      | `web`       |
+| `ses_j1k2l3` | Chrome Extension | `extension` |

--- a/contrib/routes/issue-38-device-revoke/route.mjs
+++ b/contrib/routes/issue-38-device-revoke/route.mjs
@@ -1,0 +1,79 @@
+// Mock DELETE route revoking a device session by id. No chain or DB access — the
+// sample dataset is read-only and is never mutated, so the handler is pure and
+// repeated calls for the same id return the same payload.
+import http from "node:http";
+
+const SESSIONS = {
+  ses_a1b2c3: {
+    id: "ses_a1b2c3",
+    device: "iPhone 15 Pro",
+    platform: "ios",
+    lastSeen: "2026-07-27T09:14:00.000Z",
+  },
+  ses_d4e5f6: {
+    id: "ses_d4e5f6",
+    device: "Pixel 8",
+    platform: "android",
+    lastSeen: "2026-07-26T18:02:00.000Z",
+  },
+  ses_g7h8i9: {
+    id: "ses_g7h8i9",
+    device: "MacBook Pro",
+    platform: "web",
+    lastSeen: "2026-07-28T07:45:00.000Z",
+  },
+  ses_j1k2l3: {
+    id: "ses_j1k2l3",
+    device: "Chrome Extension",
+    platform: "extension",
+    lastSeen: "2026-07-25T11:30:00.000Z",
+  },
+};
+
+export function handleRequest({ params = {} } = {}) {
+  const { id } = params;
+  // Object.hasOwn keeps inherited keys such as "constructor" from resolving to a
+  // truthy value and being mistaken for a real session.
+  const isKnown = typeof id === "string" && id !== "" && Object.hasOwn(SESSIONS, id);
+  const session = isKnown ? SESSIONS[id] : undefined;
+
+  if (!session) {
+    return {
+      status: 404,
+      body: {
+        error: "not_found",
+        message: `No device session found for id "${id ?? ""}"`,
+      },
+    };
+  }
+
+  return {
+    status: 200,
+    body: {
+      revoked: true,
+      id: session.id,
+      device: session.device,
+      platform: session.platform,
+      revokedAt: new Date().toISOString(),
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const match = req.url.match(/^\/device-sessions\/([^/?]+)$/);
+    if (req.method === "DELETE" && match) {
+      const { status, body } = handleRequest({ params: { id: decodeURIComponent(match[1]) } });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4038;
+  server.listen(port, () => {
+    console.log(`device-revoke mock listening on http://localhost:${port}/device-sessions/:id`);
+  });
+}

--- a/contrib/routes/issue-38-device-revoke/route.test.mjs
+++ b/contrib/routes/issue-38-device-revoke/route.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// Found: a known session id is revoked and echoed back with its device details.
+const hit = handleRequest({ params: { id: "ses_a1b2c3" } });
+assert.equal(hit.status, 200);
+assert.equal(hit.body.revoked, true);
+assert.equal(hit.body.id, "ses_a1b2c3");
+assert.equal(hit.body.device, "iPhone 15 Pro");
+assert.equal(hit.body.platform, "ios");
+assert.equal(Number.isNaN(Date.parse(hit.body.revokedAt)), false);
+
+// Another known id resolves to its own record.
+const other = handleRequest({ params: { id: "ses_g7h8i9" } });
+assert.equal(other.status, 200);
+assert.equal(other.body.id, "ses_g7h8i9");
+assert.equal(other.body.device, "MacBook Pro");
+
+// The sample dataset is read-only, so revoking the same id again still succeeds.
+const repeat = handleRequest({ params: { id: "ses_a1b2c3" } });
+assert.equal(repeat.status, 200);
+assert.equal(repeat.body.id, "ses_a1b2c3");
+
+// Not found: an unknown id returns a 404-style payload.
+const miss = handleRequest({ params: { id: "ses_missing" } });
+assert.equal(miss.status, 404);
+assert.equal(miss.body.error, "not_found");
+assert.match(miss.body.message, /ses_missing/);
+assert.equal(miss.body.revoked, undefined);
+
+// Not found: a missing, empty or non-string id is treated as a miss, not a crash.
+assert.equal(handleRequest().status, 404);
+assert.equal(handleRequest({ params: {} }).status, 404);
+assert.equal(handleRequest({ params: { id: "" } }).status, 404);
+assert.equal(handleRequest({ params: { id: 42 } }).status, 404);
+
+// Ids inherited from Object.prototype are not treated as sessions.
+assert.equal(handleRequest({ params: { id: "constructor" } }).status, 404);
+assert.equal(handleRequest({ params: { id: "toString" } }).status, 404);
+
+console.log("PASS: DELETE /device-sessions/:id revokes on a hit and 404s on a miss");


### PR DESCRIPTION
closes #38

## Summary

Adds a standalone mock DELETE route under `contrib/routes/issue-38-device-revoke/` that accepts a device session id and returns a revocation confirmation, or a 404-style payload when the id is not in the sample dataset.

Everything is inside `contrib/`, and the layout follows the existing mock routes on `drips` (`route.mjs` exporting a pure `handleRequest`, `route.test.mjs`, and a `README.md`).

## Files

- `contrib/routes/issue-38-device-revoke/route.mjs`
- `contrib/routes/issue-38-device-revoke/route.test.mjs`
- `contrib/routes/issue-38-device-revoke/README.md`

## Behaviour

`DELETE /device-sessions/<id>`

Found returns `200` with the revoked id echoed back:

```json
{
  "revoked": true,
  "id": "ses_a1b2c3",
  "device": "iPhone 15 Pro",
  "platform": "ios",
  "revokedAt": "2026-07-28T17:23:24.377Z"
}
```

Not found returns `404`:

```json
{
  "error": "not_found",
  "message": "No device session found for id \"ses_zzz\""
}
```

Sample dataset: `ses_a1b2c3` (iPhone 15 Pro, ios), `ses_d4e5f6` (Pixel 8, android), `ses_g7h8i9` (MacBook Pro, web), `ses_j1k2l3` (Chrome Extension, extension).

## Notes on the implementation

- The sample dataset is read-only and is never mutated, so `handleRequest` is pure and revoking the same id twice returns the same success payload. That keeps the tests order-independent; the README states this explicitly so nobody mistakes it for real revocation semantics.
- Lookups go through `Object.hasOwn`, so inherited keys such as `constructor` or `toString` resolve as misses rather than as truthy "sessions". A plain `SESSIONS[id]` check returns a function for those inputs and would have produced a `200` with an undefined id.
- A missing, empty, or non-string id is treated as not found rather than throwing.

## Testing

```sh
node contrib/routes/issue-38-device-revoke/route.test.mjs
# PASS: DELETE /device-sessions/:id revokes on a hit and 404s on a miss
```

The test covers both required cases: the found case (payload fields, echoed id, valid `revokedAt`) and the not found case (status, error code, message containing the id, no `revoked` field). It also covers repeat revocation, missing/empty/non-string ids, and the prototype-key inputs described above.

The route was also smoke-tested over real HTTP (`node route.mjs`, then `curl`): a known id returns `200`, an unknown id returns `404 not_found`, and a non-DELETE request to the same path returns `404`.

Formatting was checked with the repo's Prettier config (`npx prettier --check`).

## Checklist

- [x] Change is entirely inside `contrib/`
- [x] Base branch is `drips`
- [x] Work saved under `contrib/routes/` named after the issue
- [x] Includes a test covering both the found and not found cases
