### PR TITLE
contrib: add mock contract hash route

### DIFF
--- a/contrib/routes/issue-49-contract-hash/README.md
+++ b/contrib/routes/issue-49-contract-hash/README.md
@@ -1,0 +1,57 @@
+# Mock route: contract hash (Issue #49)
+
+Standalone mock GET route returning a fixed sample wasm hash for a contract id
+path parameter. The hash is always a 64 character lowercase hex string. No real
+chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# contract-hash mock listening on http://localhost:4049/contracts/:contractId/hash
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /contracts/CA0000000000000000000000000000000000000000000000000001/hash
+```
+
+Response:
+
+```json
+{
+  "contractId": "CA0000000000000000000000000000000000000000000000000001",
+  "wasmHash": "3f786850e387550fdab836ed7e6dc881de23001b3f786850e387550fdab836ed",
+  "network": "testnet"
+}
+```
+
+A contract id that isn't in the sample dataset returns a 404-style payload:
+
+```
+GET /contracts/CAUNKNOWN/hash
+```
+
+```json
+{
+  "error": "not_found",
+  "message": "No contract found for id \"CAUNKNOWN\""
+}
+```
+
+## Sample dataset
+
+| contractId                                               | network     |
+| -------------------------------------------------------- | ----------- |
+| `CA0000000000000000000000000000000000000000000000000001` | `testnet`   |
+| `CA0000000000000000000000000000000000000000000000000002` | `testnet`   |
+| `CA0000000000000000000000000000000000000000000000000003` | `futurenet` |

--- a/contrib/routes/issue-49-contract-hash/route.mjs
+++ b/contrib/routes/issue-49-contract-hash/route.mjs
@@ -1,0 +1,61 @@
+// Mock GET route returning the wasm hash for a sample contract id. No chain or
+// DB access.
+import http from "node:http";
+
+const CONTRACT_HASHES = {
+  CA0000000000000000000000000000000000000000000000000001: {
+    contractId: "CA0000000000000000000000000000000000000000000000000001",
+    wasmHash: "3f786850e387550fdab836ed7e6dc881de23001b3f786850e387550fdab836ed",
+    network: "testnet",
+  },
+  CA0000000000000000000000000000000000000000000000000002: {
+    contractId: "CA0000000000000000000000000000000000000000000000000002",
+    wasmHash: "89e6c98d92887913c7c9f9f5ee0e7f0e0d1a0b1c2d3e4f5061728394a5b6c7d8",
+    network: "testnet",
+  },
+  CA0000000000000000000000000000000000000000000000000003: {
+    contractId: "CA0000000000000000000000000000000000000000000000000003",
+    wasmHash: "aa0bd10b0f2e5c1c1e6f2b7a8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f70819",
+    network: "futurenet",
+  },
+};
+
+export function handleRequest({ params = {} } = {}) {
+  const { contractId } = params;
+  const record = contractId ? CONTRACT_HASHES[contractId] : undefined;
+
+  if (!record) {
+    return {
+      status: 404,
+      body: {
+        error: "not_found",
+        message: `No contract found for id "${contractId ?? ""}"`,
+      },
+    };
+  }
+
+  return { status: 200, body: { ...record } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const match = req.url.match(/^\/contracts\/([^/]+)\/hash$/);
+    if (req.method === "GET" && match) {
+      const { status, body } = handleRequest({
+        params: { contractId: decodeURIComponent(match[1]) },
+      });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4049;
+  server.listen(port, () => {
+    console.log(
+      `contract-hash mock listening on http://localhost:${port}/contracts/:contractId/hash`,
+    );
+  });
+}

--- a/contrib/routes/issue-49-contract-hash/route.test.mjs
+++ b/contrib/routes/issue-49-contract-hash/route.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const HEX_64 = /^[0-9a-f]{64}$/;
+const KNOWN_ID = "CA0000000000000000000000000000000000000000000000000001";
+
+// A known contract id returns its wasm hash as a 64 character hex string.
+const hit = handleRequest({ params: { contractId: KNOWN_ID } });
+assert.equal(hit.status, 200);
+assert.equal(hit.body.contractId, KNOWN_ID);
+assert.equal(hit.body.wasmHash.length, 64);
+assert.match(hit.body.wasmHash, HEX_64);
+assert.equal(typeof hit.body.network, "string");
+
+// Every sample entry uses the same hash format.
+for (const id of [
+  "CA0000000000000000000000000000000000000000000000000002",
+  "CA0000000000000000000000000000000000000000000000000003",
+]) {
+  const { status, body } = handleRequest({ params: { contractId: id } });
+  assert.equal(status, 200);
+  assert.match(body.wasmHash, HEX_64);
+}
+
+// An unknown contract id returns a 404-style payload.
+const miss = handleRequest({ params: { contractId: "CAUNKNOWN" } });
+assert.equal(miss.status, 404);
+assert.equal(miss.body.error, "not_found");
+assert.equal(miss.body.wasmHash, undefined);
+
+// A missing contract id is also treated as not found.
+const noId = handleRequest({});
+assert.equal(noId.status, 404);
+
+console.log("PASS: /contracts/:contractId/hash returns a wasm hash on a hit and 404 on a miss");


### PR DESCRIPTION
## Summary

Adds a standalone mock GET route under `contrib/routes/` that returns a fixed sample wasm hash for a contract id path parameter. Everything is self-contained in `contrib/routes/issue-49-contract-hash/`, with no chain or database access.

closes #49

## What's included

- `route.mjs` - exported `handleRequest({ params })` plus a `node:http` server that runs only when the file is executed directly, following the same shape as the existing `contrib/routes/*` mocks (for example `issue-34-policy-detail`).
- `route.test.mjs` - assertion script runnable with plain `node`, no test runner or dependencies.
- `README.md` - endpoint, run and test commands, example responses, and the sample dataset table.

## Endpoint

```
GET /contracts/:contractId/hash
```

Hit:

```json
{
  "contractId": "CA0000000000000000000000000000000000000000000000000001",
  "wasmHash": "3f786850e387550fdab836ed7e6dc881de23001b3f786850e387550fdab836ed",
  "network": "testnet"
}
```

Miss - 404-style payload:

```json
{
  "error": "not_found",
  "message": "No contract found for id \"CAUNKNOWN\""
}
```

Every `wasmHash` in the sample dataset is a 64 character lowercase hex string, matching the on-chain wasm hash format.

## Sample dataset

| contractId | network |
| ---------- | ------- |
| `CA0000000000000000000000000000000000000000000000000001` | `testnet` |
| `CA0000000000000000000000000000000000000000000000000002` | `testnet` |
| `CA0000000000000000000000000000000000000000000000000003` | `futurenet` |

## Testing

```sh
cd contrib/routes/issue-49-contract-hash
node route.test.mjs
# PASS: /contracts/:contractId/hash returns a wasm hash on a hit and 404 on a miss
```

The test covers the found case (status, contract id, and `wasmHash` matching `/^[0-9a-f]{64}$/`), the hash format for every entry in the dataset, the not found case, and a missing id. It also asserts the 404 payload carries no `wasmHash`, so a caller cannot mistake an error body for a hit.

## Constraints checklist

- [x] All changes are inside `contrib/` - the diff is three new files under `contrib/routes/issue-49-contract-hash/`
- [x] Branch created from `drips`, PR targets `drips`
- [x] No files outside `contrib/` added, edited, renamed, or deleted
