### PR TITLE
contrib: add webhook signature and replay check route suite

### DIFF
--- a/contrib/routes/issue-116-webhook-signature-suite/README.md
+++ b/contrib/routes/issue-116-webhook-signature-suite/README.md
@@ -1,0 +1,99 @@
+# Mock route suite: webhook signature and replay checks (Issue #116)
+
+Standalone mock route suite that verifies a webhook signature against a
+fixed sample shared secret and rejects any payload whose id has already
+been processed, simulating replay protection.
+
+Processed ids are held in memory for the lifetime of the process. No chain,
+RPC, or database access. The shared secret is a sample constant for local
+testing, not a credential.
+
+## Run
+
+```sh
+node route.mjs
+# webhook-signature suite listening on http://localhost:4116
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Signing
+
+The signature is a hex HMAC-SHA256 of the canonical string `id.event`,
+keyed by the shared secret `vellar_sample_webhook_secret`, sent in the
+`x-vellar-signature` header:
+
+```js
+import { signPayload } from "./route.mjs";
+signPayload({ id: "evt_001", event: "payment.settled" });
+```
+
+Signatures are compared with `crypto.timingSafeEqual`. The scheme is
+deliberately minimal — it exists to exercise the accept and reject paths,
+not to model a production signing scheme.
+
+## Endpoints
+
+### `POST /webhook/receive`
+
+Accepts a signed webhook delivery.
+
+Headers:
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `x-vellar-signature` | yes | Hex HMAC-SHA256 of `id.event` |
+
+Body:
+
+```json
+{ "id": "evt_001", "event": "payment.settled" }
+```
+
+Response on a valid first delivery (`202`):
+
+```json
+{
+  "accepted": true,
+  "id": "evt_001",
+  "event": "payment.settled",
+  "processedCount": 1
+}
+```
+
+Errors:
+
+| Status | `error` | Cause |
+| --- | --- | --- |
+| 400 | `invalid_payload` | `id` or `event` missing or not a string |
+| 401 | `missing_signature` | No `x-vellar-signature` header |
+| 401 | `invalid_signature` | Signature does not match the shared secret |
+| 409 | `replay_detected` | This `id` was already accepted |
+
+The signature is checked before the replay check, so a delivery with a
+forged signature never reveals whether an id has been seen. Rejected
+deliveries are never recorded.
+
+### `GET /webhook/processed-ids`
+
+Returns the ids accepted so far, oldest first.
+
+```json
+{ "ids": ["evt_001", "evt_002"], "count": 2 }
+```
+
+Any other path returns `404` with `{ "error": "not_found" }`; a wrong
+method on a known path returns `405` with `{ "error": "method_not_allowed" }`.
+
+## Notes
+
+`resetState()` is exported so a test can clear the processed-id set.
+
+The folder is named `issue-116-webhook-signature-suite` to follow the
+`contrib/routes/issue-<n>-<name>/` convention used by the sibling route
+folders; the suite itself is the `webhook-signature-suite` described in the
+issue.

--- a/contrib/routes/issue-116-webhook-signature-suite/route.mjs
+++ b/contrib/routes/issue-116-webhook-signature-suite/route.mjs
@@ -1,0 +1,163 @@
+// Mock route suite verifying a webhook signature and rejecting replays.
+// The shared secret below is a fixed sample value for local testing only —
+// it is not a credential. No chain, RPC, or database access; processed ids
+// are held in memory for the lifetime of the process.
+import http from "node:http";
+import crypto from "node:crypto";
+import { URL, pathToFileURL } from "node:url";
+
+// Sample shared secret. A real deployment would read this from config.
+export const SHARED_SECRET = "vellar_sample_webhook_secret";
+
+const SIGNATURE_HEADER = "x-vellar-signature";
+
+// Processed payload ids, newest last, used for replay rejection.
+let processed = [];
+
+export function resetState() {
+  processed = [];
+}
+
+// Signature over the canonical `id.event` string. Deliberately simple: the
+// point is to exercise the accept/reject paths, not to model a production
+// signing scheme.
+export function signPayload(payload, secret = SHARED_SECRET) {
+  return crypto
+    .createHmac("sha256", secret)
+    .update(`${payload.id}.${payload.event}`)
+    .digest("hex");
+}
+
+function signatureMatches(expected, provided) {
+  const expectedBytes = Buffer.from(expected, "utf8");
+  const providedBytes = Buffer.from(String(provided), "utf8");
+  if (expectedBytes.length !== providedBytes.length) return false;
+  return crypto.timingSafeEqual(expectedBytes, providedBytes);
+}
+
+export function receive({ headers = {}, body = {} } = {}) {
+  const signature =
+    headers[SIGNATURE_HEADER] ?? headers[SIGNATURE_HEADER.toUpperCase()];
+
+  if (!body || typeof body.id !== "string" || typeof body.event !== "string") {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_payload",
+        message: "payload requires string id and event fields",
+      },
+    };
+  }
+  if (typeof signature !== "string" || signature === "") {
+    return {
+      status: 401,
+      body: {
+        error: "missing_signature",
+        message: `${SIGNATURE_HEADER} header is required`,
+      },
+    };
+  }
+  if (!signatureMatches(signPayload(body), signature)) {
+    return {
+      status: 401,
+      body: {
+        error: "invalid_signature",
+        message: "signature does not match the shared secret",
+      },
+    };
+  }
+  // Signature checked before replay, so a forged delivery never reveals
+  // whether an id has been seen.
+  if (processed.includes(body.id)) {
+    return {
+      status: 409,
+      body: {
+        error: "replay_detected",
+        message: `payload ${body.id} was already processed`,
+        id: body.id,
+      },
+    };
+  }
+
+  processed.push(body.id);
+  return {
+    status: 202,
+    body: {
+      accepted: true,
+      id: body.id,
+      event: body.event,
+      processedCount: processed.length,
+    },
+  };
+}
+
+export function processedIds() {
+  return {
+    status: 200,
+    body: { ids: [...processed], count: processed.length },
+  };
+}
+
+export function handleRequest({
+  method = "GET",
+  path = "",
+  headers = {},
+  body = {},
+} = {}) {
+  if (path === "/webhook/receive") {
+    return method === "POST"
+      ? receive({ headers, body })
+      : { status: 405, body: { error: "method_not_allowed" } };
+  }
+  if (path === "/webhook/processed-ids") {
+    return method === "GET"
+      ? processedIds()
+      : { status: 405, body: { error: "method_not_allowed" } };
+  }
+  return { status: 404, body: { error: "not_found" } };
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
+
+// pathToFileURL keeps this check correct on Windows paths; argv[1] is
+// undefined when the module is imported rather than executed.
+const entry = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;
+const isMain = entry !== null && import.meta.url === entry;
+if (isMain) {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    const body = await readJsonBody(req);
+    const result =
+      body === null
+        ? { status: 400, body: { error: "invalid_json" } }
+        : handleRequest({
+            method: req.method,
+            path: url.pathname,
+            headers: req.headers,
+            body,
+          });
+    res.writeHead(result.status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result.body));
+  });
+  const port = process.env.PORT || 4116;
+  server.listen(port, () => {
+    console.log(`webhook-signature suite listening on http://localhost:${port}`);
+    console.log(`  POST /webhook/receive       header: ${SIGNATURE_HEADER}`);
+    console.log(`  GET  /webhook/processed-ids`);
+  });
+}

--- a/contrib/routes/issue-116-webhook-signature-suite/route.test.mjs
+++ b/contrib/routes/issue-116-webhook-signature-suite/route.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { handleRequest, resetState, signPayload } from "./route.mjs";
+
+function deliver(payload, signature = signPayload(payload)) {
+  return handleRequest({
+    method: "POST",
+    path: "/webhook/receive",
+    headers: { "x-vellar-signature": signature },
+    body: payload,
+  });
+}
+
+function listProcessed() {
+  return handleRequest({ method: "GET", path: "/webhook/processed-ids" });
+}
+
+resetState();
+
+const payload = { id: "evt_001", event: "payment.settled" };
+
+// Nothing has been processed yet.
+assert.deepEqual(listProcessed().body, { ids: [], count: 0 });
+
+// A valid first delivery is accepted and recorded.
+const first = deliver(payload);
+assert.equal(first.status, 202);
+assert.equal(first.body.accepted, true);
+assert.equal(first.body.id, "evt_001");
+assert.deepEqual(listProcessed().body, { ids: ["evt_001"], count: 1 });
+
+// The same payload delivered again is rejected as a replay.
+const replay = deliver(payload);
+assert.equal(replay.status, 409);
+assert.equal(replay.body.error, "replay_detected");
+assert.equal(listProcessed().body.count, 1);
+
+// A payload with a bad signature is rejected and never recorded.
+const forged = { id: "evt_002", event: "payment.settled" };
+const bad = deliver(forged, "deadbeef");
+assert.equal(bad.status, 401);
+assert.equal(bad.body.error, "invalid_signature");
+assert.deepEqual(listProcessed().body.ids, ["evt_001"]);
+
+// A signature valid for a different payload does not carry over.
+const swapped = deliver(forged, signPayload(payload));
+assert.equal(swapped.status, 401);
+assert.equal(swapped.body.error, "invalid_signature");
+
+// Tampering with the event after signing invalidates the signature.
+const tampered = deliver(
+  { id: "evt_003", event: "payment.reversed" },
+  signPayload({ id: "evt_003", event: "payment.settled" }),
+);
+assert.equal(tampered.status, 401);
+
+// A missing signature header is rejected separately from a wrong one.
+const unsigned = handleRequest({
+  method: "POST",
+  path: "/webhook/receive",
+  headers: {},
+  body: forged,
+});
+assert.equal(unsigned.status, 401);
+assert.equal(unsigned.body.error, "missing_signature");
+
+// A correctly signed second payload is accepted alongside the first.
+const second = deliver(forged);
+assert.equal(second.status, 202);
+assert.deepEqual(listProcessed().body, { ids: ["evt_001", "evt_002"], count: 2 });
+
+// Replaying an id with a valid signature is still rejected.
+assert.equal(deliver(forged).status, 409);
+
+// Malformed payloads are rejected before any signature check.
+const malformed = deliver({ event: "payment.settled" }, "irrelevant");
+assert.equal(malformed.status, 400);
+assert.equal(malformed.body.error, "invalid_payload");
+
+// Routing and method guards.
+assert.equal(
+  handleRequest({ method: "GET", path: "/webhook/receive" }).status,
+  405,
+);
+assert.equal(
+  handleRequest({ method: "POST", path: "/webhook/processed-ids" }).status,
+  405,
+);
+assert.equal(
+  handleRequest({ method: "GET", path: "/webhook/unknown" }).status,
+  404,
+);
+
+console.log("PASS: webhook-signature suite verifies signatures and blocks replays");


### PR DESCRIPTION
## Summary

Adds a self-contained mock route suite under `contrib/routes/issue-116-webhook-signature-suite/` that verifies a mock webhook signature against a fixed sample shared secret and rejects any payload whose id has already been processed, simulating replay protection. Processed ids are in-memory for the lifetime of the process; no chain, RPC, or database access.

closes #116

## Signing

The signature is a hex HMAC-SHA256 of the canonical string `id.event`, keyed by the sample shared secret `vellar_sample_webhook_secret`, sent in the `x-vellar-signature` header. `signPayload()` is exported so callers and tests can produce one. Comparison uses `crypto.timingSafeEqual` on equal-length buffers. The scheme is deliberately minimal — it exists to exercise the accept and reject paths, not to model production signing. The secret is a sample constant for local testing, not a credential.

## Endpoints

**`POST /webhook/receive`** with body `{ "id": "evt_001", "event": "payment.settled" }`

A valid first delivery returns 202:

```json
{ "accepted": true, "id": "evt_001", "event": "payment.settled", "processedCount": 1 }
```

| Status | `error` | Cause |
| --- | --- | --- |
| 400 | `invalid_payload` | `id` or `event` missing or not a string |
| 401 | `missing_signature` | No `x-vellar-signature` header |
| 401 | `invalid_signature` | Signature does not match the shared secret |
| 409 | `replay_detected` | This `id` was already accepted |

The signature is checked **before** the replay check, so a delivery with a forged signature cannot be used to probe which ids have been seen. Rejected deliveries are never recorded.

**`GET /webhook/processed-ids`**

Returns the accepted ids, oldest first, with a count.

Unknown paths return 404 `not_found`; a wrong method on a known path returns 405 `method_not_allowed`; a malformed JSON body returns 400 `invalid_json`.

## Files

- `contrib/routes/issue-116-webhook-signature-suite/route.mjs` — handlers plus a standalone `node route.mjs` server on port 4116
- `contrib/routes/issue-116-webhook-signature-suite/route.test.mjs` — runnable with `node route.test.mjs`, no dependencies
- `contrib/routes/issue-116-webhook-signature-suite/README.md` — per-endpoint documentation

## Testing

`node route.test.mjs` passes. It covers the three required cases — a valid first delivery (202, id recorded), a rejected replay (409, count unchanged), and a rejected bad signature (401, id never recorded) — plus a signature lifted from a different payload, an event tampered with after signing, a missing signature header (distinguished from a wrong one), a correctly signed second payload accepted alongside the first, a replay of that second id, malformed payloads, and the routing and method guards. `resetState()` is exported so tests start from an empty set.

The full accept/replay/reject flow was also exercised over HTTP on port 4116.

## Notes

The folder is named `issue-116-webhook-signature-suite` rather than `webhook-signature-suite` to satisfy the constraint that work be saved under `contrib/routes/issue-<n>-<name>/`, consistent with the existing sibling folders. This is called out in the README.

The suite uses `pathToFileURL(process.argv[1]).href` for its "run directly" check instead of the `file://${process.argv[1]}` template used by older sibling routes. That template never matches on Windows (`file://C:\...` vs `file:///C:/...`), so `node route.mjs` exits silently there instead of starting the server. The change is scoped to this new folder only.

## Scope

Every changed file is inside `contrib/`. Base branch is `drips`.
