### PR TITLE
contrib: add mock verification job status route

### DIFF
--- a/contrib/routes/issue-51-verification-status/README.md
+++ b/contrib/routes/issue-51-verification-status/README.md
@@ -1,0 +1,71 @@
+# Mock route: verification job status (Issue #51)
+
+Standalone mock GET route returning the status of a sample contract
+verification job, looked up by a `jobId` path parameter. `status` is always one
+of `pending`, `verified`, or `failed`. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# verification-status mock listening on http://localhost:4051/verification-jobs/:jobId
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /verification-jobs/job_2002
+```
+
+Response:
+
+```json
+{
+  "jobId": "job_2002",
+  "status": "verified",
+  "submittedAt": "2025-03-03T14:40:00Z",
+  "completedAt": "2025-03-03T14:47:31Z",
+  "message": "Wasm hash matches the published source"
+}
+```
+
+A job that is still running has a `null` `completedAt`:
+
+```json
+{
+  "jobId": "job_2001",
+  "status": "pending",
+  "submittedAt": "2025-03-04T09:12:00Z",
+  "completedAt": null,
+  "message": "Build queued"
+}
+```
+
+A job id that isn't in the sample dataset returns a 404-style payload:
+
+```
+GET /verification-jobs/job_9999
+```
+
+```json
+{
+  "error": "not_found",
+  "message": "No verification job found for id \"job_9999\""
+}
+```
+
+## Sample dataset
+
+| jobId      | status     |
+| ---------- | ---------- |
+| `job_2001` | `pending`  |
+| `job_2002` | `verified` |
+| `job_2003` | `failed`   |

--- a/contrib/routes/issue-51-verification-status/route.mjs
+++ b/contrib/routes/issue-51-verification-status/route.mjs
@@ -1,0 +1,69 @@
+// Mock GET route returning the status of a sample verification job looked up by
+// a job id path parameter. No chain or DB access.
+import http from "node:http";
+
+export const STATUSES = ["pending", "verified", "failed"];
+
+const JOBS = {
+  job_2001: {
+    jobId: "job_2001",
+    status: "pending",
+    submittedAt: "2025-03-04T09:12:00Z",
+    completedAt: null,
+    message: "Build queued",
+  },
+  job_2002: {
+    jobId: "job_2002",
+    status: "verified",
+    submittedAt: "2025-03-03T14:40:00Z",
+    completedAt: "2025-03-03T14:47:31Z",
+    message: "Wasm hash matches the published source",
+  },
+  job_2003: {
+    jobId: "job_2003",
+    status: "failed",
+    submittedAt: "2025-03-02T18:05:10Z",
+    completedAt: "2025-03-02T18:09:44Z",
+    message: "Reproduced wasm hash did not match the on-chain hash",
+  },
+};
+
+export function handleRequest({ params = {} } = {}) {
+  const { jobId } = params;
+  const job = jobId ? JOBS[jobId] : undefined;
+
+  if (!job) {
+    return {
+      status: 404,
+      body: {
+        error: "not_found",
+        message: `No verification job found for id "${jobId ?? ""}"`,
+      },
+    };
+  }
+
+  return { status: 200, body: { ...job } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const match = req.url.match(/^\/verification-jobs\/([^/]+)$/);
+    if (req.method === "GET" && match) {
+      const { status, body } = handleRequest({
+        params: { jobId: decodeURIComponent(match[1]) },
+      });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4051;
+  server.listen(port, () => {
+    console.log(
+      `verification-status mock listening on http://localhost:${port}/verification-jobs/:jobId`,
+    );
+  });
+}

--- a/contrib/routes/issue-51-verification-status/route.test.mjs
+++ b/contrib/routes/issue-51-verification-status/route.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { handleRequest, STATUSES } from "./route.mjs";
+
+// A known job id returns the job record with an allowed status.
+const hit = handleRequest({ params: { jobId: "job_2002" } });
+assert.equal(hit.status, 200);
+assert.equal(hit.body.jobId, "job_2002");
+assert.equal(hit.body.status, "verified");
+assert.equal(hit.body.completedAt, "2025-03-03T14:47:31Z");
+
+// Every sample job reports one of the three allowed statuses.
+for (const jobId of ["job_2001", "job_2002", "job_2003"]) {
+  const { status, body } = handleRequest({ params: { jobId } });
+  assert.equal(status, 200);
+  assert.ok(STATUSES.includes(body.status), `unexpected status: ${body.status}`);
+  assert.equal(typeof body.submittedAt, "string");
+}
+
+// A pending job has no completion timestamp yet.
+const pending = handleRequest({ params: { jobId: "job_2001" } });
+assert.equal(pending.body.status, "pending");
+assert.equal(pending.body.completedAt, null);
+
+// An unknown job id returns a 404-style payload.
+const miss = handleRequest({ params: { jobId: "job_9999" } });
+assert.equal(miss.status, 404);
+assert.equal(miss.body.error, "not_found");
+assert.equal(miss.body.status, undefined);
+
+// A missing job id is also treated as not found.
+const noId = handleRequest({});
+assert.equal(noId.status, 404);
+
+console.log("PASS: /verification-jobs/:jobId returns job status on a hit and 404 on a miss");


### PR DESCRIPTION
## Summary

Adds a standalone mock GET route under `contrib/routes/` that returns the status of a sample contract verification job, looked up by a `jobId` path parameter. Everything is self-contained in `contrib/routes/issue-51-verification-status/`, with no chain or database access.

closes #51

## What's included

- `route.mjs` - exported `handleRequest({ params })` plus a `node:http` server that runs only when the file is executed directly, following the same shape as the existing `contrib/routes/*` mocks (for example `issue-34-policy-detail`). Also exports the `STATUSES` array so the test asserts against a single source of truth.
- `route.test.mjs` - assertion script runnable with plain `node`, no test runner or dependencies.
- `README.md` - endpoint, run and test commands, example responses, and the sample dataset table.

## Endpoint

```
GET /verification-jobs/:jobId
```

Hit:

```json
{
  "jobId": "job_2002",
  "status": "verified",
  "submittedAt": "2025-03-03T14:40:00Z",
  "completedAt": "2025-03-03T14:47:31Z",
  "message": "Wasm hash matches the published source"
}
```

`status` is always one of `pending`, `verified`, or `failed`. A job still in flight keeps the same shape with a `null` `completedAt`, so consumers do not need to branch on field presence.

Miss - 404-style payload:

```json
{
  "error": "not_found",
  "message": "No verification job found for id \"job_9999\""
}
```

## Sample dataset

| jobId | status | notes |
| ----- | ------ | ----- |
| `job_2001` | `pending` | queued, `completedAt` is `null` |
| `job_2002` | `verified` | hash matches published source |
| `job_2003` | `failed` | reproduced hash did not match on-chain hash |

## Testing

```sh
cd contrib/routes/issue-51-verification-status
node route.test.mjs
# PASS: /verification-jobs/:jobId returns job status on a hit and 404 on a miss
```

The test covers the found case, every sample job reporting a status from the allowed set, the pending job having a `null` `completedAt`, the not found case, and a missing id. It also asserts the 404 payload carries no `status` field, so an error body cannot be mistaken for a hit.

## Constraints checklist

- [x] All changes are inside `contrib/` - the diff is three new files under `contrib/routes/issue-51-verification-status/`
- [x] Branch created from `drips`, PR targets `drips`
- [x] No files outside `contrib/` added, edited, renamed, or deleted
