### PR TITLE
contrib: add fee estimation route suite for simulated network load

### DIFF
--- a/contrib/routes/issue-117-fee-load-suite/README.md
+++ b/contrib/routes/issue-117-fee-load-suite/README.md
@@ -1,0 +1,95 @@
+# Mock route suite: fee estimation across network load (Issue #117)
+
+Standalone mock route suite that estimates a transaction fee from a
+simulated network load level supplied in the request. No chain, RPC, or
+database access — every value is fixed sample data.
+
+## Run
+
+```sh
+node route.mjs
+# fee-load suite listening on http://localhost:4117
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoints
+
+### `GET /fee-load/estimate`
+
+Estimates a fee for the given simulated load level.
+
+| Query | Required | Description |
+| --- | --- | --- |
+| `load` | yes | One of `low`, `medium`, `high` |
+| `operations` | no | Integer 1-100, defaults to `1` |
+
+The fee is the base fee per operation (100 stroops) multiplied by the load
+multiplier and the operation count:
+
+| Load | Multiplier | Fee per operation |
+| --- | --- | --- |
+| `low` | 1 | 100 stroops |
+| `medium` | 4 | 400 stroops |
+| `high` | 12 | 1200 stroops |
+
+Request:
+
+```
+GET /fee-load/estimate?load=high&operations=2
+```
+
+Response:
+
+```json
+{
+  "load": "high",
+  "operations": 2,
+  "multiplier": 12,
+  "baseFeePerOperation": 100,
+  "feePerOperation": 1200,
+  "estimatedFee": 2400,
+  "unit": "stroops"
+}
+```
+
+Errors:
+
+| Status | `error` | Cause |
+| --- | --- | --- |
+| 400 | `invalid_load` | `load` missing or not `low`/`medium`/`high` |
+| 400 | `invalid_operations` | `operations` not an integer in 1-100 |
+
+### `GET /fee-load/load-history`
+
+Returns a fixed sample series of recent load observations, oldest first.
+
+Response:
+
+```json
+{
+  "samples": [
+    { "observedAt": "2026-07-27T18:00:00.000Z", "load": "low" },
+    { "observedAt": "2026-07-27T19:00:00.000Z", "load": "low" },
+    { "observedAt": "2026-07-27T20:00:00.000Z", "load": "medium" },
+    { "observedAt": "2026-07-27T21:00:00.000Z", "load": "high" },
+    { "observedAt": "2026-07-27T22:00:00.000Z", "load": "high" },
+    { "observedAt": "2026-07-27T23:00:00.000Z", "load": "medium" }
+  ],
+  "count": 6,
+  "latest": "medium"
+}
+```
+
+Any other path returns `404` with `{ "error": "not_found" }`; any method
+other than `GET` returns `405` with `{ "error": "method_not_allowed" }`.
+
+## Notes
+
+The folder is named `issue-117-fee-load-suite` to follow the
+`contrib/routes/issue-<n>-<name>/` convention used by the sibling route
+folders; the suite itself is the `fee-load-suite` described in the issue.

--- a/contrib/routes/issue-117-fee-load-suite/route.mjs
+++ b/contrib/routes/issue-117-fee-load-suite/route.mjs
@@ -1,0 +1,118 @@
+// Mock route suite estimating a transaction fee from a simulated network
+// load level. No chain, RPC, or database access — every value below is
+// fixed sample data.
+import http from "node:http";
+import { URL, pathToFileURL } from "node:url";
+
+// Stroops charged per operation when the network is idle. Mirrors the
+// Stellar base fee so the numbers look familiar, but it is sample data.
+const BASE_FEE_PER_OPERATION = 100;
+
+// Multiplier applied to the base fee for each supported load level.
+const LOAD_MULTIPLIERS = {
+  low: 1,
+  medium: 4,
+  high: 12,
+};
+
+const LOAD_LEVELS = Object.keys(LOAD_MULTIPLIERS);
+
+// Fixed sample series of recent load observations, oldest first.
+const LOAD_HISTORY = [
+  { observedAt: "2026-07-27T18:00:00.000Z", load: "low" },
+  { observedAt: "2026-07-27T19:00:00.000Z", load: "low" },
+  { observedAt: "2026-07-27T20:00:00.000Z", load: "medium" },
+  { observedAt: "2026-07-27T21:00:00.000Z", load: "high" },
+  { observedAt: "2026-07-27T22:00:00.000Z", load: "high" },
+  { observedAt: "2026-07-27T23:00:00.000Z", load: "medium" },
+];
+
+function parseOperations(raw) {
+  if (raw === undefined || raw === "") return 1;
+  // Reject anything that is not a plain positive integer, including
+  // values like "2.5" or "3abc" that Number() would otherwise coerce.
+  if (!/^\d+$/.test(String(raw))) return null;
+  const operations = Number(raw);
+  return operations >= 1 && operations <= 100 ? operations : null;
+}
+
+export function estimate({ query = {} } = {}) {
+  const load = query.load;
+  if (!LOAD_LEVELS.includes(load)) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_load",
+        message: `load must be one of: ${LOAD_LEVELS.join(", ")}`,
+      },
+    };
+  }
+
+  const operations = parseOperations(query.operations);
+  if (operations === null) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_operations",
+        message: "operations must be an integer between 1 and 100",
+      },
+    };
+  }
+
+  const multiplier = LOAD_MULTIPLIERS[load];
+  return {
+    status: 200,
+    body: {
+      load,
+      operations,
+      multiplier,
+      baseFeePerOperation: BASE_FEE_PER_OPERATION,
+      feePerOperation: BASE_FEE_PER_OPERATION * multiplier,
+      estimatedFee: BASE_FEE_PER_OPERATION * multiplier * operations,
+      unit: "stroops",
+    },
+  };
+}
+
+export function loadHistory() {
+  return {
+    status: 200,
+    body: {
+      samples: LOAD_HISTORY.map((sample) => ({ ...sample })),
+      count: LOAD_HISTORY.length,
+      latest: LOAD_HISTORY[LOAD_HISTORY.length - 1].load,
+    },
+  };
+}
+
+export function handleRequest({ method = "GET", path = "", query = {} } = {}) {
+  if (method !== "GET") {
+    return { status: 405, body: { error: "method_not_allowed" } };
+  }
+  if (path === "/fee-load/estimate") return estimate({ query });
+  if (path === "/fee-load/load-history") return loadHistory();
+  return { status: 404, body: { error: "not_found" } };
+}
+
+// pathToFileURL keeps this check correct on Windows paths; argv[1] is
+// undefined when the module is imported rather than executed.
+const entry = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;
+const isMain = entry !== null && import.meta.url === entry;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    const { status, body } = handleRequest({
+      method: req.method,
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+    });
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4117;
+  server.listen(port, () => {
+    console.log(`fee-load suite listening on http://localhost:${port}`);
+    console.log(`  GET /fee-load/estimate?load=low|medium|high&operations=1`);
+    console.log(`  GET /fee-load/load-history`);
+  });
+}

--- a/contrib/routes/issue-117-fee-load-suite/route.test.mjs
+++ b/contrib/routes/issue-117-fee-load-suite/route.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+function get(path, query = {}) {
+  return handleRequest({ method: "GET", path, query });
+}
+
+// All three load levels produce a successful estimate.
+const low = get("/fee-load/estimate", { load: "low" });
+const medium = get("/fee-load/estimate", { load: "medium" });
+const high = get("/fee-load/estimate", { load: "high" });
+
+for (const result of [low, medium, high]) {
+  assert.equal(result.status, 200);
+  assert.equal(result.body.operations, 1);
+  assert.equal(result.body.unit, "stroops");
+  assert.equal(typeof result.body.estimatedFee, "number");
+}
+
+// Each level produces a distinct estimate, increasing with load.
+assert.ok(low.body.estimatedFee < medium.body.estimatedFee);
+assert.ok(medium.body.estimatedFee < high.body.estimatedFee);
+assert.equal(
+  new Set([low, medium, high].map((r) => r.body.estimatedFee)).size,
+  3,
+);
+
+// The estimate scales linearly with the operation count.
+const highTen = get("/fee-load/estimate", { load: "high", operations: "10" });
+assert.equal(highTen.body.estimatedFee, high.body.estimatedFee * 10);
+
+// Unknown and missing load levels are rejected.
+assert.equal(get("/fee-load/estimate", { load: "extreme" }).status, 400);
+assert.equal(get("/fee-load/estimate", {}).status, 400);
+
+// Operation counts must be plain positive integers within range.
+for (const operations of ["0", "-1", "2.5", "3abc", "101"]) {
+  const result = get("/fee-load/estimate", { load: "low", operations });
+  assert.equal(result.status, 400, `expected 400 for operations=${operations}`);
+  assert.equal(result.body.error, "invalid_operations");
+}
+
+// The history endpoint returns the fixed sample series.
+const history = get("/fee-load/load-history");
+assert.equal(history.status, 200);
+assert.equal(history.body.count, history.body.samples.length);
+assert.ok(history.body.count > 0);
+assert.equal(history.body.latest, history.body.samples.at(-1).load);
+for (const sample of history.body.samples) {
+  assert.ok(["low", "medium", "high"].includes(sample.load));
+  assert.equal(typeof sample.observedAt, "string");
+}
+
+// Every level seen in the history can be estimated.
+for (const sample of history.body.samples) {
+  assert.equal(get("/fee-load/estimate", { load: sample.load }).status, 200);
+}
+
+// Routing guards.
+assert.equal(get("/fee-load/unknown").status, 404);
+assert.equal(
+  handleRequest({ method: "POST", path: "/fee-load/estimate" }).status,
+  405,
+);
+
+console.log("PASS: fee-load suite scales fees across all three load levels");


### PR DESCRIPTION
## Summary

Adds a self-contained mock route suite under `contrib/routes/issue-117-fee-load-suite/` that estimates a transaction fee from a simulated network load level supplied in the request. No chain, RPC, or database access — everything is fixed sample data, matching the style of the existing `contrib/routes/` mocks.

closes #117

## Endpoints

**`GET /fee-load/estimate?load=low|medium|high&operations=N`**

Scales a base fee of 100 stroops per operation by the load multiplier and the operation count:

| Load | Multiplier | Fee per operation |
| --- | --- | --- |
| `low` | 1 | 100 stroops |
| `medium` | 4 | 400 stroops |
| `high` | 12 | 1200 stroops |

```json
{
  "load": "high",
  "operations": 2,
  "multiplier": 12,
  "baseFeePerOperation": 100,
  "feePerOperation": 1200,
  "estimatedFee": 2400,
  "unit": "stroops"
}
```

`operations` is optional and defaults to 1; it must be a plain integer in 1-100, so values like `2.5` or `3abc` are rejected rather than silently coerced. An unknown or missing `load` returns 400 `invalid_load`.

**`GET /fee-load/load-history`**

Returns a fixed sample series of six recent load observations, oldest first, plus `count` and `latest`.

Unknown paths return 404 `not_found`; non-GET methods return 405 `method_not_allowed`.

## Files

- `contrib/routes/issue-117-fee-load-suite/route.mjs` — handlers plus a standalone `node route.mjs` server on port 4117
- `contrib/routes/issue-117-fee-load-suite/route.test.mjs` — runnable with `node route.test.mjs`, no dependencies
- `contrib/routes/issue-117-fee-load-suite/README.md` — per-endpoint documentation

## Testing

`node route.test.mjs` passes. It asserts all three load levels return 200 with three distinct, strictly increasing estimates; that the fee scales linearly with `operations`; that every level appearing in `load-history` is estimable; and it covers the validation and routing error paths. The server was also exercised over HTTP on port 4117 for both endpoints.

## Notes

The folder is named `issue-117-fee-load-suite` rather than `fee-load-suite` to satisfy the constraint that work be saved under `contrib/routes/issue-<n>-<name>/`, consistent with the existing sibling folders. This is called out in the README.

The suite uses `pathToFileURL(process.argv[1]).href` for its "run directly" check instead of the `file://${process.argv[1]}` template used by older sibling routes. That template never matches on Windows (`file://C:\...` vs `file:///C:/...`), so `node route.mjs` exits silently there instead of starting the server. The change is scoped to this new folder only.

## Scope

Every changed file is inside `contrib/`. Base branch is `drips`.
