### PR TITLE
Mock routes: payment build/submit, activity log cursor pagination, verification poll, policy templates

### DIFF
--- a/contrib/routes/issue-57-payment-build-submit/README.md
+++ b/contrib/routes/issue-57-payment-build-submit/README.md
@@ -1,0 +1,96 @@
+# Mock route: payment build + submit (Issue #57)
+
+Standalone mock route module simulating a two-step payment flow: build a
+draft from a payment payload, then submit that draft to get back a fake
+transaction hash. No real chain or database access -- drafts are held in
+an in-memory `Map` that resets whenever the process restarts.
+
+## Run
+
+```sh
+node route.mjs
+# payment-build-submit mock listening on http://localhost:4057/payment/build and /payment/submit/:draftId
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoints
+
+### `POST /payment/build`
+
+Validates `recipient`, `amount`, and `asset`, then returns a draft record
+with a generated `draftId`.
+
+Request:
+
+```
+POST /payment/build
+Content-Type: application/json
+
+{
+  "recipient": "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH",
+  "amount": "25.0000000",
+  "asset": "XLM"
+}
+```
+
+Response (`200`):
+
+```json
+{
+  "draftId": "draft_1a2b3c4d5e6f",
+  "recipient": "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH",
+  "amount": "25.0000000",
+  "asset": "XLM",
+  "status": "built",
+  "createdAt": "2026-07-28T10:00:00.000Z"
+}
+```
+
+Response when a required field is missing (`400`):
+
+```json
+{
+  "error": "invalid_request",
+  "message": "Missing required field(s): amount",
+  "missingFields": ["amount"]
+}
+```
+
+### `POST /payment/submit/:draftId`
+
+Submits a previously built draft and returns a fake transaction hash.
+
+Response (`200`):
+
+```json
+{
+  "draftId": "draft_1a2b3c4d5e6f",
+  "status": "submitted",
+  "txHash": "9f2c...  (64 hex chars)",
+  "submittedAt": "2026-07-28T10:00:05.000Z"
+}
+```
+
+Response for an unknown draft id (`404`):
+
+```json
+{
+  "error": "draft_not_found",
+  "message": "No draft found for draftId \"draft_does_not_exist\""
+}
+```
+
+Response when the same draft is submitted twice (`409`, no double-spend):
+
+```json
+{
+  "error": "already_submitted",
+  "message": "Draft \"draft_1a2b3c4d5e6f\" has already been submitted",
+  "txHash": "9f2c...  (same hash as the first submission)"
+}
+```

--- a/contrib/routes/issue-57-payment-build-submit/route.mjs
+++ b/contrib/routes/issue-57-payment-build-submit/route.mjs
@@ -1,0 +1,151 @@
+// Mock route module simulating a payment build-then-submit flow.
+// POST /payment/build validates a payment payload and returns a draft id.
+// POST /payment/submit/:draftId submits a previously built draft and
+// returns a fake transaction hash. No chain or DB access.
+import http from "node:http";
+import crypto from "node:crypto";
+
+const REQUIRED_FIELDS = ["recipient", "amount", "asset"];
+
+// In-memory draft store, keyed by draftId. Cleared whenever the process
+// restarts -- this is a mock, not a persistence layer.
+const drafts = new Map();
+
+function validatePayload(body = {}) {
+  const missingFields = REQUIRED_FIELDS.filter(
+    (field) => body[field] === undefined || body[field] === null || body[field] === "",
+  );
+  return missingFields;
+}
+
+function makeDraftId() {
+  return `draft_${crypto.randomBytes(6).toString("hex")}`;
+}
+
+function makeTxHash() {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+/**
+ * Builds a mock payment draft.
+ * @param {{body?: object}} input
+ */
+export function handleBuild({ body = {} } = {}) {
+  const missingFields = validatePayload(body);
+  if (missingFields.length > 0) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_request",
+        message: `Missing required field(s): ${missingFields.join(", ")}`,
+        missingFields,
+      },
+    };
+  }
+
+  const draftId = makeDraftId();
+  const draft = {
+    draftId,
+    recipient: body.recipient,
+    amount: body.amount,
+    asset: body.asset,
+    status: "built",
+    createdAt: new Date().toISOString(),
+  };
+  drafts.set(draftId, draft);
+
+  return { status: 200, body: draft };
+}
+
+/**
+ * Submits a previously built draft.
+ * @param {{draftId?: string}} input
+ */
+export function handleSubmit({ draftId } = {}) {
+  const draft = drafts.get(draftId);
+
+  if (!draft) {
+    return {
+      status: 404,
+      body: {
+        error: "draft_not_found",
+        message: `No draft found for draftId "${draftId}"`,
+      },
+    };
+  }
+
+  if (draft.status === "submitted") {
+    return {
+      status: 409,
+      body: {
+        error: "already_submitted",
+        message: `Draft "${draftId}" has already been submitted`,
+        txHash: draft.txHash,
+      },
+    };
+  }
+
+  const txHash = makeTxHash();
+  draft.status = "submitted";
+  draft.txHash = txHash;
+  draft.submittedAt = new Date().toISOString();
+
+  return {
+    status: 200,
+    body: {
+      draftId,
+      status: "submitted",
+      txHash,
+      submittedAt: draft.submittedAt,
+    },
+  };
+}
+
+/** Test-only helper to reset in-memory state between test files/runs. */
+export function _resetDrafts() {
+  drafts.clear();
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/payment/build") {
+      let raw = "";
+      req.on("data", (chunk) => (raw += chunk));
+      req.on("end", () => {
+        let body = {};
+        try {
+          body = raw ? JSON.parse(raw) : {};
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ error: "invalid_json", message: "Request body must be valid JSON" }),
+          );
+          return;
+        }
+        const { status, body: responseBody } = handleBuild({ body });
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(responseBody));
+      });
+      return;
+    }
+
+    const submitMatch = req.url.match(/^\/payment\/submit\/([^/]+)$/);
+    if (req.method === "POST" && submitMatch) {
+      const draftId = decodeURIComponent(submitMatch[1]);
+      const { status, body: responseBody } = handleSubmit({ draftId });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(responseBody));
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4057;
+  server.listen(port, () => {
+    console.log(
+      `payment-build-submit mock listening on http://localhost:${port}/payment/build and /payment/submit/:draftId`,
+    );
+  });
+}

--- a/contrib/routes/issue-57-payment-build-submit/route.test.mjs
+++ b/contrib/routes/issue-57-payment-build-submit/route.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { handleBuild, handleSubmit, _resetDrafts } from "./route.mjs";
+
+_resetDrafts();
+
+// Build: success case.
+const built = handleBuild({
+  body: {
+    recipient: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH",
+    amount: "25.0000000",
+    asset: "XLM",
+  },
+});
+assert.equal(built.status, 200);
+assert.equal(built.body.status, "built");
+assert.ok(built.body.draftId.startsWith("draft_"));
+
+// Build: missing required field.
+const missingAmount = handleBuild({
+  body: { recipient: "GABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH", asset: "XLM" },
+});
+assert.equal(missingAmount.status, 400);
+assert.equal(missingAmount.body.error, "invalid_request");
+assert.deepEqual(missingAmount.body.missingFields, ["amount"]);
+
+// Submit: unknown draft id returns a 404-style payload.
+const unknownSubmit = handleSubmit({ draftId: "draft_does_not_exist" });
+assert.equal(unknownSubmit.status, 404);
+assert.equal(unknownSubmit.body.error, "draft_not_found");
+
+// Full sequence: build then submit the same draft.
+const draft = handleBuild({
+  body: {
+    recipient: "GXYZ9876543210ZYXWVUTSRQPONMLKJIHGFEDCBA0987654321ZYXWVUTS",
+    amount: "100.5000000",
+    asset: "USDC",
+  },
+});
+assert.equal(draft.status, 200);
+
+const submitted = handleSubmit({ draftId: draft.body.draftId });
+assert.equal(submitted.status, 200);
+assert.equal(submitted.body.status, "submitted");
+assert.equal(submitted.body.draftId, draft.body.draftId);
+assert.match(submitted.body.txHash, /^[0-9a-f]{64}$/);
+
+// Submitting the same draft again is rejected, not silently re-submitted.
+const resubmitted = handleSubmit({ draftId: draft.body.draftId });
+assert.equal(resubmitted.status, 409);
+assert.equal(resubmitted.body.error, "already_submitted");
+assert.equal(resubmitted.body.txHash, submitted.body.txHash);
+
+console.log("PASS: payment build-then-submit flow (success, validation, 404, idempotency)");

--- a/contrib/routes/issue-59-activity-log-cursor/README.md
+++ b/contrib/routes/issue-59-activity-log-cursor/README.md
@@ -1,0 +1,75 @@
+# Mock route: activity log with cursor pagination (Issue #59)
+
+Standalone mock GET route returning a cursor-paginated list of sample
+activity log entries. No real chain or database access -- 18 entries are
+hardcoded in-module, newest first.
+
+## Run
+
+```sh
+node route.mjs
+# activity-log-cursor mock listening on http://localhost:4059/activity-log?cursor=&limit=
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoint
+
+### `GET /activity-log?cursor=&limit=`
+
+- `cursor` -- the `id` of the last entry already seen; omit for the first
+  page. An unrecognized/stale cursor restarts pagination from the
+  beginning rather than erroring.
+- `limit` -- page size, default `5`, clamped to a max of `50`. Invalid
+  values (non-integer, `< 1`) fall back to the default.
+
+Response (`200`):
+
+```json
+{
+  "items": [
+    { "id": "act_018", "type": "payment_sent", "summary": "Sent 25 XLM to GABCD...FGH", "timestamp": "2026-07-28T09:45:00.000Z" },
+    { "id": "act_017", "type": "policy_updated", "summary": "Updated spending-limit policy pol_1001", "timestamp": "2026-07-28T09:30:00.000Z" },
+    { "id": "act_016", "type": "payment_received", "summary": "Received 100 USDC from GXYZ9...WVU", "timestamp": "2026-07-28T09:10:00.000Z" },
+    { "id": "act_015", "type": "session_started", "summary": "New session started from Chrome/macOS", "timestamp": "2026-07-28T08:55:00.000Z" },
+    { "id": "act_014", "type": "trustline_added", "summary": "Added trustline for AQUA", "timestamp": "2026-07-27T22:40:00.000Z" }
+  ],
+  "nextCursor": "act_014"
+}
+```
+
+The last page (nothing left to fetch) has `"nextCursor": null`:
+
+```
+GET /activity-log?cursor=act_002&limit=5
+```
+
+```json
+{
+  "items": [
+    { "id": "act_001", "type": "wallet_created", "summary": "Wallet created", "timestamp": "2026-07-23T10:00:00.000Z" }
+  ],
+  "nextCursor": null
+}
+```
+
+## Walking every page
+
+```js
+let cursor;
+const all = [];
+do {
+  const res = await fetch(`http://localhost:4059/activity-log?limit=5${cursor ? `&cursor=${cursor}` : ""}`);
+  const { items, nextCursor } = await res.json();
+  all.push(...items);
+  cursor = nextCursor;
+} while (cursor);
+```
+
+`route.test.mjs` exercises exactly this loop against `handleRequest`
+directly and asserts all 18 entries are visited exactly once with no
+gaps or duplicates.

--- a/contrib/routes/issue-59-activity-log-cursor/route.mjs
+++ b/contrib/routes/issue-59-activity-log-cursor/route.mjs
@@ -1,0 +1,181 @@
+// Mock GET route returning a cursor-paginated list of sample activity log
+// entries. No chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 50;
+
+// 18 hardcoded sample entries, ordered newest-first like a real activity
+// feed. Ids are used as opaque cursors -- a real backend would likely use
+// a timestamp or a base64-encoded composite key, but a plain id is
+// sufficient for a mock and keeps the example easy to read.
+const ENTRIES = [
+  {
+    id: "act_018",
+    type: "payment_sent",
+    summary: "Sent 25 XLM to GABCD...FGH",
+    timestamp: "2026-07-28T09:45:00.000Z",
+  },
+  {
+    id: "act_017",
+    type: "policy_updated",
+    summary: "Updated spending-limit policy pol_1001",
+    timestamp: "2026-07-28T09:30:00.000Z",
+  },
+  {
+    id: "act_016",
+    type: "payment_received",
+    summary: "Received 100 USDC from GXYZ9...WVU",
+    timestamp: "2026-07-28T09:10:00.000Z",
+  },
+  {
+    id: "act_015",
+    type: "session_started",
+    summary: "New session started from Chrome/macOS",
+    timestamp: "2026-07-28T08:55:00.000Z",
+  },
+  {
+    id: "act_014",
+    type: "trustline_added",
+    summary: "Added trustline for AQUA",
+    timestamp: "2026-07-27T22:40:00.000Z",
+  },
+  {
+    id: "act_013",
+    type: "payment_sent",
+    summary: "Sent 5.5 XLM to GDEF12...MNO",
+    timestamp: "2026-07-27T21:15:00.000Z",
+  },
+  {
+    id: "act_012",
+    type: "policy_created",
+    summary: "Created allowlist policy pol_2002",
+    timestamp: "2026-07-27T20:05:00.000Z",
+  },
+  {
+    id: "act_011",
+    type: "account_funded",
+    summary: "Account funded via testnet friendbot",
+    timestamp: "2026-07-27T18:30:00.000Z",
+  },
+  {
+    id: "act_010",
+    type: "payment_received",
+    summary: "Received 42 XLM from GHIJ34...PQR",
+    timestamp: "2026-07-27T16:20:00.000Z",
+  },
+  {
+    id: "act_009",
+    type: "session_expired",
+    summary: "Session sess_44a1 expired",
+    timestamp: "2026-07-27T12:00:00.000Z",
+  },
+  {
+    id: "act_008",
+    type: "policy_updated",
+    summary: "Paused spending-limit policy pol_1001",
+    timestamp: "2026-07-26T23:10:00.000Z",
+  },
+  {
+    id: "act_007",
+    type: "payment_sent",
+    summary: "Sent 1000 AQUA to GKLM56...STU",
+    timestamp: "2026-07-26T19:45:00.000Z",
+  },
+  {
+    id: "act_006",
+    type: "trustline_removed",
+    summary: "Removed trustline for MOBI",
+    timestamp: "2026-07-26T14:05:00.000Z",
+  },
+  {
+    id: "act_005",
+    type: "policy_created",
+    summary: "Created multi-sig policy pol_3003",
+    timestamp: "2026-07-25T22:50:00.000Z",
+  },
+  {
+    id: "act_004",
+    type: "payment_received",
+    summary: "Received 10 USDT from GNOP78...VWX",
+    timestamp: "2026-07-25T15:30:00.000Z",
+  },
+  {
+    id: "act_003",
+    type: "session_started",
+    summary: "New session started from Firefox/Windows",
+    timestamp: "2026-07-24T09:00:00.000Z",
+  },
+  {
+    id: "act_002",
+    type: "account_funded",
+    summary: "Account funded via testnet friendbot",
+    timestamp: "2026-07-23T11:15:00.000Z",
+  },
+  {
+    id: "act_001",
+    type: "wallet_created",
+    summary: "Wallet created",
+    timestamp: "2026-07-23T10:00:00.000Z",
+  },
+];
+
+function parseLimit(raw) {
+  if (raw === undefined || raw === null || raw === "") return DEFAULT_LIMIT;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+/**
+ * `cursor` is the id of the last entry the caller has already seen (i.e.
+ * "give me entries strictly after this one"), or omitted/empty for the
+ * first page. An unrecognized cursor is treated as "start from the
+ * beginning" rather than erroring, since a stale cursor from a page that
+ * no longer exists shouldn't break the caller's pagination loop.
+ */
+function findStartIndex(cursor) {
+  if (!cursor) return 0;
+  const index = ENTRIES.findIndex((entry) => entry.id === cursor);
+  return index === -1 ? 0 : index + 1;
+}
+
+export function handleRequest({ query = {} } = {}) {
+  const limit = parseLimit(query.limit);
+  const startIndex = findStartIndex(query.cursor);
+
+  const items = ENTRIES.slice(startIndex, startIndex + limit);
+  const nextIndex = startIndex + items.length;
+  const nextCursor = nextIndex < ENTRIES.length ? (items[items.length - 1]?.id ?? null) : null;
+
+  return {
+    status: 200,
+    body: {
+      items,
+      nextCursor,
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/activity-log") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleRequest({ query });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4059;
+  server.listen(port, () => {
+    console.log(
+      `activity-log-cursor mock listening on http://localhost:${port}/activity-log?cursor=&limit=`,
+    );
+  });
+}

--- a/contrib/routes/issue-59-activity-log-cursor/route.test.mjs
+++ b/contrib/routes/issue-59-activity-log-cursor/route.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// First page: no cursor, default limit.
+const page1 = handleRequest({ query: {} });
+assert.equal(page1.status, 200);
+assert.equal(page1.body.items.length, 5);
+assert.equal(page1.body.items[0].id, "act_018");
+assert.ok(page1.body.nextCursor, "first page should have a nextCursor");
+
+// Custom limit is respected.
+const smallPage = handleRequest({ query: { limit: "3" } });
+assert.equal(smallPage.body.items.length, 3);
+assert.equal(smallPage.body.nextCursor, smallPage.body.items[2].id);
+
+// Limit is clamped to a sane minimum for invalid input.
+const invalidLimit = handleRequest({ query: { limit: "0" } });
+assert.equal(invalidLimit.body.items.length, 5);
+
+// An unrecognized cursor restarts pagination from the beginning rather
+// than erroring.
+const staleCursor = handleRequest({ query: { cursor: "act_does_not_exist" } });
+assert.equal(staleCursor.body.items[0].id, "act_018");
+
+// Walk every page to the end using the cursor from the previous response,
+// collecting every entry seen along the way.
+let cursor;
+let pages = 0;
+const seenIds = [];
+let last;
+do {
+  last = handleRequest({ query: { cursor, limit: "5" } });
+  assert.equal(last.status, 200);
+  for (const entry of last.body.items) seenIds.push(entry.id);
+  cursor = last.body.nextCursor;
+  pages += 1;
+  assert.ok(pages < 100, "pagination loop did not terminate");
+} while (cursor);
+
+// All 18 entries were visited exactly once, in order, with no gaps or
+// duplicates, and the final page's nextCursor was null.
+assert.equal(seenIds.length, 18);
+assert.equal(new Set(seenIds).size, 18, "no duplicate entries across pages");
+assert.equal(last.body.nextCursor, null);
+assert.equal(pages, 4); // 5 + 5 + 5 + 3
+
+console.log(
+  `PASS: activity log paginates through all ${seenIds.length} entries across ${pages} pages`,
+);

--- a/contrib/routes/issue-63-verification-poll/README.md
+++ b/contrib/routes/issue-63-verification-poll/README.md
@@ -1,0 +1,78 @@
+# Mock route: verification submit + poll (Issue #63)
+
+Standalone mock route module simulating contract verification: submit a
+contract address to start a mock verification job, then poll the job
+until it resolves. No real chain or database access -- jobs are held in
+an in-memory `Map` that resets whenever the process restarts.
+
+## Run
+
+```sh
+node route.mjs
+# verification-poll mock listening on http://localhost:4063/verification/submit and /verification/status/:jobId
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoints
+
+### `POST /verification/submit`
+
+Starts a new verification job in the `pending` state.
+
+Request:
+
+```
+POST /verification/submit
+Content-Type: application/json
+
+{ "contractAddress": "CABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH" }
+```
+
+Response (`200`):
+
+```json
+{ "jobId": "job_1a2b3c4d5e6f", "status": "pending" }
+```
+
+### `GET /verification/status/:jobId`
+
+Polls a job's status. To simulate real-world verification delay, a
+`pending` job transitions to `verified` only after being polled **3
+times** -- the first two polls report `pending`, the third (and every
+subsequent) reports `verified`. The transition is one-way: once
+`verified`, further polls stay `verified` with the same `verifiedAt`.
+
+Response while pending (`200`):
+
+```json
+{ "jobId": "job_1a2b3c4d5e6f", "status": "pending", "pollCount": 1 }
+```
+
+Response once resolved (`200`):
+
+```json
+{
+  "jobId": "job_1a2b3c4d5e6f",
+  "status": "verified",
+  "pollCount": 3,
+  "verifiedAt": "2026-07-28T10:00:06.000Z"
+}
+```
+
+Response for an unknown job id (`404`):
+
+```json
+{
+  "error": "job_not_found",
+  "message": "No verification job found for jobId \"job_does_not_exist\""
+}
+```
+
+`route.test.mjs` submits a job and polls in a loop until it resolves,
+asserting it takes exactly 3 polls and that the state stays `verified`
+afterward.

--- a/contrib/routes/issue-63-verification-poll/route.mjs
+++ b/contrib/routes/issue-63-verification-poll/route.mjs
@@ -1,0 +1,138 @@
+// Mock route module simulating contract verification submission and
+// polling. POST /verification/submit starts a pending job; GET
+// /verification/status/:jobId transitions it to "verified" after a fixed
+// number of polls, to simulate a slow off-chain verification process. No
+// chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+import crypto from "node:crypto";
+
+// The job flips from "pending" to "verified" once it has been polled this
+// many times (inclusive of the poll that crosses the threshold).
+const POLLS_UNTIL_VERIFIED = 3;
+
+// In-memory job store, keyed by jobId. Cleared on process restart.
+const jobs = new Map();
+
+function makeJobId() {
+  return `job_${crypto.randomBytes(6).toString("hex")}`;
+}
+
+/**
+ * Submits a contract for mock verification.
+ * @param {{body?: object}} input
+ */
+export function handleSubmit({ body = {} } = {}) {
+  if (!body.contractAddress) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_request",
+        message: "Missing required field: contractAddress",
+      },
+    };
+  }
+
+  const jobId = makeJobId();
+  jobs.set(jobId, {
+    jobId,
+    contractAddress: body.contractAddress,
+    status: "pending",
+    pollCount: 0,
+    createdAt: new Date().toISOString(),
+  });
+
+  return {
+    status: 200,
+    body: { jobId, status: "pending" },
+  };
+}
+
+/**
+ * Polls a verification job. Each call to a still-pending job increments
+ * its internal poll counter; once the counter reaches
+ * POLLS_UNTIL_VERIFIED, the job transitions to "verified" and stays there
+ * for every subsequent poll (the transition is one-way).
+ * @param {{jobId?: string}} input
+ */
+export function handlePoll({ jobId } = {}) {
+  const job = jobs.get(jobId);
+
+  if (!job) {
+    return {
+      status: 404,
+      body: {
+        error: "job_not_found",
+        message: `No verification job found for jobId "${jobId}"`,
+      },
+    };
+  }
+
+  if (job.status === "pending") {
+    job.pollCount += 1;
+    if (job.pollCount >= POLLS_UNTIL_VERIFIED) {
+      job.status = "verified";
+      job.verifiedAt = new Date().toISOString();
+    }
+  }
+
+  return {
+    status: 200,
+    body: {
+      jobId: job.jobId,
+      status: job.status,
+      pollCount: job.pollCount,
+      ...(job.status === "verified" ? { verifiedAt: job.verifiedAt } : {}),
+    },
+  };
+}
+
+/** Test-only helper to reset in-memory state between test files/runs. */
+export function _resetJobs() {
+  jobs.clear();
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/verification/submit") {
+      let raw = "";
+      req.on("data", (chunk) => (raw += chunk));
+      req.on("end", () => {
+        let body = {};
+        try {
+          body = raw ? JSON.parse(raw) : {};
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ error: "invalid_json", message: "Request body must be valid JSON" }),
+          );
+          return;
+        }
+        const { status, body: responseBody } = handleSubmit({ body });
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(responseBody));
+      });
+      return;
+    }
+
+    const url = new URL(req.url, "http://localhost");
+    const pollMatch = url.pathname.match(/^\/verification\/status\/([^/]+)$/);
+    if (req.method === "GET" && pollMatch) {
+      const jobId = decodeURIComponent(pollMatch[1]);
+      const { status, body } = handlePoll({ jobId });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4063;
+  server.listen(port, () => {
+    console.log(
+      `verification-poll mock listening on http://localhost:${port}/verification/submit and /verification/status/:jobId`,
+    );
+  });
+}

--- a/contrib/routes/issue-63-verification-poll/route.test.mjs
+++ b/contrib/routes/issue-63-verification-poll/route.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { handleSubmit, handlePoll, _resetJobs } from "./route.mjs";
+
+_resetJobs();
+
+// Submit: missing required field.
+const missingAddress = handleSubmit({ body: {} });
+assert.equal(missingAddress.status, 400);
+assert.equal(missingAddress.body.error, "invalid_request");
+
+// Submit: success, job starts pending.
+const submitted = handleSubmit({
+  body: { contractAddress: "CABCD1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGH" },
+});
+assert.equal(submitted.status, 200);
+assert.equal(submitted.body.status, "pending");
+assert.ok(submitted.body.jobId.startsWith("job_"));
+
+// Poll: unknown job id.
+const unknownPoll = handlePoll({ jobId: "job_does_not_exist" });
+assert.equal(unknownPoll.status, 404);
+assert.equal(unknownPoll.body.error, "job_not_found");
+
+// Poll repeatedly until the job resolves to "verified", per the
+// requirement that this takes a fixed number of calls (simulated delay).
+const jobId = submitted.body.jobId;
+let last;
+let polls = 0;
+do {
+  last = handlePoll({ jobId });
+  polls += 1;
+  assert.ok(polls <= 10, "job did not verify within a reasonable number of polls");
+} while (last.body.status !== "verified");
+
+assert.equal(last.body.status, "verified");
+assert.equal(polls, 3, "job should verify after exactly 3 polls");
+assert.ok(last.body.verifiedAt);
+
+// Polling again after verification stays verified (one-way transition)
+// and keeps the same verifiedAt timestamp.
+const afterVerified = handlePoll({ jobId });
+assert.equal(afterVerified.body.status, "verified");
+assert.equal(afterVerified.body.verifiedAt, last.body.verifiedAt);
+
+console.log(`PASS: verification job submitted, polled ${polls}x, resolved to verified`);

--- a/contrib/routes/issue-64-policy-templates/README.md
+++ b/contrib/routes/issue-64-policy-templates/README.md
@@ -1,0 +1,73 @@
+# Mock route: policy templates with parameter schemas (Issue #64)
+
+Standalone mock GET route returning a fixed list of sample policy
+templates, each with a schema describing its configurable parameters. No
+real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# policy-templates mock listening on http://localhost:4064/policy-templates
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoint
+
+### `GET /policy-templates`
+
+Response (`200`):
+
+```json
+{
+  "templates": [
+    {
+      "id": "tpl_spending_limit",
+      "name": "spending-limit",
+      "description": "Caps the total amount that can be spent within a rolling time window.",
+      "parameters": [
+        { "name": "maxAmount", "type": "string", "required": true },
+        { "name": "asset", "type": "string", "required": true },
+        { "name": "windowSeconds", "type": "number", "required": true }
+      ]
+    },
+    {
+      "id": "tpl_allowlist",
+      "name": "allowlist",
+      "description": "Restricts outgoing payments to a fixed set of pre-approved recipient addresses.",
+      "parameters": [
+        { "name": "allowedRecipients", "type": "string[]", "required": true },
+        { "name": "allowUnlistedBelow", "type": "string", "required": false }
+      ]
+    },
+    {
+      "id": "tpl_multisig",
+      "name": "multisig",
+      "description": "Requires a minimum number of signer approvals before a transaction is executed.",
+      "parameters": [
+        { "name": "signers", "type": "string[]", "required": true },
+        { "name": "threshold", "type": "number", "required": true }
+      ]
+    },
+    {
+      "id": "tpl_time_lock",
+      "name": "time-lock",
+      "description": "Delays execution of a transaction until a specified time has elapsed.",
+      "parameters": [
+        { "name": "delaySeconds", "type": "number", "required": true },
+        { "name": "cancellable", "type": "boolean", "required": false }
+      ]
+    }
+  ]
+}
+```
+
+`route.test.mjs` verifies every template has an `id`, a `name`, and a
+non-empty `parameters` array where each parameter has a non-empty `name`,
+a recognized `type` (`string`, `number`, `boolean`, `string[]`,
+`number[]`), and a boolean `required` field.

--- a/contrib/routes/issue-64-policy-templates/route.mjs
+++ b/contrib/routes/issue-64-policy-templates/route.mjs
@@ -1,0 +1,66 @@
+// Mock GET route returning a fixed list of sample policy templates, each
+// describing its configurable parameters via a schema. No chain or DB
+// access.
+import http from "node:http";
+
+const TEMPLATES = [
+  {
+    id: "tpl_spending_limit",
+    name: "spending-limit",
+    description: "Caps the total amount that can be spent within a rolling time window.",
+    parameters: [
+      { name: "maxAmount", type: "string", required: true },
+      { name: "asset", type: "string", required: true },
+      { name: "windowSeconds", type: "number", required: true },
+    ],
+  },
+  {
+    id: "tpl_allowlist",
+    name: "allowlist",
+    description: "Restricts outgoing payments to a fixed set of pre-approved recipient addresses.",
+    parameters: [
+      { name: "allowedRecipients", type: "string[]", required: true },
+      { name: "allowUnlistedBelow", type: "string", required: false },
+    ],
+  },
+  {
+    id: "tpl_multisig",
+    name: "multisig",
+    description: "Requires a minimum number of signer approvals before a transaction is executed.",
+    parameters: [
+      { name: "signers", type: "string[]", required: true },
+      { name: "threshold", type: "number", required: true },
+    ],
+  },
+  {
+    id: "tpl_time_lock",
+    name: "time-lock",
+    description: "Delays execution of a transaction until a specified time has elapsed.",
+    parameters: [
+      { name: "delaySeconds", type: "number", required: true },
+      { name: "cancellable", type: "boolean", required: false },
+    ],
+  },
+];
+
+export function handleRequest() {
+  return { status: 200, body: { templates: TEMPLATES } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/policy-templates") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4064;
+  server.listen(port, () => {
+    console.log(`policy-templates mock listening on http://localhost:${port}/policy-templates`);
+  });
+}

--- a/contrib/routes/issue-64-policy-templates/route.test.mjs
+++ b/contrib/routes/issue-64-policy-templates/route.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const VALID_TYPES = new Set(["string", "number", "boolean", "string[]", "number[]"]);
+
+const result = handleRequest();
+assert.equal(result.status, 200);
+
+const { templates } = result.body;
+assert.ok(Array.isArray(templates), "templates should be an array");
+assert.ok(templates.length >= 3, "at least 3 templates are required");
+
+// The three templates named explicitly in the issue must be present.
+const names = templates.map((t) => t.name);
+for (const required of ["spending-limit", "allowlist", "multisig"]) {
+  assert.ok(names.includes(required), `expected template "${required}" to be present`);
+}
+
+// Every template must have a well-formed parameters array: each entry has
+// a non-empty string name, a recognized type, and a boolean required flag.
+for (const template of templates) {
+  assert.ok(template.id, `template "${template.name}" is missing an id`);
+  assert.ok(template.name, "template is missing a name");
+  assert.ok(
+    Array.isArray(template.parameters),
+    `template "${template.name}" parameters must be an array`,
+  );
+  assert.ok(
+    template.parameters.length > 0,
+    `template "${template.name}" must have at least one parameter`,
+  );
+
+  for (const param of template.parameters) {
+    assert.equal(typeof param.name, "string");
+    assert.ok(param.name.length > 0, `parameter in "${template.name}" has an empty name`);
+    assert.ok(
+      VALID_TYPES.has(param.type),
+      `parameter "${param.name}" in "${template.name}" has an unrecognized type "${param.type}"`,
+    );
+    assert.equal(
+      typeof param.required,
+      "boolean",
+      `parameter "${param.name}" in "${template.name}" must have a boolean "required" field`,
+    );
+  }
+}
+
+console.log(`PASS: all ${templates.length} policy templates have a valid parameters array`);


### PR DESCRIPTION
## Summary

Four self-contained mock route modules under `contrib/routes/`, per issues #57, #59, #63, #64. Each is plain Node.js (no framework, no build step), matching the existing modules in this folder.

- **#57 — `contrib/routes/issue-57-payment-build-submit/`**: `POST /payment/build` validates recipient/amount/asset and returns a draft id; `POST /payment/submit/:draftId` submits it for a fake tx hash. Unknown draft id returns 404; double-submit returns 409 with the original hash rather than minting a new one.
- **#59 — `contrib/routes/issue-59-activity-log-cursor/`**: `GET /activity-log?cursor=&limit=` returns cursor-paginated sample activity entries (18 hardcoded, newest-first) with a `nextCursor` field, null on the last page.
- **#63 — `contrib/routes/issue-63-verification-poll/`**: `POST /verification/submit` starts a pending job; `GET /verification/status/:jobId` transitions it to `verified` after exactly 3 polls, simulating delay.
- **#64 — `contrib/routes/issue-64-policy-templates/`**: `GET /policy-templates` returns 4 sample templates (spending-limit, allowlist, multisig, time-lock), each with a `parameters` array describing name/type/required.

## Testing

- Each module has a `route.test.mjs` (run via `node route.test.mjs`), all passing:
  - #57: full build-then-submit sequence, missing-field validation, unknown-draftId 404, double-submit 409.
  - #59: walks every page via the cursor to the end, asserting all 18 entries are visited exactly once with no gaps/duplicates and the last page's `nextCursor` is `null`.
  - #63: polls in a loop until the job resolves, asserting it takes exactly 3 polls and stays `verified` afterward.
  - #64: asserts the three explicitly-named templates are present and every template's `parameters` array is well-formed.
- Also smoke-tested each module's standalone `node route.mjs` HTTP server via `curl` against every endpoint.
- `npx prettier --check` run against all new files (repo's `.prettierrc`), formatting issues fixed.

## Scope confirmation

Every changed file is under `contrib/routes/` (verified via `git diff --name-only`) — nothing outside `contrib/` was touched, per the constraints.

Closes #57
Closes #59
Closes #63
Closes #64