### PR TITLE
feat: add four contrib route suites for Stellar Wave bounties

### DIFF
--- a/contrib/routes/blocker-report-suite/README.md
+++ b/contrib/routes/blocker-report-suite/README.md
@@ -1,0 +1,56 @@
+# Route suite: blocker report (Issue #119)
+
+Self-contained route handlers that inspect a sample Stellar account and
+produce a prioritized report of blockers ranked by a fixed severity order.
+
+## Endpoints
+
+### GET /inspect?account=<id>
+
+Inspects the given account and returns its profile plus raw list of blockers.
+
+```json
+{
+  "account": { "account": "...", "balance": "1250.5000000", "trustlines": 3, "signers": 1, "flags": 0 },
+  "blockers": [
+    { "id": "excess-trustlines", "severity": "medium", "message": "..." }
+  ]
+}
+```
+
+### GET /report?account=<id>
+
+Returns the same blockers as `/inspect`, but sorted by severity:
+`high` first, then `medium`, then `low`.
+
+```json
+{
+  "account": "...",
+  "blockers": [
+    { "id": "low-balance", "severity": "high", "message": "..." },
+    { "id": "excess-trustlines", "severity": "medium", "message": "..." },
+    { "id": "account-flagged", "severity": "low", "message": "..." }
+  ]
+}
+```
+
+## Severity levels
+
+| Level  | Meaning |
+|--------|---------|
+| high   | Critical issue that blocks further action |
+| medium | Warning that should be addressed |
+| low    | Informational notice |
+
+## Run
+
+```sh
+node route.mjs
+# blocker-report-suite mock listening on http://localhost:4050
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```

--- a/contrib/routes/blocker-report-suite/route.mjs
+++ b/contrib/routes/blocker-report-suite/route.mjs
@@ -1,0 +1,111 @@
+import http from "node:http";
+
+const SEVERITY_ORDER = { high: 0, medium: 1, low: 2 };
+
+const SAMPLE_ACCOUNTS = {
+  "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB": {
+    account: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+    balance: "1250.5000000",
+    trustlines: 3,
+    signers: 1,
+    flags: 0,
+  },
+  "GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF": {
+    account: "GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+    balance: "0.5000000",
+    trustlines: 3,
+    signers: 2,
+    flags: 1,
+  },
+};
+
+function inspectAccount(accountId) {
+  if (!SAMPLE_ACCOUNTS[accountId]) {
+    return null;
+  }
+  const acct = SAMPLE_ACCOUNTS[accountId];
+  const blockers = [];
+
+  if (parseFloat(acct.balance) < 1) {
+    blockers.push({
+      id: "low-balance",
+      severity: "high",
+      message: "Account balance is below minimum reserve",
+    });
+  }
+  if (acct.trustlines > 2) {
+    blockers.push({
+      id: "excess-trustlines",
+      severity: "medium",
+      message: "Account has more than 2 trustlines",
+    });
+  }
+  if (acct.flags !== 0) {
+    blockers.push({
+      id: "account-flagged",
+      severity: "low",
+      message: "Account has flags set",
+    });
+  }
+  if (acct.signers > 1) {
+    blockers.push({
+      id: "multiple-signers",
+      severity: "medium",
+      message: "Account has multiple signers",
+    });
+  }
+
+  return { account: acct, blockers };
+}
+
+export function handleRequest(url) {
+  const parsedUrl = new URL(url, "http://localhost");
+  const path = parsedUrl.pathname;
+
+  if (path === "/inspect") {
+    const accountId = parsedUrl.searchParams.get("account");
+    if (!accountId) {
+      return { status: 400, body: { error: "account_required" } };
+    }
+    const result = inspectAccount(accountId);
+    if (!result) {
+      return { status: 404, body: { error: "account_not_found" } };
+    }
+    return { status: 200, body: result };
+  }
+
+  if (path === "/report") {
+    const accountId = parsedUrl.searchParams.get("account");
+    if (!accountId) {
+      return { status: 400, body: { error: "account_required" } };
+    }
+    const result = inspectAccount(accountId);
+    if (!result) {
+      return { status: 404, body: { error: "account_not_found" } };
+    }
+    const sorted = [...result.blockers].sort(
+      (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
+    );
+    return {
+      status: 200,
+      body: { account: accountId, blockers: sorted },
+    };
+  }
+
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const { status, body } = handleRequest(req.url);
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4050;
+  server.listen(port, () => {
+    console.log(
+      `blocker-report-suite mock listening on http://localhost:${port}`,
+    );
+  });
+}

--- a/contrib/routes/blocker-report-suite/route.test.mjs
+++ b/contrib/routes/blocker-report-suite/route.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const ACCOUNT = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB";
+const MIXED_ACCOUNT = "GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF";
+
+// Test inspect
+{
+  const { status, body } = handleRequest(`/inspect?account=${ACCOUNT}`);
+  assert.equal(status, 200);
+  assert.equal(body.account.account, ACCOUNT);
+  assert.ok(Array.isArray(body.blockers));
+}
+
+// Test report returns sorted blockers
+{
+  const { status, body } = handleRequest(`/report?account=${ACCOUNT}`);
+  assert.equal(status, 200);
+  assert.ok(body.blockers.length >= 1);
+  for (let i = 1; i < body.blockers.length; i++) {
+    const prev = ["high", "medium", "low"].indexOf(
+      body.blockers[i - 1].severity,
+    );
+    const curr = ["high", "medium", "low"].indexOf(body.blockers[i].severity);
+    assert.ok(
+      prev <= curr,
+      `Expected severity order: ${body.blockers[i - 1].severity} before ${body.blockers[i].severity}`,
+    );
+  }
+}
+
+// Test missing account
+{
+  const { status, body } = handleRequest("/report");
+  assert.equal(status, 400);
+  assert.equal(body.error, "account_required");
+}
+
+// Test unknown account
+{
+  const { status, body } = handleRequest("/report?account=UNKNOWN");
+  assert.equal(status, 404);
+  assert.equal(body.error, "account_not_found");
+}
+
+// Test report with mixed severities (high, medium, low)
+{
+  const { status, body } = handleRequest(`/report?account=${MIXED_ACCOUNT}`);
+  assert.equal(status, 200);
+  assert.ok(body.blockers.length >= 3);
+  const severityOrder = ["high", "medium", "low"];
+  for (let i = 1; i < body.blockers.length; i++) {
+    const prev = severityOrder.indexOf(body.blockers[i - 1].severity);
+    const curr = severityOrder.indexOf(body.blockers[i].severity);
+    assert.ok(
+      prev <= curr,
+      `Expected ${body.blockers[i - 1].severity} before ${body.blockers[i].severity}`,
+    );
+  }
+  const severities = body.blockers.map((b) => b.severity);
+  assert.ok(severities.includes("high"));
+  assert.ok(severities.includes("medium"));
+  assert.ok(severities.includes("low"));
+}
+
+console.log("PASS: blocker-report-suite tests");

--- a/contrib/routes/full-cleanup-merge-suite/README.md
+++ b/contrib/routes/full-cleanup-merge-suite/README.md
@@ -1,0 +1,81 @@
+# Route suite: full cleanup and merge flow (Issue #124)
+
+Self-contained route handlers that carry a sample account through
+inspection, cleanup plan execution, verification of merge readiness,
+and a final merge build as one connected sequence.
+
+## Endpoints
+
+### GET /inspect?account=<id>
+
+Inspects the account and lists pending cleanup steps.
+
+```json
+{
+  "account": { "account": "...", "balance": "1250.5000000", "flags": 1, "trustlines": 3, "signers": 2 },
+  "pendingSteps": [
+    { "id": "clear-flags", "description": "Clear account flags" },
+    { "id": "remove-trustlines", "description": "Remove extra trustlines" },
+    { "id": "lower-signers", "description": "Reduce signer count to 1" }
+  ]
+}
+```
+
+### POST /execute-cleanup-step
+
+Executes a single cleanup step. State is tracked in memory per account.
+
+Request:
+```json
+{ "account": "...", "step": "clear-flags" }
+```
+
+Response:
+```json
+{ "completed": true, "stepId": "clear-flags" }
+```
+
+### GET /check-ready?account=<id>
+
+Checks whether all required cleanup steps have been completed.
+
+```json
+{ "ready": true, "completedSteps": [...], "missingSteps": [] }
+```
+
+### POST /build-merge
+
+Builds the final merge transaction. Refuses to proceed unless
+`/check-ready` reports the account is fully ready.
+
+Request:
+```json
+{ "account": "..." }
+```
+
+Response (ready):
+```json
+{ "account": "...", "balance": "1250.5000000", "mergeTx": { "memo": "cleanup-merge", "ready": true } }
+```
+
+Response (not ready):
+```json
+{ "error": "not_ready", "missingSteps": ["clear-flags"] }
+```
+
+## Run
+
+```sh
+node route.mjs
+# full-cleanup-merge-suite mock listening on http://localhost:4053
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+The test walks an account through the full sequence: inspect → check-ready
+(not ready) → build-merge (refused) → execute all steps → check-ready
+(ready) → build-merge (success).

--- a/contrib/routes/full-cleanup-merge-suite/route.mjs
+++ b/contrib/routes/full-cleanup-merge-suite/route.mjs
@@ -1,0 +1,187 @@
+import http from "node:http";
+
+const CLEANUP_STEPS = [
+  { id: "clear-flags", description: "Clear account flags", required: true },
+  {
+    id: "remove-trustlines",
+    description: "Remove extra trustlines",
+    required: true,
+  },
+  { id: "lower-signers", description: "Reduce signer count to 1", required: true },
+];
+
+const SAMPLE_ACCOUNTS = {
+  "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB": {
+    account: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+    balance: "1250.5000000",
+    flags: 1,
+    trustlines: 3,
+    signers: 2,
+  },
+};
+
+const accountState = new Map();
+
+function getState(accountId) {
+  if (!accountState.has(accountId)) {
+    accountState.set(accountId, { completedSteps: [] });
+  }
+  return accountState.get(accountId);
+}
+
+function inspectAccount(accountId) {
+  const acct = SAMPLE_ACCOUNTS[accountId];
+  if (!acct) return null;
+  const issues = [];
+  if (acct.flags !== 0) issues.push("clear-flags");
+  if (acct.trustlines > 1) issues.push("remove-trustlines");
+  if (acct.signers > 1) issues.push("lower-signers");
+  return {
+    account: acct,
+    pendingSteps: CLEANUP_STEPS.filter((s) => issues.includes(s.id)).map(
+      (s) => ({ id: s.id, description: s.description }),
+    ),
+  };
+}
+
+function executeStep(accountId, stepId) {
+  const acct = SAMPLE_ACCOUNTS[accountId];
+  if (!acct) return { error: "account_not_found" };
+  const step = CLEANUP_STEPS.find((s) => s.id === stepId);
+  if (!step) return { error: "unknown_step", stepId };
+  const state = getState(accountId);
+  if (state.completedSteps.includes(stepId)) {
+    return { alreadyCompleted: true, stepId };
+  }
+  state.completedSteps.push(stepId);
+  return { completed: true, stepId };
+}
+
+function checkReady(accountId) {
+  const acct = SAMPLE_ACCOUNTS[accountId];
+  if (!acct) return { error: "account_not_found" };
+  const state = getState(accountId);
+  const requiredSteps = CLEANUP_STEPS.filter((s) => s.required).map(
+    (s) => s.id,
+  );
+  const missing = requiredSteps.filter(
+    (s) => !state.completedSteps.includes(s),
+  );
+  return {
+    ready: missing.length === 0,
+    completedSteps: state.completedSteps,
+    missingSteps: missing,
+  };
+}
+
+export function handleRequest(req) {
+  const parsedUrl = new URL(req.url, "http://localhost");
+  const path = parsedUrl.pathname;
+
+  if (path === "/inspect" && req.method === "GET") {
+    const accountId = parsedUrl.searchParams.get("account");
+    if (!accountId) {
+      return { status: 400, body: { error: "account_required" } };
+    }
+    const result = inspectAccount(accountId);
+    if (!result) {
+      return { status: 404, body: { error: "account_not_found" } };
+    }
+    return { status: 200, body: result };
+  }
+
+  if (path === "/execute-cleanup-step" && req.method === "POST") {
+    return new Promise((resolve) => {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data);
+          if (!body.account || !body.step) {
+            resolve({ status: 400, body: { error: "account_and_step_required" } });
+            return;
+          }
+          const result = executeStep(body.account, body.step);
+          if (result.error) {
+            resolve({ status: 400, body: result });
+          } else {
+            resolve({ status: 200, body: result });
+          }
+        } catch {
+          resolve({ status: 400, body: { error: "invalid_json" } });
+        }
+      });
+    });
+  }
+
+  if (path === "/check-ready" && req.method === "GET") {
+    const accountId = parsedUrl.searchParams.get("account");
+    if (!accountId) {
+      return { status: 400, body: { error: "account_required" } };
+    }
+    const result = checkReady(accountId);
+    if (result.error) {
+      return { status: 400, body: result };
+    }
+    return { status: 200, body: result };
+  }
+
+  if (path === "/build-merge" && req.method === "POST") {
+    return new Promise((resolve) => {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data);
+          if (!body.account) {
+            resolve({ status: 400, body: { error: "account_required" } });
+            return;
+          }
+          const ready = checkReady(body.account);
+          if (ready.error) {
+            resolve({ status: 400, body: ready });
+            return;
+          }
+          if (!ready.ready) {
+            resolve({
+              status: 400,
+              body: {
+                error: "not_ready",
+                missingSteps: ready.missingSteps,
+              },
+            });
+            return;
+          }
+          const acct = SAMPLE_ACCOUNTS[body.account];
+          resolve({
+            status: 200,
+            body: {
+              account: body.account,
+              balance: acct.balance,
+              mergeTx: { memo: "cleanup-merge", ready: true },
+            },
+          });
+        } catch {
+          resolve({ status: 400, body: { error: "invalid_json" } });
+        }
+      });
+    });
+  }
+
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer(async (req, res) => {
+    const { status, body } = await handleRequest(req);
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4053;
+  server.listen(port, () => {
+    console.log(
+      `full-cleanup-merge-suite mock listening on http://localhost:${port}`,
+    );
+  });
+}

--- a/contrib/routes/full-cleanup-merge-suite/route.test.mjs
+++ b/contrib/routes/full-cleanup-merge-suite/route.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const ACCOUNT = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB";
+
+function makeReq(method, url, body) {
+  const readable = {
+    url,
+    method,
+    on: (event, cb) => {
+      if (event === "data") cb(JSON.stringify(body || {}));
+      if (event === "end") cb();
+    },
+  };
+  return readable;
+}
+
+// Step 1: inspect
+{
+  const { status, body } = await handleRequest({
+    method: "GET",
+    url: `/inspect?account=${ACCOUNT}`,
+  });
+  assert.equal(status, 200);
+  assert.equal(body.account.account, ACCOUNT);
+  assert.ok(body.pendingSteps.length >= 2);
+}
+
+// Step 2: check-ready (should not be ready)
+{
+  const { status, body } = await handleRequest({
+    method: "GET",
+    url: `/check-ready?account=${ACCOUNT}`,
+  });
+  assert.equal(status, 200);
+  assert.equal(body.ready, false);
+  assert.ok(body.missingSteps.length > 0);
+}
+
+// Step 3: build-merge should refuse
+{
+  const req = makeReq("POST", "/build-merge", { account: ACCOUNT });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 400);
+  assert.equal(body.error, "not_ready");
+}
+
+// Step 4: execute all required cleanup steps
+for (const step of ["clear-flags", "remove-trustlines", "lower-signers"]) {
+  const req = makeReq("POST", "/execute-cleanup-step", {
+    account: ACCOUNT,
+    step,
+  });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 200);
+  assert.equal(body.completed, true);
+}
+
+// Step 5: check-ready (should be ready now)
+{
+  const { status, body } = await handleRequest({
+    method: "GET",
+    url: `/check-ready?account=${ACCOUNT}`,
+  });
+  assert.equal(status, 200);
+  assert.equal(body.ready, true);
+  assert.equal(body.missingSteps.length, 0);
+}
+
+// Step 6: build-merge should succeed
+{
+  const req = makeReq("POST", "/build-merge", { account: ACCOUNT });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 200);
+  assert.equal(body.mergeTx.ready, true);
+  assert.equal(body.balance, "1250.5000000");
+}
+
+console.log("PASS: full-cleanup-merge-suite tests");

--- a/contrib/routes/merge-builder-suite/README.md
+++ b/contrib/routes/merge-builder-suite/README.md
@@ -1,0 +1,72 @@
+# Route suite: merge builder (Issue #122)
+
+Self-contained route handlers that validate a merge destination, build a
+mock merge transaction, and report the estimated reclaimed balance.
+
+## Endpoints
+
+### POST /validate-destination
+
+Validates whether the given destination is acceptable for a merge.
+
+Request:
+```json
+{ "destination": "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB" }
+```
+
+Response (valid):
+```json
+{ "valid": true }
+```
+
+Response (invalid):
+```json
+{ "valid": false, "error": "invalid_destination", "destination": "..." }
+```
+
+### POST /build
+
+Builds a mock merge transaction. Refuses to proceed if the destination
+is invalid (same validation as `/validate-destination`).
+
+Request:
+```json
+{ "destination": "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB" }
+```
+
+Response:
+```json
+{
+  "source": "GABCDEF...",
+  "destination": "GABCDEF...",
+  "amount": "1250.5000000",
+  "memo": "merge",
+  "txReady": true
+}
+```
+
+### GET /estimate-reclaim
+
+Returns the source balance minus a fixed reserve amount.
+
+```json
+{
+  "source": "GABCDEF...",
+  "sourceBalance": "1250.5000000",
+  "reserve": "1.0000000",
+  "estimatedReclaim": "1249.5000000"
+}
+```
+
+## Run
+
+```sh
+node route.mjs
+# merge-builder-suite mock listening on http://localhost:4051
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```

--- a/contrib/routes/merge-builder-suite/route.mjs
+++ b/contrib/routes/merge-builder-suite/route.mjs
@@ -1,0 +1,108 @@
+import http from "node:http";
+
+const VALID_DESTINATIONS = [
+  "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+  "GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+];
+
+const FIXED_RESERVE = "1.0000000";
+
+const SAMPLE_SOURCE = {
+  account: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+  balance: "1250.5000000",
+};
+
+function validateDestination(dest) {
+  if (!dest) {
+    return { valid: false, error: "destination_required" };
+  }
+  if (!VALID_DESTINATIONS.includes(dest)) {
+    return { valid: false, error: "invalid_destination", destination: dest };
+  }
+  return { valid: true };
+}
+
+export function handleRequest(req) {
+  const parsedUrl = new URL(req.url, "http://localhost");
+  const path = parsedUrl.pathname;
+
+  if (path === "/validate-destination" && req.method === "POST") {
+    return new Promise((resolve) => {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data);
+          const result = validateDestination(body.destination);
+          resolve({
+            status: result.valid ? 200 : 400,
+            body: result,
+          });
+        } catch {
+          resolve({ status: 400, body: { error: "invalid_json" } });
+        }
+      });
+    });
+  }
+
+  if (path === "/build" && req.method === "POST") {
+    return new Promise((resolve) => {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data);
+          const destCheck = validateDestination(body.destination);
+          if (!destCheck.valid) {
+            resolve({ status: 400, body: destCheck });
+            return;
+          }
+          resolve({
+            status: 200,
+            body: {
+              source: SAMPLE_SOURCE.account,
+              destination: body.destination,
+              amount: SAMPLE_SOURCE.balance,
+              memo: "merge",
+              txReady: true,
+            },
+          });
+        } catch {
+          resolve({ status: 400, body: { error: "invalid_json" } });
+        }
+      });
+    });
+  }
+
+  if (path === "/estimate-reclaim" && req.method === "GET") {
+    const balance = parseFloat(SAMPLE_SOURCE.balance);
+    const reserve = parseFloat(FIXED_RESERVE);
+    const reclaimed = (balance - reserve).toFixed(7);
+    return {
+      status: 200,
+      body: {
+        source: SAMPLE_SOURCE.account,
+        sourceBalance: SAMPLE_SOURCE.balance,
+        reserve: FIXED_RESERVE,
+        estimatedReclaim: reclaimed,
+      },
+    };
+  }
+
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer(async (req, res) => {
+    const { status, body } = await handleRequest(req);
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4051;
+  server.listen(port, () => {
+    console.log(
+      `merge-builder-suite mock listening on http://localhost:${port}`,
+    );
+  });
+}

--- a/contrib/routes/merge-builder-suite/route.test.mjs
+++ b/contrib/routes/merge-builder-suite/route.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const VALID_DEST = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB";
+const INVALID_DEST = "INVALIDACCOUNT";
+
+function makeReq(method, url, body) {
+  const readable = {
+    url,
+    method,
+    on: (event, cb) => {
+      if (event === "data") cb(JSON.stringify(body || {}));
+      if (event === "end") cb();
+    },
+  };
+  return readable;
+}
+
+// Test validate-destination with valid destination
+{
+  const req = makeReq("POST", "/validate-destination", {
+    destination: VALID_DEST,
+  });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 200);
+  assert.equal(body.valid, true);
+}
+
+// Test validate-destination with invalid destination
+{
+  const req = makeReq("POST", "/validate-destination", {
+    destination: INVALID_DEST,
+  });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 400);
+  assert.equal(body.valid, false);
+  assert.equal(body.error, "invalid_destination");
+}
+
+// Test build with valid destination
+{
+  const req = makeReq("POST", "/build", { destination: VALID_DEST });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 200);
+  assert.equal(body.txReady, true);
+  assert.equal(body.destination, VALID_DEST);
+}
+
+// Test build refuses invalid destination
+{
+  const req = makeReq("POST", "/build", { destination: INVALID_DEST });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 400);
+  assert.equal(body.valid, false);
+}
+
+// Test estimate-reclaim
+{
+  const { status, body } = await handleRequest({
+    method: "GET",
+    url: "/estimate-reclaim",
+  });
+  assert.equal(status, 200);
+  assert.equal(body.sourceBalance, "1250.5000000");
+  assert.equal(body.reserve, "1.0000000");
+  assert.equal(body.estimatedReclaim, "1249.5000000");
+}
+
+console.log("PASS: merge-builder-suite tests");

--- a/contrib/routes/template-versioning-suite/README.md
+++ b/contrib/routes/template-versioning-suite/README.md
@@ -1,0 +1,89 @@
+# Route suite: template versioning migration (Issue #123)
+
+Self-contained route handlers that list versions of a policy template and
+migrate an account using an older version to the current one, preserving
+compatible fields.
+
+## Endpoints
+
+### GET /versions
+
+Lists all available template versions and the current version.
+
+```json
+{
+  "versions": ["1.0", "1.1", "2.0"],
+  "current": "2.0"
+}
+```
+
+### GET /current-config
+
+Returns the current template version and its field names.
+
+```json
+{
+  "version": "2.0",
+  "fields": ["policyName", "maxSigners", "network", "expiry"]
+}
+```
+
+### POST /migrate
+
+Migrates a config from an older version to the current version by mapping
+old field names to new ones.
+
+Request (old version):
+```json
+{
+  "version": "1.0",
+  "name": "My Policy",
+  "signerLimit": 3,
+  "chain": "testnet"
+}
+```
+
+Response:
+```json
+{
+  "migrated": true,
+  "config": {
+    "version": "2.0",
+    "policyName": "My Policy",
+    "maxSigners": 3,
+    "network": "testnet"
+  }
+}
+```
+
+Request (already current):
+```json
+{ "version": "2.0", "policyName": "X", "maxSigners": 1, "network": "mainnet" }
+```
+
+Response:
+```json
+{ "migrated": false, "config": {...}, "reason": "already_current" }
+```
+
+## Field migration map
+
+| Old version | Old field     | New field    |
+|-------------|---------------|--------------|
+| 1.0         | name          | policyName   |
+| 1.0         | signerLimit   | maxSigners   |
+| 1.0         | chain         | network      |
+| 1.1         | (no changes)  | —            |
+
+## Run
+
+```sh
+node route.mjs
+# template-versioning-suite mock listening on http://localhost:4052
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```

--- a/contrib/routes/template-versioning-suite/route.mjs
+++ b/contrib/routes/template-versioning-suite/route.mjs
@@ -1,0 +1,116 @@
+import http from "node:http";
+
+const TEMPLATE_VERSIONS = [
+  {
+    version: "1.0",
+    fields: { policyName: "name", maxSigners: "signerLimit", network: "chain" },
+  },
+  {
+    version: "1.1",
+    fields: {
+      policyName: "policyName",
+      maxSigners: "maxSigners",
+      network: "network",
+    },
+  },
+  {
+    version: "2.0",
+    fields: {
+      policyName: "policyName",
+      maxSigners: "maxSigners",
+      network: "network",
+      expiry: "expiry",
+    },
+  },
+];
+
+const CURRENT_VERSION = "2.0";
+const FIELD_MIGRATIONS = {
+  "1.0": { name: "policyName", signerLimit: "maxSigners", chain: "network" },
+  "1.1": {},
+};
+
+function getCurrentConfig() {
+  const current = TEMPLATE_VERSIONS.find((v) => v.version === CURRENT_VERSION);
+  return {
+    version: current.version,
+    fields: Object.keys(current.fields),
+  };
+}
+
+function migrate(config) {
+  if (!config || !config.version) {
+    return { error: "version_required" };
+  }
+  if (config.version === CURRENT_VERSION) {
+    return { migrated: false, config, reason: "already_current" };
+  }
+  const migration = FIELD_MIGRATIONS[config.version];
+  if (!migration) {
+    return { error: "unknown_version", version: config.version };
+  }
+  const newConfig = { ...config, version: CURRENT_VERSION };
+  for (const [oldKey, newKey] of Object.entries(migration)) {
+    if (oldKey in newConfig) {
+      newConfig[newKey] = newConfig[oldKey];
+      delete newConfig[oldKey];
+    }
+  }
+  return { migrated: true, config: newConfig };
+}
+
+export function handleRequest(req) {
+  const parsedUrl = new URL(req.url, "http://localhost");
+  const path = parsedUrl.pathname;
+
+  if (path === "/versions" && req.method === "GET") {
+    return {
+      status: 200,
+      body: {
+        versions: TEMPLATE_VERSIONS.map((v) => v.version),
+        current: CURRENT_VERSION,
+      },
+    };
+  }
+
+  if (path === "/current-config" && req.method === "GET") {
+    return { status: 200, body: getCurrentConfig() };
+  }
+
+  if (path === "/migrate" && req.method === "POST") {
+    return new Promise((resolve) => {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data);
+          const result = migrate(body);
+          if (result.error) {
+            resolve({ status: 400, body: result });
+          } else {
+            resolve({ status: 200, body: result });
+          }
+        } catch {
+          resolve({ status: 400, body: { error: "invalid_json" } });
+        }
+      });
+    });
+  }
+
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer(async (req, res) => {
+    const { status, body } = await handleRequest(req);
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4052;
+  server.listen(port, () => {
+    console.log(
+      `template-versioning-suite mock listening on http://localhost:${port}`,
+    );
+  });
+}

--- a/contrib/routes/template-versioning-suite/route.test.mjs
+++ b/contrib/routes/template-versioning-suite/route.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+function makeReq(method, url, body) {
+  const readable = {
+    url,
+    method,
+    on: (event, cb) => {
+      if (event === "data") cb(JSON.stringify(body || {}));
+      if (event === "end") cb();
+    },
+  };
+  return readable;
+}
+
+// Test versions
+{
+  const { status, body } = await handleRequest({
+    method: "GET",
+    url: "/versions",
+  });
+  assert.equal(status, 200);
+  assert.ok(Array.isArray(body.versions));
+  assert.ok(body.versions.includes("1.0"));
+  assert.ok(body.versions.includes("2.0"));
+  assert.equal(body.current, "2.0");
+}
+
+// Test current-config
+{
+  const { status, body } = await handleRequest({
+    method: "GET",
+    url: "/current-config",
+  });
+  assert.equal(status, 200);
+  assert.equal(body.version, "2.0");
+  assert.ok(Array.isArray(body.fields));
+  assert.ok(body.fields.includes("policyName"));
+}
+
+// Test migrate from old version
+{
+  const req = makeReq("POST", "/migrate", {
+    version: "1.0",
+    name: "My Policy",
+    signerLimit: 3,
+    chain: "testnet",
+  });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 200);
+  assert.equal(body.migrated, true);
+  assert.equal(body.config.version, "2.0");
+  assert.equal(body.config.policyName, "My Policy");
+  assert.equal(body.config.maxSigners, 3);
+  assert.equal(body.config.network, "testnet");
+  assert.equal(body.config.name, undefined);
+}
+
+// Test migrate no-op on current version
+{
+  const req = makeReq("POST", "/migrate", {
+    version: "2.0",
+    policyName: "Current",
+    maxSigners: 5,
+    network: "mainnet",
+  });
+  const { status, body } = await handleRequest(req);
+  assert.equal(status, 200);
+  assert.equal(body.migrated, false);
+  assert.equal(body.reason, "already_current");
+}
+
+console.log("PASS: template-versioning-suite tests");


### PR DESCRIPTION
Closes #119, Closes #122, Closes #123, Closes #124

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

Adds four self-contained route handler suites under `contrib/routes/` for Stellar Wave bounty issues #119, #122, #123, and #124. Each suite is a standalone mock API with its own README, route handlers, and test file — all living exclusively inside `contrib/`.

## Motivation / Context

These route suites address the assigned Stellar Wave bounty issues:

- **#119 (Blocker Report Suite)** — Two endpoints (`/inspect`, `/report`) that inspect a sample account and return blockers sorted by severity (high → medium → low).
- **#122 (Merge Builder Suite)** — Three endpoints (`/validate-destination`, `/build`, `/estimate-reclaim`) that validate merge destinations, build mock merge transactions, and estimate reclaimed balances. Build refuses invalid destinations.
- **#123 (Template Versioning Suite)** — Three endpoints (`/versions`, `/current-config`, `/migrate`) that list policy template versions and migrate old configs to the current version by mapping field names.
- **#124 (Full Cleanup Merge Suite)** — Four endpoints (`/inspect`, `/execute-cleanup-step`, `/check-ready`, `/build-merge`) that walk an account through cleanup execution, readiness verification, and final merge build. Build-merge refuses unless all required steps are completed. State tracked in memory per account.

Each suite includes:
- `route.mjs` — Standalone HTTP server with mock handlers (no chain/DB access)
- `route.test.mjs` — Tests covering happy paths, error cases, and the full sequence for #124
- `README.md` — Endpoint documentation, severity levels, field migration maps

## Testing

All four test suites pass:

```sh
node contrib/routes/blocker-report-suite/route.test.mjs
node contrib/routes/merge-builder-suite/route.test.mjs
node contrib/routes/template-versioning-suite/route.test.mjs
node contrib/routes/full-cleanup-merge-suite/route.test.mjs
```

The #119 test covers mixed-severity accounts with sort order verification. The #122 test covers valid/invalid destination flows. The #123 test covers migration from old versions and no-op on current version. The #124 test walks through the full inspect → cleanup → readiness → merge sequence.

## Out of scope

- No changes outside `contrib/`
- No real chain or database access — all data is mock/hardcoded
- No shared code between suites (each is fully self-contained per issue requirements)

Closes #119, Closes #122, Closes #123, Closes #124