### PR TITLE
contrib: add build verification diff route suite

### DIFF
--- a/contrib/routes/issue-121-build-diff-suite/README.md
+++ b/contrib/routes/issue-121-build-diff-suite/README.md
@@ -1,0 +1,100 @@
+# Mock route suite: verification diff between builds (Issue #121)
+
+Standalone mock route suite that compares two sample build results for the
+same contract and reports which fields differ. No chain, RPC, or database
+access — every build record is fixed sample data.
+
+## Run
+
+```sh
+node route.mjs
+# build-diff suite listening on http://localhost:4121
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoints
+
+### `GET /build-diff/builds`
+
+Lists the sample build records and the field names the compare endpoint
+inspects.
+
+Response (abridged):
+
+```json
+{
+  "builds": [
+    {
+      "id": "build_001",
+      "contract": "vellar_verified_registry",
+      "builtAt": "2026-07-26T09:15:00.000Z",
+      "wasmHash": "9f2c41ab...d7a2",
+      "size": 41728,
+      "compiler": "soroban-cli 21.5.0",
+      "optimized": true
+    }
+  ],
+  "count": 4,
+  "comparedFields": ["wasmHash", "size", "compiler", "optimized"]
+}
+```
+
+Sample data is arranged so both outcomes are reachable: `build_001` and
+`build_003` are byte identical reproductions, `build_002` differs in hash,
+size, and optimization, and `build_004` differs only in hash and compiler.
+
+### `GET /build-diff/compare`
+
+Compares two builds by id.
+
+| Query | Required | Description |
+| --- | --- | --- |
+| `a` | yes | First build id |
+| `b` | yes | Second build id |
+
+Request:
+
+```
+GET /build-diff/compare?a=build_001&b=build_002
+```
+
+Response:
+
+```json
+{
+  "a": "build_001",
+  "b": "build_002",
+  "contract": "vellar_verified_registry",
+  "identical": false,
+  "differingFields": ["wasmHash", "size", "optimized"],
+  "differences": [
+    { "field": "wasmHash", "a": "9f2c41ab...d7a2", "b": "3d81ff05...0f74" },
+    { "field": "size", "a": 41728, "b": 43904 },
+    { "field": "optimized", "a": true, "b": false }
+  ]
+}
+```
+
+For identical builds, `identical` is `true` and both `differingFields` and
+`differences` are empty.
+
+Errors:
+
+| Status | `error` | Cause |
+| --- | --- | --- |
+| 400 | `missing_build_id` | `a` or `b` not supplied |
+| 404 | `build_not_found` | An id does not match a sample build |
+
+Any other path returns `404` with `{ "error": "not_found" }`; any method
+other than `GET` returns `405` with `{ "error": "method_not_allowed" }`.
+
+## Notes
+
+The folder is named `issue-121-build-diff-suite` to follow the
+`contrib/routes/issue-<n>-<name>/` convention used by the sibling route
+folders; the suite itself is the `build-diff-suite` described in the issue.

--- a/contrib/routes/issue-121-build-diff-suite/route.mjs
+++ b/contrib/routes/issue-121-build-diff-suite/route.mjs
@@ -1,0 +1,141 @@
+// Mock route suite comparing two sample contract build results and
+// reporting which fields differ. No chain, RPC, or database access —
+// every build record below is fixed sample data.
+import http from "node:http";
+import { URL, pathToFileURL } from "node:url";
+
+// Fields compared by the compare endpoint, in report order.
+const COMPARED_FIELDS = ["wasmHash", "size", "compiler", "optimized"];
+
+// Sample build records for the same contract. Builds 1 and 3 are byte
+// identical reproductions of each other; the others diverge.
+const BUILDS = [
+  {
+    id: "build_001",
+    contract: "vellar_verified_registry",
+    builtAt: "2026-07-26T09:15:00.000Z",
+    wasmHash: "9f2c41ab7d0e5c68b3aa10f4e7c9d2b581a6f3049ce7bb2d4a1f8036c5e9d7a2",
+    size: 41728,
+    compiler: "soroban-cli 21.5.0",
+    optimized: true,
+  },
+  {
+    id: "build_002",
+    contract: "vellar_verified_registry",
+    builtAt: "2026-07-26T14:02:00.000Z",
+    wasmHash: "3d81ff05a6c94e27b1d0e5a83f6c721940bb5e3c8d2a7f61049ce3b8a5d20f74",
+    size: 43904,
+    compiler: "soroban-cli 21.5.0",
+    optimized: false,
+  },
+  {
+    id: "build_003",
+    contract: "vellar_verified_registry",
+    builtAt: "2026-07-27T08:41:00.000Z",
+    wasmHash: "9f2c41ab7d0e5c68b3aa10f4e7c9d2b581a6f3049ce7bb2d4a1f8036c5e9d7a2",
+    size: 41728,
+    compiler: "soroban-cli 21.5.0",
+    optimized: true,
+  },
+  {
+    id: "build_004",
+    contract: "vellar_verified_registry",
+    builtAt: "2026-07-27T16:20:00.000Z",
+    wasmHash: "c07a5e9182b4d36f0ae7c1b58d29f43607e5a2c9418bd63f0a7e259c4d18b3f6",
+    size: 41728,
+    compiler: "soroban-cli 22.0.1",
+    optimized: true,
+  },
+];
+
+function findBuild(id) {
+  return BUILDS.find((build) => build.id === id);
+}
+
+export function builds() {
+  return {
+    status: 200,
+    body: {
+      builds: BUILDS.map((build) => ({ ...build })),
+      count: BUILDS.length,
+      comparedFields: [...COMPARED_FIELDS],
+    },
+  };
+}
+
+export function compare({ query = {} } = {}) {
+  const { a, b } = query;
+  if (!a || !b) {
+    return {
+      status: 400,
+      body: {
+        error: "missing_build_id",
+        message: "both a and b build ids are required",
+      },
+    };
+  }
+
+  const left = findBuild(a);
+  const right = findBuild(b);
+  const unknown = [
+    ...(left ? [] : [a]),
+    ...(right ? [] : [b]),
+  ];
+  if (unknown.length > 0) {
+    return {
+      status: 404,
+      body: {
+        error: "build_not_found",
+        message: `unknown build id(s): ${unknown.join(", ")}`,
+      },
+    };
+  }
+
+  const differences = COMPARED_FIELDS.filter(
+    (field) => left[field] !== right[field],
+  ).map((field) => ({ field, a: left[field], b: right[field] }));
+
+  return {
+    status: 200,
+    body: {
+      a: left.id,
+      b: right.id,
+      contract: left.contract,
+      identical: differences.length === 0,
+      differingFields: differences.map((difference) => difference.field),
+      differences,
+    },
+  };
+}
+
+export function handleRequest({ method = "GET", path = "", query = {} } = {}) {
+  if (method !== "GET") {
+    return { status: 405, body: { error: "method_not_allowed" } };
+  }
+  if (path === "/build-diff/builds") return builds();
+  if (path === "/build-diff/compare") return compare({ query });
+  return { status: 404, body: { error: "not_found" } };
+}
+
+// pathToFileURL keeps this check correct on Windows paths; argv[1] is
+// undefined when the module is imported rather than executed.
+const entry = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;
+const isMain = entry !== null && import.meta.url === entry;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    const { status, body } = handleRequest({
+      method: req.method,
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+    });
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4121;
+  server.listen(port, () => {
+    console.log(`build-diff suite listening on http://localhost:${port}`);
+    console.log(`  GET /build-diff/builds`);
+    console.log(`  GET /build-diff/compare?a=build_001&b=build_002`);
+  });
+}

--- a/contrib/routes/issue-121-build-diff-suite/route.test.mjs
+++ b/contrib/routes/issue-121-build-diff-suite/route.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+function get(path, query = {}) {
+  return handleRequest({ method: "GET", path, query });
+}
+
+// The builds endpoint lists sample records with the required fields.
+const listed = get("/build-diff/builds");
+assert.equal(listed.status, 200);
+assert.equal(listed.body.count, listed.body.builds.length);
+assert.ok(listed.body.count >= 2);
+for (const build of listed.body.builds) {
+  assert.equal(typeof build.id, "string");
+  assert.equal(typeof build.wasmHash, "string");
+  assert.equal(typeof build.size, "number");
+}
+
+// Two identical builds report no differing fields.
+const identical = get("/build-diff/compare", { a: "build_001", b: "build_003" });
+assert.equal(identical.status, 200);
+assert.equal(identical.body.identical, true);
+assert.deepEqual(identical.body.differingFields, []);
+assert.deepEqual(identical.body.differences, []);
+
+// Comparing a build with itself is also identical.
+const self = get("/build-diff/compare", { a: "build_002", b: "build_002" });
+assert.equal(self.body.identical, true);
+assert.deepEqual(self.body.differingFields, []);
+
+// Two differing builds report exactly the fields that differ.
+const differing = get("/build-diff/compare", { a: "build_001", b: "build_002" });
+assert.equal(differing.status, 200);
+assert.equal(differing.body.identical, false);
+assert.deepEqual(differing.body.differingFields, [
+  "wasmHash",
+  "size",
+  "optimized",
+]);
+for (const difference of differing.body.differences) {
+  assert.notEqual(difference.a, difference.b);
+}
+
+// A build differing only in compiler and hash reports just those fields.
+const compilerOnly = get("/build-diff/compare", {
+  a: "build_001",
+  b: "build_004",
+});
+assert.deepEqual(compilerOnly.body.differingFields, ["wasmHash", "compiler"]);
+
+// Comparison is symmetric in the reported field names.
+const reversed = get("/build-diff/compare", { a: "build_002", b: "build_001" });
+assert.deepEqual(
+  reversed.body.differingFields,
+  differing.body.differingFields,
+);
+
+// Missing and unknown build ids are rejected.
+assert.equal(get("/build-diff/compare", { a: "build_001" }).status, 400);
+assert.equal(get("/build-diff/compare", {}).status, 400);
+const notFound = get("/build-diff/compare", { a: "build_001", b: "build_999" });
+assert.equal(notFound.status, 404);
+assert.equal(notFound.body.error, "build_not_found");
+
+// Routing guards.
+assert.equal(get("/build-diff/unknown").status, 404);
+assert.equal(
+  handleRequest({ method: "POST", path: "/build-diff/builds" }).status,
+  405,
+);
+
+console.log("PASS: build-diff suite reports differing fields between builds");


### PR DESCRIPTION
## Summary

Adds a self-contained mock route suite under `contrib/routes/issue-121-build-diff-suite/` that compares two sample build results for the same contract and reports which fields differ. No chain, RPC, or database access — every build record is fixed sample data, matching the style of the existing `contrib/routes/` mocks.

closes #121

## Endpoints

**`GET /build-diff/builds`**

Lists four sample build records for `vellar_verified_registry`, each with an `id`, `wasmHash`, `size`, `compiler`, `optimized`, and `builtAt`, alongside the `comparedFields` the compare endpoint inspects.

The sample data is arranged so both outcomes are reachable without any setup:

| Build | Relationship to `build_001` |
| --- | --- |
| `build_003` | Byte identical reproduction |
| `build_002` | Differs in hash, size, and optimization |
| `build_004` | Differs only in hash and compiler |

**`GET /build-diff/compare?a=<id>&b=<id>`**

Returns the names of the fields that differ, plus the values on each side:

```json
{
  "a": "build_001",
  "b": "build_002",
  "contract": "vellar_verified_registry",
  "identical": false,
  "differingFields": ["wasmHash", "size", "optimized"],
  "differences": [
    { "field": "wasmHash", "a": "9f2c41ab...d7a2", "b": "3d81ff05...0f74" },
    { "field": "size", "a": 41728, "b": 43904 },
    { "field": "optimized", "a": true, "b": false }
  ]
}
```

For identical builds, `identical` is `true` and both lists are empty. A missing `a` or `b` returns 400 `missing_build_id`; an unknown id returns 404 `build_not_found` naming the ids that did not resolve. Unknown paths return 404 `not_found`; non-GET methods return 405 `method_not_allowed`.

## Files

- `contrib/routes/issue-121-build-diff-suite/route.mjs` — handlers plus a standalone `node route.mjs` server on port 4121
- `contrib/routes/issue-121-build-diff-suite/route.test.mjs` — runnable with `node route.test.mjs`, no dependencies
- `contrib/routes/issue-121-build-diff-suite/README.md` — per-endpoint documentation

## Testing

`node route.test.mjs` passes. It covers two identical builds (empty `differingFields`, `identical: true`), two differing builds (exact expected field list, with every reported difference asserted to actually differ), a build differing only in compiler and hash, comparing a build with itself, symmetry when `a` and `b` are swapped, and the 400/404/405 paths. The server was also exercised over HTTP on port 4121 for both the identical and differing cases.

## Notes

The folder is named `issue-121-build-diff-suite` rather than `build-diff-suite` to satisfy the constraint that work be saved under `contrib/routes/issue-<n>-<name>/`, consistent with the existing sibling folders. This is called out in the README.

The suite uses `pathToFileURL(process.argv[1]).href` for its "run directly" check instead of the `file://${process.argv[1]}` template used by older sibling routes. That template never matches on Windows (`file://C:\...` vs `file:///C:/...`), so `node route.mjs` exits silently there instead of starting the server. The change is scoped to this new folder only.

## Scope

Every changed file is inside `contrib/`. Base branch is `drips`.
