### PR TITLE
contrib: add mock balance lookup route module

### DIFF
--- a/contrib/routes/balance-lookup/README.md
+++ b/contrib/routes/balance-lookup/README.md
@@ -1,0 +1,99 @@
+# Mock route: balance lookup (Issue #62)
+
+Self-contained mock route module that returns balances for a single account or
+for a batch of accounts in one request. Balances come from a fixed in-memory
+fixture — no chain, RPC or database access — so it is for local UI/dev testing
+only.
+
+## Run
+
+```sh
+node route.mjs
+# balance-lookup mock listening on http://localhost:4055
+#   GET  /balances/:accountId
+#   POST /balances/batch
+```
+
+Set `PORT` to use a different port.
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+Covers the single lookup (hit and miss), the batch lookup (order preservation,
+per-item misses, agreement with the single lookup), batch validation, and the
+method/path guards.
+
+## Endpoints
+
+### `GET /balances/:accountId`
+
+Returns every balance held by one account.
+
+```sh
+curl -s http://localhost:4055/balances/GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB
+```
+
+```json
+{
+  "accountId": "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+  "balances": [
+    { "assetCode": "XLM", "balance": "1250.5000000" },
+    { "assetCode": "USDC", "balance": "310.0000000" }
+  ]
+}
+```
+
+An unknown account is a `404` with `{"error":"account_not_found","accountId":"..."}`.
+
+### `POST /balances/batch`
+
+Resolves up to 50 accounts in one request. Results are returned in the same
+order as the ids were sent, and an unknown account is a per-item miss rather
+than a failure of the whole batch.
+
+```sh
+curl -s -X POST http://localhost:4055/balances/batch \
+  -H 'Content-Type: application/json' \
+  -d '{"accountIds":["GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF","GZZZUNKNOWN"]}'
+```
+
+```json
+{
+  "results": [
+    {
+      "accountId": "GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+      "found": true,
+      "balances": [{ "assetCode": "XLM", "balance": "0.5000000" }]
+    },
+    { "accountId": "GZZZUNKNOWN", "found": false, "balances": [] }
+  ],
+  "requested": 2,
+  "found": 1
+}
+```
+
+## Errors
+
+| Status | `error`                | Cause                                                |
+| ------ | ---------------------- | ---------------------------------------------------- |
+| 404    | `account_not_found`    | Single lookup for an id not in the fixture           |
+| 400    | `account_ids_required` | Batch body had no `accountIds` array                 |
+| 400    | `account_ids_empty`    | `accountIds` was an empty array                      |
+| 400    | `batch_too_large`      | More than 50 ids (`maxBatchSize` is echoed back)     |
+| 400    | `invalid_account_id`   | An entry was not a non-blank string                  |
+| 400    | `invalid_body`         | Batch body was not a JSON object                     |
+| 400    | `invalid_json`         | Batch body was not valid JSON                        |
+| 405    | `method_not_allowed`   | Path matched but the method did not                  |
+| 413    | `body_too_large`       | Body exceeded 64 KiB                                 |
+| 404    | `not_found`            | Unknown path                                         |
+
+## Fixture accounts
+
+| Account id                                            | Balances               |
+| ----------------------------------------------------- | ---------------------- |
+| `GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB`  | XLM, USDC              |
+| `GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF` | XLM                    |
+| `GHIJ1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF` | XLM, USDC, EURC        |

--- a/contrib/routes/balance-lookup/route.mjs
+++ b/contrib/routes/balance-lookup/route.mjs
@@ -1,0 +1,151 @@
+// Mock balance lookup routes: one account by path parameter, or many accounts
+// in a single batch request. Balances come from a fixed in-memory fixture —
+// no chain, RPC or database access.
+import http from "node:http";
+
+const MAX_BODY_BYTES = 64 * 1024;
+const MAX_BATCH_SIZE = 50;
+
+/** Fixed sample ledger. Keys are account ids; values are the balances that
+ * account holds, ordered most-significant asset first. */
+const ACCOUNTS = {
+  GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB: [
+    { assetCode: "XLM", balance: "1250.5000000" },
+    { assetCode: "USDC", balance: "310.0000000" },
+  ],
+  GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF: [
+    { assetCode: "XLM", balance: "0.5000000" },
+  ],
+  GHIJ1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF: [
+    { assetCode: "XLM", balance: "42.0000000" },
+    { assetCode: "USDC", balance: "0.0000000" },
+    { assetCode: "EURC", balance: "18.7500000" },
+  ],
+};
+
+/**
+ * Looks up one account. Returns `null` when the account is unknown so callers
+ * can decide between a 404 (single lookup) and a per-item miss (batch).
+ */
+export function lookupAccount(accountId) {
+  const balances = ACCOUNTS[accountId];
+  if (!balances) {
+    return null;
+  }
+  // Copied so a caller mutating the response can't corrupt the fixture.
+  return { accountId, balances: balances.map((b) => ({ ...b })) };
+}
+
+/**
+ * Resolves a list of account ids, preserving request order and reporting
+ * misses per item rather than failing the whole batch.
+ */
+export function lookupBatch(accountIds) {
+  if (!Array.isArray(accountIds)) {
+    return { status: 400, body: { error: "account_ids_required" } };
+  }
+  if (accountIds.length === 0) {
+    return { status: 400, body: { error: "account_ids_empty" } };
+  }
+  if (accountIds.length > MAX_BATCH_SIZE) {
+    return {
+      status: 400,
+      body: { error: "batch_too_large", maxBatchSize: MAX_BATCH_SIZE },
+    };
+  }
+  if (accountIds.some((id) => typeof id !== "string" || id.trim() === "")) {
+    return { status: 400, body: { error: "invalid_account_id" } };
+  }
+
+  const results = accountIds.map((id) => {
+    const account = lookupAccount(id.trim());
+    return account
+      ? { accountId: id.trim(), found: true, balances: account.balances }
+      : { accountId: id.trim(), found: false, balances: [] };
+  });
+
+  return {
+    status: 200,
+    body: {
+      results,
+      requested: results.length,
+      found: results.filter((r) => r.found).length,
+    },
+  };
+}
+
+/** Collects the request body, rejecting anything larger than MAX_BODY_BYTES
+ * so a runaway client can't grow the buffer without bound. */
+function readBody(req) {
+  return new Promise((resolve) => {
+    let data = "";
+    let tooLarge = false;
+    req.on("data", (chunk) => {
+      if (tooLarge) return;
+      data += chunk;
+      if (data.length > MAX_BODY_BYTES) {
+        tooLarge = true;
+      }
+    });
+    req.on("end", () => resolve(tooLarge ? { tooLarge: true } : { raw: data }));
+  });
+}
+
+export async function handleRequest(req) {
+  const path = new URL(req.url, "http://localhost").pathname;
+
+  if (path === "/balances/batch") {
+    if (req.method !== "POST") {
+      return { status: 405, body: { error: "method_not_allowed" } };
+    }
+
+    const { raw, tooLarge } = await readBody(req);
+    if (tooLarge) {
+      return { status: 413, body: { error: "body_too_large" } };
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(raw === "" ? "null" : raw);
+    } catch {
+      return { status: 400, body: { error: "invalid_json" } };
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { status: 400, body: { error: "invalid_body" } };
+    }
+
+    return lookupBatch(parsed.accountIds);
+  }
+
+  // Single lookup: /balances/:accountId — matched after the batch path so
+  // "batch" is never treated as an account id.
+  const single = /^\/balances\/([^/]+)$/.exec(path);
+  if (single) {
+    if (req.method !== "GET") {
+      return { status: 405, body: { error: "method_not_allowed" } };
+    }
+    const accountId = decodeURIComponent(single[1]);
+    const account = lookupAccount(accountId);
+    if (!account) {
+      return { status: 404, body: { error: "account_not_found", accountId } };
+    }
+    return { status: 200, body: account };
+  }
+
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer(async (req, res) => {
+    const { status, body } = await handleRequest(req);
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4055;
+  server.listen(port, () => {
+    console.log(`balance-lookup mock listening on http://localhost:${port}`);
+    console.log(`  GET  /balances/:accountId`);
+    console.log(`  POST /balances/batch`);
+  });
+}

--- a/contrib/routes/balance-lookup/route.test.mjs
+++ b/contrib/routes/balance-lookup/route.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const ACCOUNT_A = "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB";
+const ACCOUNT_B = "GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF";
+const UNKNOWN = "GZZZ1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF";
+
+/** Minimal stand-in for an http.IncomingMessage carrying a JSON body. */
+function makeReq(method, url, body) {
+  return {
+    url,
+    method,
+    on: (event, cb) => {
+      if (event === "data" && body !== undefined) cb(JSON.stringify(body));
+      if (event === "end") cb();
+    },
+  };
+}
+
+// --- single lookup ---------------------------------------------------------
+
+// Known account returns its balances.
+{
+  const { status, body } = await handleRequest(
+    makeReq("GET", `/balances/${ACCOUNT_A}`),
+  );
+
+  assert.equal(status, 200);
+  assert.equal(body.accountId, ACCOUNT_A);
+  assert.equal(body.balances.length, 2);
+  assert.equal(body.balances[0].assetCode, "XLM");
+  assert.equal(typeof body.balances[0].balance, "string");
+}
+
+// Unknown account is a 404, and the id is echoed back.
+{
+  const { status, body } = await handleRequest(
+    makeReq("GET", `/balances/${UNKNOWN}`),
+  );
+
+  assert.equal(status, 404);
+  assert.equal(body.error, "account_not_found");
+  assert.equal(body.accountId, UNKNOWN);
+}
+
+// The response is a copy: mutating it must not corrupt the fixture.
+{
+  const first = await handleRequest(makeReq("GET", `/balances/${ACCOUNT_A}`));
+  first.body.balances[0].balance = "0";
+  const second = await handleRequest(makeReq("GET", `/balances/${ACCOUNT_A}`));
+
+  assert.equal(second.body.balances[0].balance, "1250.5000000");
+}
+
+// --- batch lookup ----------------------------------------------------------
+
+// Mixed batch: results keep request order and misses are reported per item.
+{
+  const { status, body } = await handleRequest(
+    makeReq("POST", "/balances/batch", {
+      accountIds: [ACCOUNT_B, UNKNOWN, ACCOUNT_A],
+    }),
+  );
+
+  assert.equal(status, 200);
+  assert.equal(body.requested, 3);
+  assert.equal(body.found, 2);
+  assert.deepEqual(
+    body.results.map((r) => r.accountId),
+    [ACCOUNT_B, UNKNOWN, ACCOUNT_A],
+  );
+  assert.deepEqual(
+    body.results.map((r) => r.found),
+    [true, false, true],
+  );
+  assert.deepEqual(body.results[1].balances, []);
+  assert.equal(body.results[2].balances.length, 2);
+}
+
+// A single-element batch matches the single-lookup response for that account.
+{
+  const batch = await handleRequest(
+    makeReq("POST", "/balances/batch", { accountIds: [ACCOUNT_A] }),
+  );
+  const single = await handleRequest(makeReq("GET", `/balances/${ACCOUNT_A}`));
+
+  assert.deepEqual(batch.body.results[0].balances, single.body.balances);
+}
+
+// Validation: missing, empty, oversized and malformed inputs.
+{
+  const missing = await handleRequest(makeReq("POST", "/balances/batch", {}));
+  assert.equal(missing.status, 400);
+  assert.equal(missing.body.error, "account_ids_required");
+
+  const empty = await handleRequest(
+    makeReq("POST", "/balances/batch", { accountIds: [] }),
+  );
+  assert.equal(empty.status, 400);
+  assert.equal(empty.body.error, "account_ids_empty");
+
+  const tooMany = await handleRequest(
+    makeReq("POST", "/balances/batch", {
+      accountIds: Array.from({ length: 51 }, (_, i) => `G${i}`),
+    }),
+  );
+  assert.equal(tooMany.status, 400);
+  assert.equal(tooMany.body.error, "batch_too_large");
+  assert.equal(tooMany.body.maxBatchSize, 50);
+
+  const badEntry = await handleRequest(
+    makeReq("POST", "/balances/batch", { accountIds: [ACCOUNT_A, ""] }),
+  );
+  assert.equal(badEntry.status, 400);
+  assert.equal(badEntry.body.error, "invalid_account_id");
+}
+
+// Routing guards: wrong methods and unknown paths.
+{
+  const wrongBatchMethod = await handleRequest(
+    makeReq("GET", "/balances/batch"),
+  );
+  assert.equal(wrongBatchMethod.status, 405);
+
+  const wrongSingleMethod = await handleRequest(
+    makeReq("POST", `/balances/${ACCOUNT_A}`, {}),
+  );
+  assert.equal(wrongSingleMethod.status, 405);
+
+  const unknownPath = await handleRequest(makeReq("GET", "/nope"));
+  assert.equal(unknownPath.status, 404);
+  assert.equal(unknownPath.body.error, "not_found");
+}
+
+console.log("PASS: GET /balances/:accountId and POST /balances/batch");


### PR DESCRIPTION
closes #62

## What this adds

A self-contained mock route module under `contrib/routes/balance-lookup/` that returns balances for a single account and for a batch of accounts in one request. Balances come from a fixed in-memory fixture, so there is no chain, RPC or database access.

- `route.mjs` - both handlers, plus a small `http` server behind an `import.meta.url` guard so the file is both importable and runnable.
- `route.test.mjs` - a node-only test script, no test runner or dependency required.
- `README.md` - endpoint reference, error table, fixture accounts, and curl examples.

## Endpoints

### `GET /balances/:accountId`

Single lookup by path parameter.

```json
{
  "accountId": "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
  "balances": [
    { "assetCode": "XLM", "balance": "1250.5000000" },
    { "assetCode": "USDC", "balance": "310.0000000" }
  ]
}
```

An unknown account is a `404` with the id echoed back.

### `POST /balances/batch`

Takes `{ "accountIds": [...] }` and resolves up to 50 accounts at once.

```json
{
  "results": [
    { "accountId": "GDEF...", "found": true, "balances": [{ "assetCode": "XLM", "balance": "0.5000000" }] },
    { "accountId": "GZZZUNKNOWN", "found": false, "balances": [] }
  ],
  "requested": 2,
  "found": 1
}
```

## Design notes

- **Order is preserved.** Results come back in the same order the ids were sent, so a caller can zip them against its own list without matching on id.
- **A miss is per-item, not fatal.** One unknown account in a batch is reported as `found: false` rather than failing the whole request, which is the behaviour a UI rendering a list of accounts needs. The single lookup still returns a `404`, since there the account is the whole request.
- **The batch path is matched before the `:accountId` pattern**, so `batch` can never be mistaken for an account id.
- **Responses are copies of the fixture**, so a caller mutating a response cannot corrupt later lookups. There is a test for this.
- **Batch size is capped at 50** and the cap is echoed back in the error body so the client does not have to hardcode it.

## Tests

```sh
node contrib/routes/balance-lookup/route.test.mjs
# PASS: GET /balances/:accountId and POST /balances/batch
```

Covers the single lookup (hit, miss, and fixture immutability), the batch lookup (order preservation, mixed hit/miss, and agreement between a one-element batch and the equivalent single lookup), every batch validation branch (missing, empty, oversized, non-string entry), and the method/path guards.

## Conventions and scope

Follows the existing `contrib/routes/` layout, the `{ status, body }` handler shape, and the snake_case `error` codes used by the neighbouring modules. Default port is `4055`, which does not collide with any module already on `drips`, and `PORT` overrides it.

Every file is inside `contrib/`, and the PR is based on and targets `drips`.
