### PR TITLE
contrib: add mock audit log route

### DIFF
--- a/contrib/routes/issue-52-audit-log/README.md
+++ b/contrib/routes/issue-52-audit-log/README.md
@@ -1,0 +1,56 @@
+# Mock route: audit log (Issue #52)
+
+Standalone mock GET route returning a fixed array of sample audit log entries.
+Each entry has an `actor`, an `action`, and an ISO-8601 UTC `timestamp`. No real
+chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# audit-log mock listening on http://localhost:4052/audit-log
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /audit-log
+```
+
+Response:
+
+```json
+{
+  "entries": [
+    {
+      "actor": "user_1001",
+      "action": "wallet.created",
+      "timestamp": "2025-03-01T08:15:22Z"
+    },
+    {
+      "actor": "admin_2001",
+      "action": "contract.verified",
+      "timestamp": "2025-03-02T11:30:05Z"
+    },
+    {
+      "actor": "system",
+      "action": "session.expired",
+      "timestamp": "2025-03-03T00:00:00Z"
+    }
+  ]
+}
+```
+
+## Sample dataset
+
+Six entries with six distinct actions, ordered oldest to newest:
+`wallet.created`, `policy.updated`, `contract.verified`, `transaction.signed`,
+`session.expired`, `trustline.removed`.

--- a/contrib/routes/issue-52-audit-log/route.mjs
+++ b/contrib/routes/issue-52-audit-log/route.mjs
@@ -1,0 +1,58 @@
+// Mock GET route returning a fixed array of sample audit log entries. No chain
+// or DB access.
+import http from "node:http";
+
+const MOCK_AUDIT_LOG = [
+  {
+    actor: "user_1001",
+    action: "wallet.created",
+    timestamp: "2025-03-01T08:15:22Z",
+  },
+  {
+    actor: "user_1001",
+    action: "policy.updated",
+    timestamp: "2025-03-01T09:02:47Z",
+  },
+  {
+    actor: "admin_2001",
+    action: "contract.verified",
+    timestamp: "2025-03-02T11:30:05Z",
+  },
+  {
+    actor: "user_1002",
+    action: "transaction.signed",
+    timestamp: "2025-03-02T16:44:19Z",
+  },
+  {
+    actor: "system",
+    action: "session.expired",
+    timestamp: "2025-03-03T00:00:00Z",
+  },
+  {
+    actor: "admin_2001",
+    action: "trustline.removed",
+    timestamp: "2025-03-03T13:21:58Z",
+  },
+];
+
+export function handleRequest() {
+  return { status: 200, body: { entries: MOCK_AUDIT_LOG } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/audit-log") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4052;
+  server.listen(port, () => {
+    console.log(`audit-log mock listening on http://localhost:${port}/audit-log`);
+  });
+}

--- a/contrib/routes/issue-52-audit-log/route.test.mjs
+++ b/contrib/routes/issue-52-audit-log/route.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const { status, body } = handleRequest();
+
+assert.equal(status, 200);
+assert.ok(Array.isArray(body.entries));
+assert.ok(body.entries.length >= 5);
+
+for (const entry of body.entries) {
+  assert.equal(typeof entry.actor, "string");
+  assert.ok(entry.actor.length > 0);
+  assert.equal(typeof entry.action, "string");
+  assert.ok(entry.action.length > 0);
+  assert.equal(typeof entry.timestamp, "string");
+  // Timestamps are ISO-8601 UTC strings.
+  assert.ok(!Number.isNaN(Date.parse(entry.timestamp)));
+  assert.match(entry.timestamp, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+}
+
+// The sample data uses varied actions rather than repeating one.
+const actions = new Set(body.entries.map((e) => e.action));
+assert.ok(actions.size >= 5);
+
+console.log("PASS: /audit-log returns an array of audit entries with actor, action, timestamp");


### PR DESCRIPTION
## Summary

Adds a standalone mock GET route under `contrib/routes/` that returns a fixed array of sample audit log entries. Everything is self-contained in `contrib/routes/issue-52-audit-log/`, with no chain or database access.

closes #52

## What's included

- `route.mjs` - exported `handleRequest()` plus a `node:http` server that runs only when the file is executed directly, following the same shape as the existing `contrib/routes/*` list mocks (for example `issue-43-trustline-list`).
- `route.test.mjs` - assertion script runnable with plain `node`, no test runner or dependencies.
- `README.md` - endpoint, run and test commands, an example response, and the sample dataset summary.

## Endpoint

```
GET /audit-log
```

Response:

```json
{
  "entries": [
    {
      "actor": "user_1001",
      "action": "wallet.created",
      "timestamp": "2025-03-01T08:15:22Z"
    },
    {
      "actor": "admin_2001",
      "action": "contract.verified",
      "timestamp": "2025-03-02T11:30:05Z"
    },
    {
      "actor": "system",
      "action": "session.expired",
      "timestamp": "2025-03-03T00:00:00Z"
    }
  ]
}
```

Every entry has an `actor`, an `action`, and an ISO-8601 UTC `timestamp`.

## Sample dataset

Six entries (the issue asks for at least five), ordered oldest to newest, with six distinct actions spanning wallet, policy, contract, transaction, session, and trustline events:

| actor | action | timestamp |
| ----- | ------ | --------- |
| `user_1001` | `wallet.created` | `2025-03-01T08:15:22Z` |
| `user_1001` | `policy.updated` | `2025-03-01T09:02:47Z` |
| `admin_2001` | `contract.verified` | `2025-03-02T11:30:05Z` |
| `user_1002` | `transaction.signed` | `2025-03-02T16:44:19Z` |
| `system` | `session.expired` | `2025-03-03T00:00:00Z` |
| `admin_2001` | `trustline.removed` | `2025-03-03T13:21:58Z` |

Actors cover an end user, a second user, an admin, and the `system` actor for automated events, so consumers can exercise per-actor grouping and filtering.

## Testing

```sh
cd contrib/routes/issue-52-audit-log
node route.test.mjs
# PASS: /audit-log returns an array of audit entries with actor, action, timestamp
```

The test verifies the response status, that `entries` is an array with at least five items, that every entry has non-empty string `actor` and `action` fields, and that each `timestamp` both parses as a date and matches the ISO-8601 UTC pattern. It also asserts the actions are varied rather than one action repeated.

## Constraints checklist

- [x] All changes are inside `contrib/` - the diff is three new files under `contrib/routes/issue-52-audit-log/`
- [x] Branch created from `drips`, PR targets `drips`
- [x] No files outside `contrib/` added, edited, renamed, or deleted
