### PR TITLE
contrib: add export job queue route suite

### DIFF
--- a/contrib/routes/export-queue-suite/README.md
+++ b/contrib/routes/export-queue-suite/README.md
@@ -1,0 +1,137 @@
+# Mock routes: export job queue (Issue #151)
+
+Self-contained mock route suite that queues export jobs with a selected output
+format and drains them strictly first-in-first-out, one at a time. All state is
+held in process memory — no worker process, no storage, no chain access — so it
+is for local UI/dev testing only.
+
+## Run
+
+```sh
+node route.mjs
+# export-queue-suite mock listening on http://localhost:4056
+#   POST /export/enqueue
+#   POST /export/process
+#   GET  /export/queue-status
+#   GET  /export/jobs/:jobId
+```
+
+Set `PORT` to use a different port.
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+The first case enqueues two jobs and drains the queue, asserting that they
+complete in the order they were enqueued and that only one is ever in flight.
+Further cases cover queue positions shifting as the queue drains, format
+validation, single-job lookup, and the idle/method/path guards.
+
+## How the queue works
+
+A job is `queued` on arrival. If the single processing slot is free, the head of
+the queue is immediately promoted to `processing` — so at most one job is ever
+in flight. Draining is driven explicitly by `POST /export/process` rather than
+by a timer, which keeps the ordering observable and lets a test assert it
+without waiting on the clock. Each completed job gets an `artifact` naming the
+file the export would have produced.
+
+```
+enqueue A ─┐
+enqueue B ─┴─> [processing: A] [queued: B]
+process    ──> [completed: A]  [processing: B]
+process    ──> [completed: A, B]  (idle)
+```
+
+## Endpoints
+
+### `POST /export/enqueue`
+
+| Field      | Type   | Required | Notes                                                     |
+| ---------- | ------ | -------- | --------------------------------------------------------- |
+| `format`   | string | yes      | `csv` or `json`; trimmed and lower-cased before matching.  |
+| `resource` | string | no       | What is being exported. Defaults to `transactions`.        |
+
+```sh
+curl -s -X POST http://localhost:4056/export/enqueue \
+  -H 'Content-Type: application/json' \
+  -d '{"format":"csv","resource":"transactions"}'
+```
+
+```json
+{
+  "jobId": "exp_0001",
+  "format": "csv",
+  "resource": "transactions",
+  "status": "processing",
+  "sequence": 1
+}
+```
+
+A job that has to wait comes back with `"status": "queued"` and a 1-based
+`position` in the queue.
+
+### `POST /export/process`
+
+Completes the in-flight job and promotes the next one.
+
+```json
+{
+  "completed": {
+    "jobId": "exp_0001",
+    "format": "csv",
+    "resource": "transactions",
+    "status": "completed",
+    "sequence": 1,
+    "artifact": { "filename": "transactions-exp_0001.csv", "contentType": "text/csv" }
+  },
+  "nowProcessing": {
+    "jobId": "exp_0002",
+    "format": "json",
+    "resource": "balances",
+    "status": "processing",
+    "sequence": 2
+  }
+}
+```
+
+`nowProcessing` is `null` once the queue is empty.
+
+### `GET /export/queue-status`
+
+```json
+{
+  "processing": { "jobId": "exp_0001", "status": "processing", "...": "..." },
+  "queued": [{ "jobId": "exp_0002", "status": "queued", "position": 1 }],
+  "completed": [],
+  "counts": { "processing": 1, "queued": 1, "completed": 0, "total": 2 },
+  "allowedFormats": ["csv", "json"]
+}
+```
+
+`queued` is in queue order and `completed` is in completion order, so the two
+together show that jobs finish in the order they arrived.
+
+### `GET /export/jobs/:jobId`
+
+Returns a single job, for a client that holds a job id and wants to poll just
+that one.
+
+## Errors
+
+| Status | `error`               | Cause                                                        |
+| ------ | --------------------- | ------------------------------------------------------------ |
+| 400    | `format_required`     | No `format` field (`allowedFormats` is echoed back)           |
+| 400    | `invalid_format`      | `format` was not a string                                     |
+| 400    | `unsupported_format`  | `format` was not in the allowed list                          |
+| 400    | `invalid_resource`    | `resource` was present but not a string                       |
+| 400    | `invalid_body`        | Body was not a JSON object                                    |
+| 400    | `invalid_json`        | Body was not valid JSON                                       |
+| 409    | `queue_idle`          | `POST /export/process` with nothing in flight                 |
+| 429    | `queue_full`          | More than 100 jobs pending (`maxQueueLength` is echoed back)  |
+| 404    | `job_not_found`       | Unknown job id                                                |
+| 405    | `method_not_allowed`  | Path matched but the method did not                           |
+| 413    | `body_too_large`      | Body exceeded 64 KiB                                          |
+| 404    | `not_found`           | Unknown path                                                  |

--- a/contrib/routes/export-queue-suite/route.mjs
+++ b/contrib/routes/export-queue-suite/route.mjs
@@ -1,0 +1,258 @@
+// Mock export job queue: jobs are enqueued with an output format and drained
+// strictly first-in-first-out, one at a time. Everything lives in process
+// memory — no worker, no storage, no chain access.
+import http from "node:http";
+
+const MAX_BODY_BYTES = 64 * 1024;
+const MAX_QUEUE_LENGTH = 100;
+
+/** The only output formats an export job may request. */
+export const ALLOWED_FORMATS = ["csv", "json"];
+
+const CONTENT_TYPES = { csv: "text/csv", json: "application/json" };
+
+/** Queue state. `processing` holds the single in-flight job id, which is what
+ * makes this one-at-a-time: a job is only promoted out of `queued` once the
+ * previous one has completed. */
+let jobs = new Map();
+let queued = [];
+let processing = null;
+let completed = [];
+let jobCounter = 0;
+
+/** Resets all queue state. Used by the test script so runs are deterministic. */
+export function resetQueue() {
+  jobs = new Map();
+  queued = [];
+  processing = null;
+  completed = [];
+  jobCounter = 0;
+}
+
+function nextJobId() {
+  jobCounter += 1;
+  return `exp_${String(jobCounter).padStart(4, "0")}`;
+}
+
+/** Promotes the head of the queue into the processing slot, if it is free. */
+function promoteNext() {
+  if (processing !== null || queued.length === 0) {
+    return;
+  }
+  processing = queued.shift();
+  jobs.get(processing).status = "processing";
+}
+
+function serialize(jobId) {
+  const job = jobs.get(jobId);
+  const view = {
+    jobId: job.jobId,
+    format: job.format,
+    resource: job.resource,
+    status: job.status,
+    sequence: job.sequence,
+  };
+  if (job.status === "queued") {
+    view.position = queued.indexOf(jobId) + 1;
+  }
+  if (job.artifact) {
+    view.artifact = { ...job.artifact };
+  }
+  return view;
+}
+
+/**
+ * Validates the enqueue payload and appends the job. The first job enqueued
+ * into an idle queue starts processing immediately; later ones wait behind it.
+ */
+export function enqueue(body) {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { status: 400, body: { error: "invalid_body" } };
+  }
+  if (!("format" in body)) {
+    return {
+      status: 400,
+      body: { error: "format_required", allowedFormats: ALLOWED_FORMATS },
+    };
+  }
+  if (typeof body.format !== "string") {
+    return {
+      status: 400,
+      body: { error: "invalid_format", allowedFormats: ALLOWED_FORMATS },
+    };
+  }
+
+  const format = body.format.trim().toLowerCase();
+  if (!ALLOWED_FORMATS.includes(format)) {
+    return {
+      status: 400,
+      body: {
+        error: "unsupported_format",
+        format: body.format,
+        allowedFormats: ALLOWED_FORMATS,
+      },
+    };
+  }
+
+  if (body.resource !== undefined && typeof body.resource !== "string") {
+    return { status: 400, body: { error: "invalid_resource" } };
+  }
+  if (queued.length + (processing === null ? 0 : 1) >= MAX_QUEUE_LENGTH) {
+    return {
+      status: 429,
+      body: { error: "queue_full", maxQueueLength: MAX_QUEUE_LENGTH },
+    };
+  }
+
+  const jobId = nextJobId();
+  jobs.set(jobId, {
+    jobId,
+    format,
+    resource: body.resource ?? "transactions",
+    status: "queued",
+    sequence: jobCounter,
+    artifact: null,
+  });
+  queued.push(jobId);
+  promoteNext();
+
+  return { status: 202, body: serialize(jobId) };
+}
+
+/**
+ * Completes the in-flight job and promotes the next one. Draining is driven
+ * explicitly rather than by a timer so the FIFO order is observable and
+ * testable without waiting on the clock.
+ */
+export function processNext() {
+  if (processing === null) {
+    return { status: 409, body: { error: "queue_idle" } };
+  }
+
+  const jobId = processing;
+  const job = jobs.get(jobId);
+  job.status = "completed";
+  job.artifact = {
+    filename: `${job.resource}-${jobId}.${job.format}`,
+    contentType: CONTENT_TYPES[job.format],
+  };
+  completed.push(jobId);
+  processing = null;
+  promoteNext();
+
+  return {
+    status: 200,
+    body: { completed: serialize(jobId), nowProcessing: processing ? serialize(processing) : null },
+  };
+}
+
+/** Snapshot of the queue: what is in flight, what is waiting (in order), and
+ * what has finished (in completion order). */
+export function queueStatus() {
+  return {
+    status: 200,
+    body: {
+      processing: processing ? serialize(processing) : null,
+      queued: queued.map(serialize),
+      completed: completed.map(serialize),
+      counts: {
+        processing: processing ? 1 : 0,
+        queued: queued.length,
+        completed: completed.length,
+        total: jobs.size,
+      },
+      allowedFormats: ALLOWED_FORMATS,
+    },
+  };
+}
+
+/** Single job lookup, so a client that holds a job id can poll just that one. */
+export function getJob(jobId) {
+  if (!jobs.has(jobId)) {
+    return { status: 404, body: { error: "job_not_found", jobId } };
+  }
+  return { status: 200, body: serialize(jobId) };
+}
+
+/** Collects the request body, rejecting anything larger than MAX_BODY_BYTES
+ * so a runaway client can't grow the buffer without bound. */
+function readBody(req) {
+  return new Promise((resolve) => {
+    let data = "";
+    let tooLarge = false;
+    req.on("data", (chunk) => {
+      if (tooLarge) return;
+      data += chunk;
+      if (data.length > MAX_BODY_BYTES) {
+        tooLarge = true;
+      }
+    });
+    req.on("end", () => resolve(tooLarge ? { tooLarge: true } : { raw: data }));
+  });
+}
+
+async function readJson(req) {
+  const { raw, tooLarge } = await readBody(req);
+  if (tooLarge) {
+    return { error: { status: 413, body: { error: "body_too_large" } } };
+  }
+  try {
+    return { value: JSON.parse(raw === "" ? "null" : raw) };
+  } catch {
+    return { error: { status: 400, body: { error: "invalid_json" } } };
+  }
+}
+
+export async function handleRequest(req) {
+  const path = new URL(req.url, "http://localhost").pathname;
+
+  if (path === "/export/enqueue") {
+    if (req.method !== "POST") {
+      return { status: 405, body: { error: "method_not_allowed" } };
+    }
+    const { value, error } = await readJson(req);
+    if (error) return error;
+    return enqueue(value);
+  }
+
+  if (path === "/export/process") {
+    if (req.method !== "POST") {
+      return { status: 405, body: { error: "method_not_allowed" } };
+    }
+    return processNext();
+  }
+
+  if (path === "/export/queue-status") {
+    if (req.method !== "GET") {
+      return { status: 405, body: { error: "method_not_allowed" } };
+    }
+    return queueStatus();
+  }
+
+  const job = /^\/export\/jobs\/([^/]+)$/.exec(path);
+  if (job) {
+    if (req.method !== "GET") {
+      return { status: 405, body: { error: "method_not_allowed" } };
+    }
+    return getJob(decodeURIComponent(job[1]));
+  }
+
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer(async (req, res) => {
+    const { status, body } = await handleRequest(req);
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  const port = process.env.PORT || 4056;
+  server.listen(port, () => {
+    console.log(`export-queue-suite mock listening on http://localhost:${port}`);
+    console.log(`  POST /export/enqueue`);
+    console.log(`  POST /export/process`);
+    console.log(`  GET  /export/queue-status`);
+    console.log(`  GET  /export/jobs/:jobId`);
+  });
+}

--- a/contrib/routes/export-queue-suite/route.test.mjs
+++ b/contrib/routes/export-queue-suite/route.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { handleRequest, resetQueue } from "./route.mjs";
+
+/** Minimal stand-in for an http.IncomingMessage carrying a JSON body. */
+function makeReq(method, url, body) {
+  return {
+    url,
+    method,
+    on: (event, cb) => {
+      if (event === "data" && body !== undefined) cb(JSON.stringify(body));
+      if (event === "end") cb();
+    },
+  };
+}
+
+const enqueueJob = (body) => handleRequest(makeReq("POST", "/export/enqueue", body));
+const processNextJob = () => handleRequest(makeReq("POST", "/export/process"));
+const status = () => handleRequest(makeReq("GET", "/export/queue-status"));
+
+// --- two queued jobs are processed in the order they were enqueued ---------
+{
+  resetQueue();
+
+  const first = await enqueueJob({ format: "csv", resource: "transactions" });
+  const second = await enqueueJob({ format: "json", resource: "balances" });
+
+  assert.equal(first.status, 202);
+  assert.equal(second.status, 202);
+
+  // The first job took the single processing slot; the second waits behind it.
+  assert.equal(first.body.status, "processing");
+  assert.equal(second.body.status, "queued");
+  assert.equal(second.body.position, 1);
+
+  const beforeDraining = await status();
+  assert.equal(beforeDraining.body.processing.jobId, first.body.jobId);
+  assert.deepEqual(
+    beforeDraining.body.queued.map((j) => j.jobId),
+    [second.body.jobId],
+  );
+  assert.deepEqual(beforeDraining.body.counts, {
+    processing: 1,
+    queued: 1,
+    completed: 0,
+    total: 2,
+  });
+
+  // Draining once completes the first job and promotes the second.
+  const firstDrain = await processNextJob();
+  assert.equal(firstDrain.status, 200);
+  assert.equal(firstDrain.body.completed.jobId, first.body.jobId);
+  assert.equal(firstDrain.body.completed.status, "completed");
+  assert.equal(firstDrain.body.completed.artifact.filename, `transactions-${first.body.jobId}.csv`);
+  assert.equal(firstDrain.body.completed.artifact.contentType, "text/csv");
+  assert.equal(firstDrain.body.nowProcessing.jobId, second.body.jobId);
+
+  const secondDrain = await processNextJob();
+  assert.equal(secondDrain.body.completed.jobId, second.body.jobId);
+  assert.equal(secondDrain.body.completed.artifact.filename, `balances-${second.body.jobId}.json`);
+  assert.equal(secondDrain.body.completed.artifact.contentType, "application/json");
+  assert.equal(secondDrain.body.nowProcessing, null);
+
+  // Completion order matches enqueue order — the FIFO guarantee.
+  const drained = await status();
+  assert.deepEqual(
+    drained.body.completed.map((j) => j.jobId),
+    [first.body.jobId, second.body.jobId],
+  );
+  assert.equal(drained.body.processing, null);
+  assert.equal(drained.body.queued.length, 0);
+}
+
+// --- queue positions shift as the queue drains -----------------------------
+{
+  resetQueue();
+
+  const a = await enqueueJob({ format: "csv" });
+  const b = await enqueueJob({ format: "json" });
+  const c = await enqueueJob({ format: "csv" });
+
+  assert.equal(b.body.position, 1);
+  assert.equal(c.body.position, 2);
+
+  await processNextJob(); // completes a, promotes b
+
+  const afterOne = await status();
+  assert.equal(afterOne.body.processing.jobId, b.body.jobId);
+  assert.equal(afterOne.body.queued[0].jobId, c.body.jobId);
+  assert.equal(afterOne.body.queued[0].position, 1);
+}
+
+// --- format validation -----------------------------------------------------
+{
+  resetQueue();
+
+  const missing = await enqueueJob({ resource: "transactions" });
+  assert.equal(missing.status, 400);
+  assert.equal(missing.body.error, "format_required");
+  assert.deepEqual(missing.body.allowedFormats, ["csv", "json"]);
+
+  const unsupported = await enqueueJob({ format: "xlsx" });
+  assert.equal(unsupported.status, 400);
+  assert.equal(unsupported.body.error, "unsupported_format");
+  assert.equal(unsupported.body.format, "xlsx");
+
+  const wrongType = await enqueueJob({ format: 7 });
+  assert.equal(wrongType.status, 400);
+  assert.equal(wrongType.body.error, "invalid_format");
+
+  const badResource = await enqueueJob({ format: "csv", resource: 12 });
+  assert.equal(badResource.status, 400);
+  assert.equal(badResource.body.error, "invalid_resource");
+
+  // Rejected submissions never enter the queue.
+  const afterRejections = await status();
+  assert.equal(afterRejections.body.counts.total, 0);
+
+  // Format matching is case- and whitespace-insensitive, and normalized.
+  const normalized = await enqueueJob({ format: " CSV " });
+  assert.equal(normalized.status, 202);
+  assert.equal(normalized.body.format, "csv");
+}
+
+// --- job lookup and idle/guard cases ---------------------------------------
+{
+  resetQueue();
+
+  const job = await enqueueJob({ format: "json" });
+  const lookup = await handleRequest(makeReq("GET", `/export/jobs/${job.body.jobId}`));
+  assert.equal(lookup.status, 200);
+  assert.equal(lookup.body.jobId, job.body.jobId);
+
+  const unknown = await handleRequest(makeReq("GET", "/export/jobs/exp_9999"));
+  assert.equal(unknown.status, 404);
+  assert.equal(unknown.body.error, "job_not_found");
+
+  await processNextJob();
+  const idle = await processNextJob();
+  assert.equal(idle.status, 409);
+  assert.equal(idle.body.error, "queue_idle");
+
+  const wrongMethod = await handleRequest(makeReq("GET", "/export/enqueue"));
+  assert.equal(wrongMethod.status, 405);
+
+  const badJson = await handleRequest({
+    url: "/export/enqueue",
+    method: "POST",
+    on: (event, cb) => {
+      if (event === "data") cb("{not json");
+      if (event === "end") cb();
+    },
+  });
+  assert.equal(badJson.status, 400);
+  assert.equal(badJson.body.error, "invalid_json");
+
+  const unknownPath = await handleRequest(makeReq("GET", "/nope"));
+  assert.equal(unknownPath.status, 404);
+}
+
+console.log("PASS: export queue enqueues, validates formats and drains FIFO one at a time");


### PR DESCRIPTION
closes #151

## What this adds

A self-contained route suite under `contrib/routes/export-queue-suite/` that queues export jobs with a selected output format and processes them in order, one at a time. All state lives in process memory - no worker process, no storage, no chain access.

- `route.mjs` - the four handlers and the queue itself, plus a small `http` server behind an `import.meta.url` guard so the file is both importable and runnable.
- `route.test.mjs` - a node-only test script, no test runner or dependency required.
- `README.md` - a description of each endpoint, the queue model, and an error table.

## Endpoints

| Method | Path | Purpose |
| --- | --- | --- |
| POST | `/export/enqueue` | Queue a job with a `format` and an optional `resource` |
| POST | `/export/process` | Complete the in-flight job and promote the next one |
| GET | `/export/queue-status` | Snapshot: in-flight job, queued jobs, completed jobs, counts |
| GET | `/export/jobs/:jobId` | A single job, for a client polling one id |

The issue asked for at least enqueue and queue-status; `process` is included because it is what makes the ordering observable (see below), and the single-job lookup is a two-line addition that saves a client from scanning the whole status payload.

## How the queue works

A job is `queued` on arrival. If the single processing slot is free, the head of the queue is promoted to `processing` immediately, so at most one job is ever in flight.

```
enqueue A  ->  [processing: A] [queued: ]
enqueue B  ->  [processing: A] [queued: B]
process    ->  [completed: A]  [processing: B]
process    ->  [completed: A, B]  (idle)
```

Draining is driven explicitly by `POST /export/process` rather than by a timer. That was a deliberate choice: a timer-driven queue can only be tested by sleeping and hoping, whereas an explicit tick makes the FIFO guarantee something a test can assert directly, and it lets a developer step a local queue at their own pace. Each completed job gets an `artifact` naming the file the export would have produced (`transactions-exp_0001.csv`, with a matching content type).

Queued jobs report a 1-based `position`, computed at serialization time so it stays correct as the queue drains.

## Format validation

`format` is validated against `ALLOWED_FORMATS` (`csv`, `json`), which is exported and echoed back in both the error body and the queue-status payload so a client never has to hardcode the list. The value is trimmed and lower-cased before matching, so `" CSV "` is accepted and normalized to `csv`. Missing, wrong-typed, and unsupported values are reported as distinct error codes rather than one generic 400, and a rejected submission never enters the queue - there is a test for that.

## Tests

```sh
node contrib/routes/export-queue-suite/route.test.mjs
# PASS: export queue enqueues, validates formats and drains FIFO one at a time
```

The first case is the one the issue calls for: it enqueues two jobs, asserts the first is `processing` while the second is `queued` at position 1, drains the queue one step at a time, and asserts the completion order matches the enqueue order along with the artifact each job produced. Further cases cover positions shifting as the queue drains, every format-validation branch, single-job lookup, draining an idle queue (`409`), malformed JSON, and the method/path guards.

## Conventions and scope

Follows the existing `contrib/routes/` layout, the `{ status, body }` handler shape, and the snake_case `error` codes used by the neighbouring suites. Default port is `4056`, which does not collide with any module already on `drips`, and `PORT` overrides it.

Every file is inside `contrib/`, and the PR is based on and targets `drips`.
