### PR TITLE
contrib: add mock merge eligibility route

### DIFF
--- a/contrib/routes/issue-48-merge-eligibility/README.md
+++ b/contrib/routes/issue-48-merge-eligibility/README.md
@@ -1,0 +1,72 @@
+# Mock route: merge eligibility (Issue #48)
+
+Standalone mock GET route returning whether a sample account is eligible for a
+merge operation, looked up by an `accountId` path parameter. No real chain or
+database access.
+
+## Run
+
+```sh
+node route.mjs
+# merge-eligibility mock listening on http://localhost:4048/accounts/:accountId/merge-eligibility
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /accounts/acc_1001/merge-eligibility
+```
+
+Response:
+
+```json
+{
+  "accountId": "acc_1001",
+  "eligible": true,
+  "reasons": []
+}
+```
+
+An ineligible account keeps the same shape and fills in `reasons`:
+
+```
+GET /accounts/acc_1002/merge-eligibility
+```
+
+```json
+{
+  "accountId": "acc_1002",
+  "eligible": false,
+  "reasons": ["account_has_open_trustlines", "account_has_subentries"]
+}
+```
+
+An account id that isn't in the sample dataset returns a 404-style payload:
+
+```
+GET /accounts/acc_9999/merge-eligibility
+```
+
+```json
+{
+  "error": "not_found",
+  "message": "No merge eligibility record found for account \"acc_9999\""
+}
+```
+
+## Sample dataset
+
+| accountId  | eligible | reasons                                                 |
+| ---------- | -------- | ------------------------------------------------------- |
+| `acc_1001` | `true`   | —                                                       |
+| `acc_1002` | `false`  | `account_has_open_trustlines`, `account_has_subentries` |
+| `acc_1003` | `false`  | `balance_below_reserve`                                  |
+| `acc_1004` | `true`   | —                                                       |

--- a/contrib/routes/issue-48-merge-eligibility/route.mjs
+++ b/contrib/routes/issue-48-merge-eligibility/route.mjs
@@ -1,0 +1,63 @@
+// Mock GET route returning whether a sample account is eligible for a merge
+// operation. No chain or DB access.
+import http from "node:http";
+
+const MERGE_ELIGIBILITY = {
+  acc_1001: { eligible: true, reasons: [] },
+  acc_1002: {
+    eligible: false,
+    reasons: ["account_has_open_trustlines", "account_has_subentries"],
+  },
+  acc_1003: {
+    eligible: false,
+    reasons: ["balance_below_reserve"],
+  },
+  acc_1004: { eligible: true, reasons: [] },
+};
+
+export function handleRequest({ params = {} } = {}) {
+  const { accountId } = params;
+  const record = accountId ? MERGE_ELIGIBILITY[accountId] : undefined;
+
+  if (!record) {
+    return {
+      status: 404,
+      body: {
+        error: "not_found",
+        message: `No merge eligibility record found for account "${accountId ?? ""}"`,
+      },
+    };
+  }
+
+  return {
+    status: 200,
+    body: {
+      accountId,
+      eligible: record.eligible,
+      reasons: [...record.reasons],
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const match = req.url.match(/^\/accounts\/([^/]+)\/merge-eligibility$/);
+    if (req.method === "GET" && match) {
+      const { status, body } = handleRequest({
+        params: { accountId: decodeURIComponent(match[1]) },
+      });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4048;
+  server.listen(port, () => {
+    console.log(
+      `merge-eligibility mock listening on http://localhost:${port}/accounts/:accountId/merge-eligibility`,
+    );
+  });
+}

--- a/contrib/routes/issue-48-merge-eligibility/route.test.mjs
+++ b/contrib/routes/issue-48-merge-eligibility/route.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// An eligible account reports eligible: true with an empty reasons array.
+const eligible = handleRequest({ params: { accountId: "acc_1001" } });
+assert.equal(eligible.status, 200);
+assert.equal(eligible.body.accountId, "acc_1001");
+assert.equal(eligible.body.eligible, true);
+assert.ok(Array.isArray(eligible.body.reasons));
+assert.equal(eligible.body.reasons.length, 0);
+
+// An ineligible account reports eligible: false and lists why.
+const ineligible = handleRequest({ params: { accountId: "acc_1002" } });
+assert.equal(ineligible.status, 200);
+assert.equal(ineligible.body.eligible, false);
+assert.ok(Array.isArray(ineligible.body.reasons));
+assert.ok(ineligible.body.reasons.length > 0);
+for (const reason of ineligible.body.reasons) {
+  assert.equal(typeof reason, "string");
+}
+
+// The returned reasons array is a copy, so callers cannot mutate the dataset.
+ineligible.body.reasons.push("tampered");
+const refetched = handleRequest({ params: { accountId: "acc_1002" } });
+assert.ok(!refetched.body.reasons.includes("tampered"));
+
+// An unknown account id returns a 404-style payload.
+const miss = handleRequest({ params: { accountId: "acc_9999" } });
+assert.equal(miss.status, 404);
+assert.equal(miss.body.error, "not_found");
+
+// A missing account id is also treated as not found.
+const noId = handleRequest({});
+assert.equal(noId.status, 404);
+
+console.log(
+  "PASS: /accounts/:accountId/merge-eligibility reports eligible and ineligible accounts",
+);


### PR DESCRIPTION
## Summary

Adds a standalone mock GET route under `contrib/routes/` that reports whether a sample account is eligible for a merge operation, looked up by an `accountId` path parameter. Everything is self-contained in `contrib/routes/issue-48-merge-eligibility/`, with no chain or database access.

closes #48

## What's included

- `route.mjs` - exported `handleRequest({ params })` plus a `node:http` server that runs only when the file is executed directly, following the same shape as the existing `contrib/routes/*` mocks (for example `issue-34-policy-detail`).
- `route.test.mjs` - assertion script runnable with plain `node`, no test runner or dependencies.
- `README.md` - endpoint, run and test commands, example responses, and the sample dataset table.

## Endpoint

```
GET /accounts/:accountId/merge-eligibility
```

Eligible account:

```json
{
  "accountId": "acc_1001",
  "eligible": true,
  "reasons": []
}
```

Ineligible account - same shape, `reasons` populated:

```json
{
  "accountId": "acc_1002",
  "eligible": false,
  "reasons": ["account_has_open_trustlines", "account_has_subentries"]
}
```

Unknown account id returns a 404-style payload:

```json
{
  "error": "not_found",
  "message": "No merge eligibility record found for account \"acc_9999\""
}
```

`reasons` is always present and always an array, so consumers do not need to branch on its existence.

## Sample dataset

| accountId  | eligible | reasons |
| ---------- | -------- | ------- |
| `acc_1001` | `true`   | - |
| `acc_1002` | `false`  | `account_has_open_trustlines`, `account_has_subentries` |
| `acc_1003` | `false`  | `balance_below_reserve` |
| `acc_1004` | `true`   | - |

## Testing

```sh
cd contrib/routes/issue-48-merge-eligibility
node route.test.mjs
# PASS: /accounts/:accountId/merge-eligibility reports eligible and ineligible accounts
```

The test covers an eligible id, an ineligible id (asserting a non-empty string `reasons` array), an unknown id, and a missing id. It also asserts that the returned `reasons` array is a copy, so a caller mutating the response cannot corrupt the sample dataset for later requests.

## Constraints checklist

- [x] All changes are inside `contrib/` - the diff is three new files under `contrib/routes/issue-48-merge-eligibility/`
- [x] Branch created from `drips`, PR targets `drips`
- [x] No files outside `contrib/` added, edited, renamed, or deleted
