### PR TITLE
feat: add mock GET route for health check payload

### DIFF
--- a/contrib/routes/issue-39-health-check/README.md
+++ b/contrib/routes/issue-39-health-check/README.md
@@ -1,0 +1,57 @@
+# Mock route: health check (Issue #39)
+
+Standalone mock GET route returning a health check style JSON payload.
+
+## This is a mock, not a real service check
+
+The handler always reports `"ok"`. It does **not** probe Horizon, the database, the
+API service, or any other dependency, and it will keep returning `"ok"` while those
+are down. Treat it as a payload shape reference only — do not wire it into uptime
+monitoring, load balancer health probes, or alerting.
+
+The only real value in the response is the process uptime of whatever is running
+this file.
+
+## Run
+
+```sh
+node route.mjs
+# health-check mock listening on http://localhost:4039/health
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Request
+
+```
+GET /health
+```
+
+## Example
+
+Response `200`:
+
+```json
+{
+  "status": "ok",
+  "service": "vellar-mock",
+  "uptimeSeconds": 90,
+  "startedAt": "2026-07-28T11:58:30.000Z",
+  "timestamp": "2026-07-28T12:00:00.000Z"
+}
+```
+
+| Field           | Notes                                                       |
+| --------------- | ----------------------------------------------------------- |
+| `status`        | Always `"ok"` — see the caveat above                        |
+| `service`       | Fixed service identifier                                    |
+| `uptimeSeconds` | Whole seconds since the process started, floored, never < 0 |
+| `startedAt`     | ISO-8601 timestamp, `uptimeSeconds` before `timestamp`      |
+| `timestamp`     | ISO-8601 timestamp of the response                          |
+
+`handleRequest` accepts optional `now` and `uptimeSeconds` overrides so tests can
+assert against fixed values rather than wall-clock time.

--- a/contrib/routes/issue-39-health-check/route.mjs
+++ b/contrib/routes/issue-39-health-check/route.mjs
@@ -1,0 +1,42 @@
+// Mock GET route returning a health check style payload. It reports on nothing but
+// itself — no chain, database or downstream service is probed.
+import http from "node:http";
+import { URL } from "node:url";
+
+const SERVICE = "vellar-mock";
+
+// `now` and `uptimeSeconds` are injectable so tests can assert on fixed values
+// instead of wall-clock time. In normal use both come from the running process.
+export function handleRequest({ now = Date.now(), uptimeSeconds = process.uptime() } = {}) {
+  const uptime = Math.max(0, Math.floor(uptimeSeconds));
+
+  return {
+    status: 200,
+    body: {
+      status: "ok",
+      service: SERVICE,
+      uptimeSeconds: uptime,
+      startedAt: new Date(now - uptime * 1000).toISOString(),
+      timestamp: new Date(now).toISOString(),
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/health") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4039;
+  server.listen(port, () => {
+    console.log(`health-check mock listening on http://localhost:${port}/health`);
+  });
+}

--- a/contrib/routes/issue-39-health-check/route.test.mjs
+++ b/contrib/routes/issue-39-health-check/route.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// The status field is "ok".
+const health = handleRequest();
+assert.equal(health.status, 200);
+assert.equal(health.body.status, "ok");
+assert.equal(health.body.service, "vellar-mock");
+
+// Uptime is a non-negative whole number of seconds.
+assert.equal(typeof health.body.uptimeSeconds, "number");
+assert.ok(Number.isInteger(health.body.uptimeSeconds));
+assert.ok(health.body.uptimeSeconds >= 0);
+
+// The timestamps are valid ISO-8601 strings.
+assert.equal(Number.isNaN(Date.parse(health.body.timestamp)), false);
+assert.equal(Number.isNaN(Date.parse(health.body.startedAt)), false);
+assert.equal(new Date(health.body.timestamp).toISOString(), health.body.timestamp);
+
+// With injected values the payload is fully deterministic.
+const fixed = handleRequest({ now: Date.parse("2026-07-28T12:00:00.000Z"), uptimeSeconds: 90 });
+assert.equal(fixed.body.status, "ok");
+assert.equal(fixed.body.uptimeSeconds, 90);
+assert.equal(fixed.body.timestamp, "2026-07-28T12:00:00.000Z");
+assert.equal(fixed.body.startedAt, "2026-07-28T11:58:30.000Z");
+
+// startedAt is always uptimeSeconds before timestamp.
+const elapsed = (Date.parse(fixed.body.timestamp) - Date.parse(fixed.body.startedAt)) / 1000;
+assert.equal(elapsed, fixed.body.uptimeSeconds);
+
+// Fractional uptime is floored, and a negative reading is clamped to zero.
+assert.equal(handleRequest({ uptimeSeconds: 12.9 }).body.uptimeSeconds, 12);
+assert.equal(handleRequest({ uptimeSeconds: -5 }).body.uptimeSeconds, 0);
+
+console.log("PASS: /health reports status ok with an uptime and timestamp");


### PR DESCRIPTION
closes #39

## Summary

Adds a standalone mock GET route under `contrib/routes/issue-39-health-check/` that returns a health check style JSON payload with a `status` field and uptime/timestamp fields.

Everything is inside `contrib/`, and the layout follows the existing mock routes on `drips` (`route.mjs` exporting a pure `handleRequest`, `route.test.mjs`, and a `README.md`).

## Files

- `contrib/routes/issue-39-health-check/route.mjs`
- `contrib/routes/issue-39-health-check/route.test.mjs`
- `contrib/routes/issue-39-health-check/README.md`

## Behaviour

`GET /health` returns `200`:

```json
{
  "status": "ok",
  "service": "vellar-mock",
  "uptimeSeconds": 90,
  "startedAt": "2026-07-28T11:58:30.000Z",
  "timestamp": "2026-07-28T12:00:00.000Z"
}
```

| Field | Notes |
| --- | --- |
| `status` | Always `"ok"` |
| `service` | Fixed service identifier |
| `uptimeSeconds` | Whole seconds since process start, floored, never negative |
| `startedAt` | ISO-8601, always `uptimeSeconds` before `timestamp` |
| `timestamp` | ISO-8601 timestamp of the response |

## This is a mock, and the README says so

The README carries a dedicated section stating that this is a mock and not a real service check: it probes no dependency (Horizon, database, API service) and will keep returning `"ok"` while those are down, so it should not be wired into uptime monitoring, load balancer probes, or alerting.

## Notes on the implementation

- `handleRequest` accepts optional `now` and `uptimeSeconds` overrides, defaulting to `Date.now()` and `process.uptime()`. That makes the payload assertable against fixed values instead of wall-clock time, and keeps the test free of timing tolerances.
- Fractional uptime is floored and negative readings are clamped to zero, so `uptimeSeconds` is always a non-negative integer.

## Testing

```sh
node contrib/routes/issue-39-health-check/route.test.mjs
# PASS: /health reports status ok with an uptime and timestamp
```

The test asserts `status` equals `ok`, as required, plus: uptime is a non-negative integer, both timestamps are valid ISO-8601, injected values produce an exact deterministic payload, `startedAt` is exactly `uptimeSeconds` before `timestamp`, and the flooring/clamping edge cases.

The route was also smoke-tested over real HTTP (`node route.mjs`, then `curl`): `/health` returns `200` with `"status":"ok"`, and an unknown path returns `404`.

Formatting was checked with the repo's Prettier config (`npx prettier --check`).

## Checklist

- [x] Change is entirely inside `contrib/`
- [x] Base branch is `drips`
- [x] Work saved under `contrib/routes/` named after the issue
- [x] Response includes a status field and an uptime style timestamp field
- [x] Test asserts the status field equals ok
- [x] README documents that this is a mock and not a real service check
