### PR TITLE
feat: add four contrib route suites (Issues #113, #114, #115, #118)

### DIFF
--- a/contrib/routes/issue-113-policy-rollback-suite/README.md
+++ b/contrib/routes/issue-113-policy-rollback-suite/README.md
@@ -1,0 +1,54 @@
+# Mock route: policy rollback suite (Issue #113)
+
+Simulates deploying a new policy version, detecting a failure, and rolling back to the previous known good version.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/deploy` | Deploy a new policy version. Body: `{ "version": "v2.0.0", "fail": false }`. Set `fail: true` to simulate a failed deploy. |
+| GET | `/deploy-status` | Returns the last deploy result and currently active version. |
+| POST | `/rollback` | Rolls back to the previously active version. |
+
+## Run
+
+```sh
+node route.mjs
+# policy-rollback mock listening on http://localhost:4113
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example — successful deploy
+
+```
+POST /deploy
+{ "version": "v2.0.0" }
+```
+
+```json
+{ "deployed": true, "version": "v2.0.0", "activeVersion": "v2.0.0" }
+```
+
+## Example — failed deploy then rollback
+
+```
+POST /deploy
+{ "version": "v3.0.0", "fail": true }
+```
+
+```json
+{ "deployed": false, "reason": "simulated_failure", "activeVersion": "v2.0.0" }
+```
+
+```
+POST /rollback
+```
+
+```json
+{ "rolledBack": true, "activeVersion": "v2.0.0", "rolledTo": "v2.0.0" }
+```

--- a/contrib/routes/issue-113-policy-rollback-suite/route.mjs
+++ b/contrib/routes/issue-113-policy-rollback-suite/route.mjs
@@ -1,0 +1,60 @@
+import http from "node:http";
+
+let activeVersion = "v1.0.0";
+let previousVersion = null;
+let lastDeployResult = null;
+
+function deploy(body) {
+  const { version = "v2.0.0", fail = false } = body || {};
+  previousVersion = activeVersion;
+  if (fail) {
+    lastDeployResult = { status: "failed", version, activeVersion };
+    return { status: 200, body: { deployed: false, reason: "simulated_failure", activeVersion } };
+  }
+  activeVersion = version;
+  lastDeployResult = { status: "success", version, activeVersion };
+  return { status: 200, body: { deployed: true, version, activeVersion } };
+}
+
+function deployStatus() {
+  if (!lastDeployResult) {
+    return { status: 200, body: { status: "no_deploy_yet", activeVersion } };
+  }
+  return { status: 200, body: { ...lastDeployResult, activeVersion } };
+}
+
+function rollback() {
+  if (!previousVersion) {
+    return { status: 200, body: { rolledBack: false, reason: "no_previous_version", activeVersion } };
+  }
+  const rolledTo = previousVersion;
+  activeVersion = previousVersion;
+  previousVersion = null;
+  lastDeployResult = null;
+  return { status: 200, body: { rolledBack: true, activeVersion, rolledTo } };
+}
+
+export function handleRequest(method, url, body) {
+  if (method === "POST" && url === "/deploy") return deploy(body);
+  if (method === "GET" && url === "/deploy-status") return deployStatus();
+  if (method === "POST" && url === "/rollback") return rollback();
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      const parsed = body ? JSON.parse(body) : undefined;
+      const { status, body: resp } = handleRequest(req.method, req.url, parsed);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(resp));
+    });
+  });
+  const port = process.env.PORT || 4113;
+  server.listen(port, () => {
+    console.log(`policy-rollback mock listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-113-policy-rollback-suite/route.test.mjs
+++ b/contrib/routes/issue-113-policy-rollback-suite/route.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// Test successful deploy
+let res = handleRequest("POST", "/deploy", { version: "v2.0.0" });
+assert.equal(res.status, 200);
+assert.equal(res.body.deployed, true);
+assert.equal(res.body.version, "v2.0.0");
+assert.equal(res.body.activeVersion, "v2.0.0");
+
+// Test deploy status
+res = handleRequest("GET", "/deploy-status");
+assert.equal(res.status, 200);
+assert.equal(res.body.status, "success");
+assert.equal(res.body.activeVersion, "v2.0.0");
+
+// Test rollback
+res = handleRequest("POST", "/rollback");
+assert.equal(res.status, 200);
+assert.equal(res.body.rolledBack, true);
+assert.equal(res.body.activeVersion, "v1.0.0");
+
+// Test failed deploy then rollback
+res = handleRequest("POST", "/deploy", { version: "v3.0.0", fail: true });
+assert.equal(res.status, 200);
+assert.equal(res.body.deployed, false);
+assert.equal(res.body.activeVersion, "v1.0.0");
+
+res = handleRequest("GET", "/deploy-status");
+assert.equal(res.body.status, "failed");
+
+res = handleRequest("POST", "/rollback");
+assert.equal(res.body.rolledBack, true);
+assert.equal(res.body.activeVersion, "v1.0.0");
+
+// Test 404
+res = handleRequest("GET", "/unknown");
+assert.equal(res.status, 404);
+
+console.log("PASS: policy-rollback suite — deploy, status, rollback, and failed-deploy+rollback all work");

--- a/contrib/routes/issue-114-permission-scope-suite/README.md
+++ b/contrib/routes/issue-114-permission-scope-suite/README.md
@@ -1,0 +1,46 @@
+# Mock route: permission scope suite (Issue #114)
+
+Simulates a dApp permission scope handshake: a dApp requests scopes, a user approves a subset, and scopes can be checked.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/request-scopes` | dApp requests permission scopes. Body: `{ "scopes": ["read", "write", "admin"] }` |
+| POST | `/approve-scopes` | User approves a subset. Body: `{ "requestId": "req_1", "approvedScopes": ["read"] }` |
+| GET | `/check-scope` | Check if a scope is approved. Query: `?requestId=req_1&scope=read` |
+
+## Run
+
+```sh
+node route.mjs
+# permission-scope mock listening on http://localhost:4114
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example — full flow
+
+1. Request scopes:
+```
+POST /request-scopes
+{ "scopes": ["read", "write", "admin"] }
+```
+→ `{ "requestId": "req_1", "requestedScopes": ["read", "write", "admin"] }`
+
+2. Approve subset:
+```
+POST /approve-scopes
+{ "requestId": "req_1", "approvedScopes": ["read", "write"] }
+```
+→ `{ "requestId": "req_1", "approved": ["read", "write"], "rejected": ["admin"] }`
+
+3. Check scope:
+```
+GET /check-scope?requestId=req_1&scope=admin
+```
+→ `{ "scope": "admin", "approved": false }`

--- a/contrib/routes/issue-114-permission-scope-suite/route.mjs
+++ b/contrib/routes/issue-114-permission-scope-suite/route.mjs
@@ -1,0 +1,64 @@
+import http from "node:http";
+
+const requests = new Map();
+let nextId = 1;
+
+function requestScopes(body) {
+  const { scopes = [] } = body || {};
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    return { status: 400, body: { error: "scopes array required" } };
+  }
+  const id = `req_${nextId++}`;
+  requests.set(id, { scopes, approved: [] });
+  return { status: 200, body: { requestId: id, requestedScopes: scopes } };
+}
+
+function approveScopes(body) {
+  const { requestId, approvedScopes = [] } = body || {};
+  if (!requestId || !requests.has(requestId)) {
+    return { status: 404, body: { error: "request not found" } };
+  }
+  const req = requests.get(requestId);
+  const valid = approvedScopes.filter((s) => req.scopes.includes(s));
+  req.approved = valid;
+  return { status: 200, body: { requestId, approved: valid, rejected: req.scopes.filter((s) => !valid.includes(s)) } };
+}
+
+function checkScope(query) {
+  const { requestId, scope } = query || {};
+  if (!requestId || !scope) {
+    return { status: 400, body: { error: "requestId and scope required" } };
+  }
+  const req = requests.get(requestId);
+  if (!req) {
+    return { status: 404, body: { error: "request not found" } };
+  }
+  return { status: 200, body: { scope, approved: req.approved.includes(scope) } };
+}
+
+export function handleRequest(method, url, body, query) {
+  if (method === "POST" && url === "/request-scopes") return requestScopes(body);
+  if (method === "POST" && url === "/approve-scopes") return approveScopes(body);
+  if (method === "GET" && url === "/check-scope") return checkScope(query);
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      const parsed = body ? JSON.parse(body) : undefined;
+      const urlObj = new URL(req.url, `http://${req.headers.host}`);
+      const query = Object.fromEntries(urlObj.searchParams);
+      const { status, body: resp } = handleRequest(req.method, urlObj.pathname, parsed, query);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(resp));
+    });
+  });
+  const port = process.env.PORT || 4114;
+  server.listen(port, () => {
+    console.log(`permission-scope mock listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-114-permission-scope-suite/route.test.mjs
+++ b/contrib/routes/issue-114-permission-scope-suite/route.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// Request scopes
+let res = handleRequest("POST", "/request-scopes", { scopes: ["read", "write", "admin"] });
+assert.equal(res.status, 200);
+assert.ok(res.body.requestId);
+const requestId = res.body.requestId;
+assert.deepEqual(res.body.requestedScopes, ["read", "write", "admin"]);
+
+// Approve only a subset
+res = handleRequest("POST", "/approve-scopes", { requestId, approvedScopes: ["read", "write"] });
+assert.equal(res.status, 200);
+assert.deepEqual(res.body.approved, ["read", "write"]);
+assert.deepEqual(res.body.rejected, ["admin"]);
+
+// Check approved scope
+res = handleRequest("GET", "/check-scope", null, { requestId, scope: "read" });
+assert.equal(res.status, 200);
+assert.equal(res.body.approved, true);
+
+res = handleRequest("GET", "/check-scope", null, { requestId, scope: "write" });
+assert.equal(res.body.approved, true);
+
+// Check rejected scope
+res = handleRequest("GET", "/check-scope", null, { requestId, scope: "admin" });
+assert.equal(res.status, 200);
+assert.equal(res.body.approved, false);
+
+// Missing params
+res = handleRequest("POST", "/request-scopes", {});
+assert.equal(res.status, 400);
+
+res = handleRequest("GET", "/check-scope");
+assert.equal(res.status, 400);
+
+console.log("PASS: permission-scope suite — request, partial approve, check approved and rejected scopes");

--- a/contrib/routes/issue-115-rate-limit-sliding-suite/README.md
+++ b/contrib/routes/issue-115-rate-limit-sliding-suite/README.md
@@ -1,0 +1,43 @@
+# Mock route: rate limit sliding window (Issue #115)
+
+Implements a sliding window rate limit counter for a sample client id using a simulated current time value.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/hit` | Record a hit. Body: `{ "clientId": "abc", "time": 1000000 }`. Returns 429 if over limit. |
+| GET | `/status` | Check remaining allowance. Query: `?clientId=abc&time=1000000` |
+
+## Defaults
+
+- Window: 60 seconds
+- Limit: 5 hits per window
+
+## Run
+
+```sh
+node route.mjs
+# rate-limit-sliding mock listening on http://localhost:4115
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example — fill window then get rejected
+
+```
+POST /hit
+{ "clientId": "alice", "time": 1000000 }
+```
+→ `{ "clientId": "alice", "allowed": true, "remaining": 4, ... }`
+
+After 5 hits:
+```
+POST /hit
+{ "clientId": "alice", "time": 1000500 }
+```
+→ 429: `{ "clientId": "alice", "allowed": false, "remaining": 0, ... }`

--- a/contrib/routes/issue-115-rate-limit-sliding-suite/route.mjs
+++ b/contrib/routes/issue-115-rate-limit-sliding-suite/route.mjs
@@ -1,0 +1,56 @@
+import http from "node:http";
+
+const WINDOW_MS = 60_000;
+const MAX_HITS = 5;
+
+const hits = new Map();
+
+function hit(body) {
+  const { clientId = "default", time } = body || {};
+  const now = typeof time === "number" ? time : Date.now();
+  if (!hits.has(clientId)) hits.set(clientId, []);
+  const clientHits = hits.get(clientId);
+  const windowStart = now - WINDOW_MS;
+  const active = clientHits.filter((t) => t > windowStart);
+  if (active.length >= MAX_HITS) {
+    return { status: 429, body: { clientId, allowed: false, remaining: 0, windowMs: WINDOW_MS, limit: MAX_HITS } };
+  }
+  active.push(now);
+  hits.set(clientId, active);
+  return { status: 200, body: { clientId, allowed: true, remaining: MAX_HITS - active.length, windowMs: WINDOW_MS, limit: MAX_HITS } };
+}
+
+function status(query) {
+  const { clientId = "default", time } = query || {};
+  const now = typeof time === "number" ? Number(time) : Date.now();
+  const clientHits = hits.get(clientId) || [];
+  const windowStart = now - WINDOW_MS;
+  const active = clientHits.filter((t) => t > windowStart);
+  return { status: 200, body: { clientId, remaining: MAX_HITS - active.length, used: active.length, windowMs: WINDOW_MS, limit: MAX_HITS } };
+}
+
+export function handleRequest(method, url, body, query) {
+  if (method === "POST" && url === "/hit") return hit(body);
+  if (method === "GET" && url === "/status") return status(query);
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      const parsed = body ? JSON.parse(body) : undefined;
+      const urlObj = new URL(req.url, `http://${req.headers.host}`);
+      const query = Object.fromEntries(urlObj.searchParams);
+      const { status: code, body: resp } = handleRequest(req.method, urlObj.pathname, parsed, query);
+      res.writeHead(code, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(resp));
+    });
+  });
+  const port = process.env.PORT || 4115;
+  server.listen(port, () => {
+    console.log(`rate-limit-sliding mock listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-115-rate-limit-sliding-suite/route.test.mjs
+++ b/contrib/routes/issue-115-rate-limit-sliding-suite/route.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const clientId = "test-client";
+const baseTime = 1000000;
+
+// Fill the window with 5 hits
+for (let i = 0; i < 5; i++) {
+  const res = handleRequest("POST", "/hit", { clientId, time: baseTime + i * 1000 });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.allowed, true);
+  assert.equal(res.body.remaining, 4 - i);
+}
+
+// 6th hit should be rejected
+let res = handleRequest("POST", "/hit", { clientId, time: baseTime + 5000 });
+assert.equal(res.status, 429);
+assert.equal(res.body.allowed, false);
+assert.equal(res.body.remaining, 0);
+
+// Check status
+res = handleRequest("GET", "/status", null, { clientId, time: baseTime + 5000 });
+assert.equal(res.status, 200);
+assert.equal(res.body.used, 5);
+assert.equal(res.body.remaining, 0);
+
+// Age out: advance time past the 60s window from the last hit (baseTime+4000)
+res = handleRequest("GET", "/status", null, { clientId, time: baseTime + 65000 });
+assert.equal(res.body.used, 0);
+assert.equal(res.body.remaining, 5);
+
+// Hits should work again after window expires
+res = handleRequest("POST", "/hit", { clientId, time: baseTime + 65000 });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+
+console.log("PASS: rate-limit-sliding suite — fill window, reject over-limit, age out, resume");

--- a/contrib/routes/issue-118-policy-conflict-suite/README.md
+++ b/contrib/routes/issue-118-policy-conflict-suite/README.md
@@ -1,0 +1,53 @@
+# Mock route: policy conflict suite (Issue #118)
+
+Simulates multiple spending policies applying to the same account. A check endpoint resolves which policy governs a given transfer using a defined precedence rule (highest precedence number wins = most restrictive).
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/list-active` | Lists active policies and their types. |
+| POST | `/check-transfer` | Resolves which policy governs a transfer. Body: `{ "amount": 300, "toAddress": "GABC" }` |
+
+## Precedence Rule
+
+The policy with the **highest precedence number** wins (most restrictive). If multiple policies conflict, all conflicts are returned with the winning one identified.
+
+## Policies (built-in)
+
+| ID | Type | Rule | Precedence |
+|----|------|------|------------|
+| pol_A | spending-limit | max 500/day | 1 |
+| pol_B | spending-limit | max 200/day | 2 |
+| pol_C | allowlist | only GABC, GDEF | 0 |
+
+## Run
+
+```sh
+node route.mjs
+# policy-conflict mock listening on http://localhost:4118
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example — transfer blocked by spending limit
+
+```
+POST /check-transfer
+{ "amount": 300, "toAddress": "GABC" }
+```
+
+```json
+{
+  "allowed": false,
+  "governedBy": "pol_B",
+  "reason": "amount 300 exceeds limit 200",
+  "allConflicts": [
+    { "policyId": "pol_B", "reason": "amount 300 exceeds limit 200", "precedence": 2 }
+  ]
+}
+```

--- a/contrib/routes/issue-118-policy-conflict-suite/route.mjs
+++ b/contrib/routes/issue-118-policy-conflict-suite/route.mjs
@@ -1,0 +1,60 @@
+import http from "node:http";
+
+const policies = [
+  { id: "pol_A", type: "spending-limit", limitPerDay: 500, precedence: 1 },
+  { id: "pol_B", type: "spending-limit", limitPerDay: 200, precedence: 2 },
+  { id: "pol_C", type: "allowlist", allowedAddresses: ["GABC", "GDEF"], precedence: 0 },
+];
+
+function listActive() {
+  return { status: 200, body: policies.map(({ id, type }) => ({ id, type })) };
+}
+
+function checkTransfer(body) {
+  const { amount, toAddress } = body || {};
+  if (typeof amount !== "number" || !toAddress) {
+    return { status: 400, body: { error: "amount (number) and toAddress (string) required" } };
+  }
+
+  const governing = [];
+  for (const p of policies) {
+    if (p.type === "spending-limit" && amount > p.limitPerDay) {
+      governing.push({ policyId: p.id, reason: `amount ${amount} exceeds limit ${p.limitPerDay}`, precedence: p.precedence });
+    }
+    if (p.type === "allowlist" && !p.allowedAddresses.includes(toAddress)) {
+      governing.push({ policyId: p.id, reason: `address ${toAddress} not in allowlist`, precedence: p.precedence });
+    }
+  }
+
+  if (governing.length === 0) {
+    return { status: 200, body: { allowed: true, governedBy: null, reason: "no policy blocks this transfer" } };
+  }
+
+  governing.sort((a, b) => b.precedence - a.precedence);
+  const winner = governing[0];
+  return { status: 200, body: { allowed: false, governedBy: winner.policyId, reason: winner.reason, allConflicts: governing } };
+}
+
+export function handleRequest(method, url, body) {
+  if (method === "GET" && url === "/list-active") return listActive();
+  if (method === "POST" && url === "/check-transfer") return checkTransfer(body);
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      const parsed = body ? JSON.parse(body) : undefined;
+      const { status, body: resp } = handleRequest(req.method, req.url, parsed);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(resp));
+    });
+  });
+  const port = process.env.PORT || 4118;
+  server.listen(port, () => {
+    console.log(`policy-conflict mock listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-118-policy-conflict-suite/route.test.mjs
+++ b/contrib/routes/issue-118-policy-conflict-suite/route.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// List active policies
+let res = handleRequest("GET", "/list-active");
+assert.equal(res.status, 200);
+assert.equal(res.body.length, 3);
+
+// Transfer allowed by all policies
+res = handleRequest("POST", "/check-transfer", { amount: 100, toAddress: "GABC" });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+assert.equal(res.body.governedBy, null);
+
+// Transfer exceeds pol_B limit (200) but not pol_A (500) — pol_B wins (higher precedence)
+res = handleRequest("POST", "/check-transfer", { amount: 300, toAddress: "GABC" });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.equal(res.body.governedBy, "pol_B");
+
+// Transfer exceeds both limits — pol_B still wins (higher precedence)
+res = handleRequest("POST", "/check-transfer", { amount: 600, toAddress: "GABC" });
+assert.equal(res.body.allowed, false);
+assert.equal(res.body.governedBy, "pol_B");
+assert.ok(res.body.allConflicts.length >= 2);
+
+// Address not in allowlist — pol_C governs
+res = handleRequest("POST", "/check-transfer", { amount: 100, toAddress: "GXXX" });
+assert.equal(res.body.allowed, false);
+assert.equal(res.body.governedBy, "pol_C");
+
+// Missing params
+res = handleRequest("POST", "/check-transfer", {});
+assert.equal(res.status, 400);
+
+console.log("PASS: policy-conflict suite — list, allow, spending-limit conflict, allowlist conflict, precedence resolved");


### PR DESCRIPTION
Closes #113, Closes #114, Closes #115, Closes #118

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Summary

This PR adds four self-contained route handler suites under `contrib/routes/`:

1. **Policy Rollback Suite (#113)** — Deploy, deploy-status, and rollback endpoints simulating policy version management with failure detection and rollback.
2. **Permission Scope Suite (#114)** — Request-scopes, approve-scopes, and check-scope endpoints simulating a dApp permission scope handshake with partial user approval.
3. **Rate Limit Sliding Suite (#115)** — Hit and status endpoints implementing a sliding window rate limit counter with simulated time for deterministic testing.
4. **Policy Conflict Suite (#118)** — List-active and check-transfer endpoints resolving which policy governs a transfer using a precedence rule (most restrictive wins).

Each suite includes README documentation, route handlers, and passing tests.

## Motivation / Context

These mock route suites provide realistic simulations of common dApp/backend patterns (policy lifecycle, permission flows, rate limiting, conflict resolution) for development and testing purposes. All work is contained within `contrib/` as required.

Closes #113, Closes #114, Closes #115, Closes #118