### PR TITLE
contrib: add mock verification submit POST route

### DIFF
--- a/contrib/routes/verification-submit/README.md
+++ b/contrib/routes/verification-submit/README.md
@@ -1,0 +1,70 @@
+# Mock route: verification submit (Issue #50)
+
+Standalone mock `POST` route that accepts a contract verification submission
+and returns a generated verification job id. Nothing is persisted and no chain
+or database is touched — the job id comes from an in-process counter, so it is
+for local UI/dev testing only.
+
+## Run
+
+```sh
+node route.mjs
+# verification-submit mock listening on http://localhost:4054/verification/submit
+```
+
+Set `PORT` to use a different port.
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoint
+
+### `POST /verification/submit`
+
+Body fields:
+
+| Field        | Type   | Required | Notes                            |
+| ------------ | ------ | -------- | -------------------------------- |
+| `contractId` | string | yes      | Must be present and non-blank.   |
+
+Success (`202 Accepted`):
+
+```json
+{
+  "jobId": "vjob_000001",
+  "contractId": "CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K",
+  "status": "queued"
+}
+```
+
+Job ids are sequential (`vjob_000001`, `vjob_000002`, ...) so responses are
+reproducible across a run.
+
+### Errors
+
+| Status | `error`                | Cause                                        |
+| ------ | ---------------------- | -------------------------------------------- |
+| 400    | `contract_id_required` | No `contractId` field in the body            |
+| 400    | `invalid_contract_id`  | `contractId` is not a string, or is blank    |
+| 400    | `invalid_body`         | Body is not a JSON object                    |
+| 400    | `invalid_json`         | Body is not valid JSON                       |
+| 405    | `method_not_allowed`   | Path matched but the method was not `POST`   |
+| 413    | `body_too_large`       | Body exceeded 64 KiB                         |
+| 404    | `not_found`            | Unknown path                                 |
+
+## Example
+
+```sh
+curl -s -X POST http://localhost:4054/verification/submit \
+  -H 'Content-Type: application/json' \
+  -d '{"contractId":"CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K"}'
+```
+
+```sh
+curl -s -X POST http://localhost:4054/verification/submit \
+  -H 'Content-Type: application/json' -d '{}'
+# {"error":"contract_id_required"}
+```

--- a/contrib/routes/verification-submit/route.mjs
+++ b/contrib/routes/verification-submit/route.mjs
@@ -1,0 +1,102 @@
+// Mock POST route accepting a contract verification submission. No chain,
+// queue or database access — the job id comes from an in-process counter.
+import http from "node:http";
+
+const MAX_BODY_BYTES = 64 * 1024;
+
+let jobCounter = 0;
+
+/** Resets the id counter. Only used by the test script so each run is
+ * deterministic regardless of test order. */
+export function resetJobCounter() {
+  jobCounter = 0;
+}
+
+/** Generates the next job id, e.g. `vjob_000001`. Sequential rather than
+ * random so responses are reproducible in tests and local dev. */
+function nextJobId() {
+  jobCounter += 1;
+  return `vjob_${String(jobCounter).padStart(6, "0")}`;
+}
+
+/**
+ * Validates the submission body and, on success, produces the queued job.
+ * Exported separately from the HTTP plumbing so it can be tested directly.
+ */
+export function submitVerification(body) {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { status: 400, body: { error: "invalid_body" } };
+  }
+  if (!("contractId" in body)) {
+    return { status: 400, body: { error: "contract_id_required" } };
+  }
+  if (typeof body.contractId !== "string" || body.contractId.trim() === "") {
+    return { status: 400, body: { error: "invalid_contract_id" } };
+  }
+
+  return {
+    status: 202,
+    body: {
+      jobId: nextJobId(),
+      contractId: body.contractId.trim(),
+      status: "queued",
+    },
+  };
+}
+
+/** Collects the request body, rejecting anything larger than MAX_BODY_BYTES
+ * so a runaway client can't grow the buffer without bound. */
+function readBody(req) {
+  return new Promise((resolve) => {
+    let data = "";
+    let tooLarge = false;
+    req.on("data", (chunk) => {
+      if (tooLarge) return;
+      data += chunk;
+      if (data.length > MAX_BODY_BYTES) {
+        tooLarge = true;
+      }
+    });
+    req.on("end", () => resolve(tooLarge ? { tooLarge: true } : { raw: data }));
+  });
+}
+
+export async function handleRequest(req) {
+  const path = new URL(req.url, "http://localhost").pathname;
+
+  if (path !== "/verification/submit") {
+    return { status: 404, body: { error: "not_found" } };
+  }
+  if (req.method !== "POST") {
+    return { status: 405, body: { error: "method_not_allowed" } };
+  }
+
+  const { raw, tooLarge } = await readBody(req);
+  if (tooLarge) {
+    return { status: 413, body: { error: "body_too_large" } };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw === "" ? "null" : raw);
+  } catch {
+    return { status: 400, body: { error: "invalid_json" } };
+  }
+
+  return submitVerification(parsed);
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer(async (req, res) => {
+    const { status, body } = await handleRequest(req);
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4054;
+  server.listen(port, () => {
+    console.log(
+      `verification-submit mock listening on http://localhost:${port}/verification/submit`,
+    );
+  });
+}

--- a/contrib/routes/verification-submit/route.test.mjs
+++ b/contrib/routes/verification-submit/route.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { handleRequest, resetJobCounter } from "./route.mjs";
+
+/** Minimal stand-in for an http.IncomingMessage carrying a JSON body. */
+function makeReq(method, url, body) {
+  return {
+    url,
+    method,
+    on: (event, cb) => {
+      if (event === "data" && body !== undefined) cb(JSON.stringify(body));
+      if (event === "end") cb();
+    },
+  };
+}
+
+resetJobCounter();
+
+// Success: a contractId is present, so a job id comes back.
+{
+  const req = makeReq("POST", "/verification/submit", {
+    contractId: "CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K",
+  });
+  const { status, body } = await handleRequest(req);
+
+  assert.equal(status, 202);
+  assert.equal(body.jobId, "vjob_000001");
+  assert.equal(
+    body.contractId,
+    "CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K",
+  );
+  assert.equal(body.status, "queued");
+}
+
+// Each submission gets a distinct job id.
+{
+  const req = makeReq("POST", "/verification/submit", { contractId: "CB2" });
+  const { status, body } = await handleRequest(req);
+
+  assert.equal(status, 202);
+  assert.equal(body.jobId, "vjob_000002");
+}
+
+// Missing field: no contractId at all.
+{
+  const req = makeReq("POST", "/verification/submit", { name: "token" });
+  const { status, body } = await handleRequest(req);
+
+  assert.equal(status, 400);
+  assert.equal(body.error, "contract_id_required");
+  assert.equal(body.jobId, undefined);
+}
+
+// Present but blank contractId is rejected too.
+{
+  const req = makeReq("POST", "/verification/submit", { contractId: "   " });
+  const { status, body } = await handleRequest(req);
+
+  assert.equal(status, 400);
+  assert.equal(body.error, "invalid_contract_id");
+}
+
+// Malformed JSON is reported as such rather than crashing the handler.
+{
+  const req = {
+    url: "/verification/submit",
+    method: "POST",
+    on: (event, cb) => {
+      if (event === "data") cb("{not json");
+      if (event === "end") cb();
+    },
+  };
+  const { status, body } = await handleRequest(req);
+
+  assert.equal(status, 400);
+  assert.equal(body.error, "invalid_json");
+}
+
+// Wrong method and unknown path are handled explicitly.
+{
+  const wrongMethod = await handleRequest(makeReq("GET", "/verification/submit"));
+  assert.equal(wrongMethod.status, 405);
+
+  const unknownPath = await handleRequest(makeReq("POST", "/nope", {}));
+  assert.equal(unknownPath.status, 404);
+}
+
+console.log("PASS: POST /verification/submit success, validation and error cases");


### PR DESCRIPTION
closes #50

## What this adds

A standalone mock `POST` route under `contrib/routes/verification-submit/` that accepts a contract verification submission and returns a generated verification job id. Nothing is persisted and no chain or database is touched, so it is usable as a local stand-in while the real verification pipeline is built.

- `route.mjs` - the handler, plus a small `http` server behind an `import.meta.url` guard so the file is both importable and runnable.
- `route.test.mjs` - a node-only test script, no test runner or dependency required.
- `README.md` - endpoint reference, error table, and curl examples.

## Endpoint

`POST /verification/submit`

| Field | Type | Required | Notes |
| --- | --- | --- | --- |
| `contractId` | string | yes | Must be present and non-blank |

Success responds `202 Accepted`:

```json
{
  "jobId": "vjob_000001",
  "contractId": "CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K",
  "status": "queued"
}
```

Job ids come from an in-process counter (`vjob_000001`, `vjob_000002`, ...) rather than a random value, so responses are reproducible across a run and tests do not have to match on a pattern. `resetJobCounter()` is exported so the test script starts from a known state.

## Validation

`contractId` is checked for presence and for being a non-blank string, and the two cases are reported separately (`contract_id_required` vs `invalid_contract_id`) so a client can tell "you forgot the field" from "you sent something unusable". Malformed JSON, a non-object body, a wrong method, an unknown path, and an oversized body each get their own status and error code instead of falling through to a generic 400.

## Tests

```sh
node contrib/routes/verification-submit/route.test.mjs
# PASS: POST /verification/submit success, validation and error cases
```

Covers the success case (including that a second submission gets a distinct id), the missing-field case, a blank `contractId`, malformed JSON, and the method/path guards.

## Conventions and scope

Follows the existing `contrib/routes/` layout (`route.mjs` / `route.test.mjs` / `README.md`), the `{ status, body }` handler shape, and the snake_case `error` codes used by the neighbouring modules. Default port is `4054`, which does not collide with any module already on `drips`, and `PORT` overrides it.

Every file is inside `contrib/`, and the PR is based on and targets `drips`.
