### PR TITLE
contrib: add signer expiration sweep route suite

### DIFF
--- a/contrib/routes/issue-120-signer-sweep-suite/README.md
+++ b/contrib/routes/issue-120-signer-sweep-suite/README.md
@@ -1,0 +1,121 @@
+# Mock route suite: signer expiration sweep job (Issue #120)
+
+Standalone mock route suite simulating a periodic job that finds expired
+signers and marks them removed, plus an endpoint to trigger that sweep
+manually. Both endpoints accept a simulated current time so expiration can
+be exercised without real delays.
+
+State is held in memory for the lifetime of the process. No chain, RPC, or
+database access — the signer list is fixed sample data.
+
+## Run
+
+```sh
+node route.mjs
+# signer-sweep suite listening on http://localhost:4120
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Sample signers
+
+| id | expiresAt |
+| --- | --- |
+| `signer_admin` | `null` (never expires) |
+| `signer_session_a` | 2026-07-27T12:00:00.000Z |
+| `signer_session_b` | 2026-07-27T18:00:00.000Z |
+| `signer_device` | 2026-07-28T09:00:00.000Z |
+| `signer_recovery` | 2026-08-04T00:00:00.000Z |
+
+A signer is expired when `expiresAt` is at or before the simulated time
+(the comparison is inclusive). A `null` `expiresAt` never expires.
+
+## Endpoints
+
+### `GET /signer-sweep/list-signers`
+
+Lists every signer with its current sweep status.
+
+| Query | Required | Description |
+| --- | --- | --- |
+| `now` | no | ISO 8601 simulated current time, defaults to the real clock |
+
+Request:
+
+```
+GET /signer-sweep/list-signers?now=2026-07-27T20:00:00.000Z
+```
+
+Response (abridged):
+
+```json
+{
+  "now": "2026-07-27T20:00:00.000Z",
+  "signers": [
+    {
+      "id": "signer_session_a",
+      "label": "Session key A",
+      "expiresAt": "2026-07-27T12:00:00.000Z",
+      "status": "active",
+      "removedAt": null,
+      "sweepPending": true
+    }
+  ],
+  "activeCount": 5,
+  "removedCount": 0,
+  "sweepPendingCount": 2
+}
+```
+
+`sweepPending` marks signers that are expired but not yet swept — that is,
+what the next `run-sweep` at the same simulated time would remove.
+
+### `POST /signer-sweep/run-sweep`
+
+Runs the sweep once, marking every expired active signer as `removed` and
+stamping `removedAt`.
+
+Body (or the equivalent `now` query parameter):
+
+```json
+{ "now": "2026-07-27T20:00:00.000Z" }
+```
+
+Response:
+
+```json
+{
+  "now": "2026-07-27T20:00:00.000Z",
+  "sweepRun": 1,
+  "removedCount": 2,
+  "removedSignerIds": ["signer_session_a", "signer_session_b"],
+  "remainingActive": 3
+}
+```
+
+The sweep is idempotent for a given simulated time: running it again with
+the same `now` returns `removedCount: 0`, since already-removed signers are
+skipped. Advancing `now` sweeps whatever has expired since.
+
+Errors:
+
+| Status | `error` | Cause |
+| --- | --- | --- |
+| 400 | `invalid_now` | `now` is not a parseable ISO 8601 timestamp |
+
+Any other path returns `404` with `{ "error": "not_found" }`; a wrong
+method on a known path returns `405` with `{ "error": "method_not_allowed" }`.
+
+## Notes
+
+`resetState()` is exported so a test can restore the seed signer list and
+replay sweeps from a known baseline.
+
+The folder is named `issue-120-signer-sweep-suite` to follow the
+`contrib/routes/issue-<n>-<name>/` convention used by the sibling route
+folders; the suite itself is the `signer-sweep-suite` described in the
+issue.

--- a/contrib/routes/issue-120-signer-sweep-suite/route.mjs
+++ b/contrib/routes/issue-120-signer-sweep-suite/route.mjs
@@ -1,0 +1,186 @@
+// Mock route suite simulating a periodic sweep that marks expired signers
+// removed. State lives in memory for the lifetime of the process — no
+// chain, RPC, or database access.
+import http from "node:http";
+import { URL, pathToFileURL } from "node:url";
+
+// Seed signers. A null expiresAt means the signer never expires.
+const SEED_SIGNERS = [
+  {
+    id: "signer_admin",
+    label: "Primary admin key",
+    expiresAt: null,
+  },
+  {
+    id: "signer_session_a",
+    label: "Session key A",
+    expiresAt: "2026-07-27T12:00:00.000Z",
+  },
+  {
+    id: "signer_session_b",
+    label: "Session key B",
+    expiresAt: "2026-07-27T18:00:00.000Z",
+  },
+  {
+    id: "signer_device",
+    label: "Device key",
+    expiresAt: "2026-07-28T09:00:00.000Z",
+  },
+  {
+    id: "signer_recovery",
+    label: "Recovery key",
+    expiresAt: "2026-08-04T00:00:00.000Z",
+  },
+];
+
+let signers = seed();
+let sweepCount = 0;
+
+function seed() {
+  return SEED_SIGNERS.map((signer) => ({
+    ...signer,
+    status: "active",
+    removedAt: null,
+  }));
+}
+
+// Resets in-memory state so tests can run sweeps from a known baseline.
+export function resetState() {
+  signers = seed();
+  sweepCount = 0;
+}
+
+function parseNow(raw) {
+  if (raw === undefined || raw === "") return Date.now();
+  const parsed = new Date(raw).getTime();
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function isExpired(signer, nowMs) {
+  if (signer.expiresAt === null) return false;
+  return new Date(signer.expiresAt).getTime() <= nowMs;
+}
+
+function invalidNow() {
+  return {
+    status: 400,
+    body: {
+      error: "invalid_now",
+      message: "now must be an ISO 8601 timestamp",
+    },
+  };
+}
+
+export function listSigners({ query = {} } = {}) {
+  const nowMs = parseNow(query.now);
+  if (nowMs === null) return invalidNow();
+
+  const view = signers.map((signer) => ({
+    ...signer,
+    // Expired but not yet swept — what the next run would pick up.
+    sweepPending: signer.status === "active" && isExpired(signer, nowMs),
+  }));
+
+  return {
+    status: 200,
+    body: {
+      now: new Date(nowMs).toISOString(),
+      signers: view,
+      activeCount: view.filter((signer) => signer.status === "active").length,
+      removedCount: view.filter((signer) => signer.status === "removed").length,
+      sweepPendingCount: view.filter((signer) => signer.sweepPending).length,
+    },
+  };
+}
+
+export function runSweep({ query = {}, body = {} } = {}) {
+  const raw = body?.now ?? query.now;
+  const nowMs = parseNow(raw);
+  if (nowMs === null) return invalidNow();
+
+  const now = new Date(nowMs).toISOString();
+  const removed = [];
+  for (const signer of signers) {
+    if (signer.status !== "active" || !isExpired(signer, nowMs)) continue;
+    signer.status = "removed";
+    signer.removedAt = now;
+    removed.push(signer.id);
+  }
+  sweepCount += 1;
+
+  return {
+    status: 200,
+    body: {
+      now,
+      sweepRun: sweepCount,
+      removedCount: removed.length,
+      removedSignerIds: removed,
+      remainingActive: signers.filter((signer) => signer.status === "active")
+        .length,
+    },
+  };
+}
+
+export function handleRequest({
+  method = "GET",
+  path = "",
+  query = {},
+  body = {},
+} = {}) {
+  if (path === "/signer-sweep/list-signers") {
+    return method === "GET"
+      ? listSigners({ query })
+      : { status: 405, body: { error: "method_not_allowed" } };
+  }
+  if (path === "/signer-sweep/run-sweep") {
+    return method === "POST"
+      ? runSweep({ query, body })
+      : { status: 405, body: { error: "method_not_allowed" } };
+  }
+  return { status: 404, body: { error: "not_found" } };
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
+
+// pathToFileURL keeps this check correct on Windows paths; argv[1] is
+// undefined when the module is imported rather than executed.
+const entry = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;
+const isMain = entry !== null && import.meta.url === entry;
+if (isMain) {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    const body = await readJsonBody(req);
+    const result =
+      body === null
+        ? { status: 400, body: { error: "invalid_json" } }
+        : handleRequest({
+            method: req.method,
+            path: url.pathname,
+            query: Object.fromEntries(url.searchParams),
+            body,
+          });
+    res.writeHead(result.status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result.body));
+  });
+  const port = process.env.PORT || 4120;
+  server.listen(port, () => {
+    console.log(`signer-sweep suite listening on http://localhost:${port}`);
+    console.log(`  GET  /signer-sweep/list-signers?now=2026-07-28T00:00:00.000Z`);
+    console.log(`  POST /signer-sweep/run-sweep  body: {"now":"..."}`);
+  });
+}

--- a/contrib/routes/issue-120-signer-sweep-suite/route.test.mjs
+++ b/contrib/routes/issue-120-signer-sweep-suite/route.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { handleRequest, resetState } from "./route.mjs";
+
+function list(now) {
+  return handleRequest({
+    method: "GET",
+    path: "/signer-sweep/list-signers",
+    query: { now },
+  });
+}
+
+function sweep(now) {
+  return handleRequest({
+    method: "POST",
+    path: "/signer-sweep/run-sweep",
+    body: { now },
+  });
+}
+
+// At this simulated time, two session keys have passed their expiry and
+// three signers (admin, device, recovery) are still active.
+const NOW = "2026-07-27T20:00:00.000Z";
+
+resetState();
+
+// Before any sweep, every signer is still active but the expired ones are
+// flagged as pending.
+const before = list(NOW);
+assert.equal(before.status, 200);
+assert.equal(before.body.now, NOW);
+assert.equal(before.body.removedCount, 0);
+assert.equal(before.body.activeCount, before.body.signers.length);
+assert.deepEqual(
+  before.body.signers.filter((s) => s.sweepPending).map((s) => s.id),
+  ["signer_session_a", "signer_session_b"],
+);
+
+// The sweep removes exactly the expired signers.
+const first = sweep(NOW);
+assert.equal(first.status, 200);
+assert.equal(first.body.removedCount, 2);
+assert.deepEqual(first.body.removedSignerIds, [
+  "signer_session_a",
+  "signer_session_b",
+]);
+assert.equal(first.body.sweepRun, 1);
+
+// Only the expired signers changed; the rest are untouched and active.
+const after = list(NOW);
+assert.equal(after.body.removedCount, 2);
+assert.equal(after.body.sweepPendingCount, 0);
+for (const signer of after.body.signers) {
+  const expired =
+    signer.expiresAt !== null &&
+    new Date(signer.expiresAt).getTime() <= new Date(NOW).getTime();
+  assert.equal(signer.status, expired ? "removed" : "active", signer.id);
+  assert.equal(signer.removedAt, expired ? NOW : null, signer.id);
+}
+
+// A signer that never expires is never swept.
+const admin = after.body.signers.find((s) => s.id === "signer_admin");
+assert.equal(admin.expiresAt, null);
+assert.equal(admin.status, "active");
+
+// Re-running at the same time is a no-op: nothing is left to remove.
+const second = sweep(NOW);
+assert.equal(second.body.removedCount, 0);
+assert.deepEqual(second.body.removedSignerIds, []);
+assert.equal(second.body.sweepRun, 2);
+
+// Advancing simulated time sweeps the next signer to expire.
+const later = sweep("2026-07-28T12:00:00.000Z");
+assert.equal(later.body.removedCount, 1);
+assert.deepEqual(later.body.removedSignerIds, ["signer_device"]);
+assert.equal(later.body.remainingActive, 2);
+
+// Expiry is inclusive: a signer is swept exactly at its expiresAt.
+resetState();
+const atBoundary = sweep("2026-07-27T12:00:00.000Z");
+assert.deepEqual(atBoundary.body.removedSignerIds, ["signer_session_a"]);
+
+// A moment earlier, nothing is expired yet.
+resetState();
+assert.equal(sweep("2026-07-27T11:59:59.999Z").body.removedCount, 0);
+
+// An unparseable simulated time is rejected by both endpoints.
+assert.equal(list("not-a-date").status, 400);
+assert.equal(sweep("not-a-date").status, 400);
+assert.equal(sweep("not-a-date").body.error, "invalid_now");
+
+// Routing and method guards.
+assert.equal(
+  handleRequest({ method: "GET", path: "/signer-sweep/run-sweep" }).status,
+  405,
+);
+assert.equal(
+  handleRequest({ method: "POST", path: "/signer-sweep/list-signers" }).status,
+  405,
+);
+assert.equal(
+  handleRequest({ method: "GET", path: "/signer-sweep/unknown" }).status,
+  404,
+);
+
+console.log("PASS: signer-sweep suite removes only expired signers");


### PR DESCRIPTION
## Summary

Adds a self-contained mock route suite under `contrib/routes/issue-120-signer-sweep-suite/` that simulates a periodic job identifying expired signers and marking them removed, plus a manual trigger for testing. Both endpoints accept a simulated current time, so expiration is exercised without real delays. State is in-memory for the lifetime of the process; no chain, RPC, or database access.

closes #120

## Sample signers

| id | expiresAt |
| --- | --- |
| `signer_admin` | `null` (never expires) |
| `signer_session_a` | 2026-07-27T12:00:00.000Z |
| `signer_session_b` | 2026-07-27T18:00:00.000Z |
| `signer_device` | 2026-07-28T09:00:00.000Z |
| `signer_recovery` | 2026-08-04T00:00:00.000Z |

A signer is expired when `expiresAt` is at or before the simulated time (inclusive). A `null` `expiresAt` never expires.

## Endpoints

**`GET /signer-sweep/list-signers?now=<iso>`**

Lists every signer with `status`, `removedAt`, and a derived `sweepPending` flag marking signers that are expired but not yet swept — that is, exactly what the next run at the same simulated time would remove. Also returns `activeCount`, `removedCount`, and `sweepPendingCount`.

**`POST /signer-sweep/run-sweep`** with body `{ "now": "<iso>" }`

Runs the sweep once, marking every expired active signer `removed` and stamping `removedAt`:

```json
{
  "now": "2026-07-27T20:00:00.000Z",
  "sweepRun": 1,
  "removedCount": 2,
  "removedSignerIds": ["signer_session_a", "signer_session_b"],
  "remainingActive": 3
}
```

The sweep is idempotent for a given simulated time: re-running with the same `now` returns `removedCount: 0`, since already-removed signers are skipped. Advancing `now` sweeps whatever expired since. `now` may also be passed as a query parameter.

An unparseable `now` returns 400 `invalid_now` on both endpoints; unknown paths return 404 `not_found`; a wrong method on a known path returns 405 `method_not_allowed`; a malformed JSON body returns 400 `invalid_json`.

## Files

- `contrib/routes/issue-120-signer-sweep-suite/route.mjs` — handlers plus a standalone `node route.mjs` server on port 4120
- `contrib/routes/issue-120-signer-sweep-suite/route.test.mjs` — runnable with `node route.test.mjs`, no dependencies
- `contrib/routes/issue-120-signer-sweep-suite/README.md` — per-endpoint documentation

## Testing

`node route.test.mjs` passes. Against a mix of expired and active signers it asserts that a sweep removes exactly the two expired session keys; that every other signer is left `active` with a `null` `removedAt`; that the never-expiring admin key is never swept; that a second run at the same time is a no-op; that advancing simulated time sweeps the next signer to expire; that expiry is inclusive at exactly `expiresAt` and not a millisecond earlier; and the 400/404/405 paths. `resetState()` is exported so tests replay from a known baseline. The server was also exercised over HTTP on port 4120.

## Notes

The folder is named `issue-120-signer-sweep-suite` rather than `signer-sweep-suite` to satisfy the constraint that work be saved under `contrib/routes/issue-<n>-<name>/`, consistent with the existing sibling folders. This is called out in the README.

The suite uses `pathToFileURL(process.argv[1]).href` for its "run directly" check instead of the `file://${process.argv[1]}` template used by older sibling routes. That template never matches on Windows (`file://C:\...` vs `file:///C:/...`), so `node route.mjs` exits silently there instead of starting the server. The change is scoped to this new folder only.

## Scope

Every changed file is inside `contrib/`. Base branch is `drips`.
