### PR TITLE
feat: Add mock route modules for wallet and merge eligibility flows

### DIFF
--- a/contrib/routes/cleanup-plan-steps/README.md
+++ b/contrib/routes/cleanup-plan-steps/README.md
@@ -1,0 +1,92 @@
+# Cleanup Plan Steps Mock Route
+
+A self-contained mock route module that generates a cleanup plan for accounts, returning an ordered list of steps to resolve blockers.
+
+## Overview
+
+This module provides a mock implementation of cleanup planning that returns a structured set of steps an account owner must complete to resolve merge blockers. Steps are ordered and include type and description information.
+
+## Step Types
+
+Step types classify the action needed to resolve a blocker:
+
+- `CLOSE_TRUSTLINE` - Close an open trustline
+- `CANCEL_OFFER` - Cancel a pending offer
+- `RELEASE_ESCROW` - Release an escrow entry
+- `DISABLE_CLAWBACK` - Disable clawback on issued assets
+- `VERIFY_SEQUENCE` - Verify and clear pending sequence operations
+- `FINALIZE` - Final verification step before merge
+
+## API
+
+### `getCleanupPlan(accountId: string): CleanupPlan`
+
+Retrieves the cleanup plan for an account.
+
+**Parameters:**
+
+- `accountId`: The account ID to get the cleanup plan for
+
+**Returns:**
+
+```typescript
+{
+  accountId: string;
+  steps: Step[];
+}
+
+interface Step {
+  order: number;
+  type: string;
+  description: string;
+}
+```
+
+## Usage
+
+```typescript
+import { getCleanupPlan } from "./planner";
+
+const plan = getCleanupPlan("GAAA...");
+console.log(plan);
+// {
+//   accountId: 'GAAA...',
+//   steps: [
+//     { order: 1, type: 'CLOSE_TRUSTLINE', description: '...' },
+//     { order: 2, type: 'CANCEL_OFFER', description: '...' },
+//     { order: 3, type: 'FINALIZE', description: '...' }
+//   ]
+// }
+```
+
+## Sample Accounts
+
+### Account 1: GAAA... (Simple cleanup)
+
+- 1 open trustline to close
+- 1 pending offer to cancel
+- Final verification
+- Total: 3 steps
+
+### Account 2: GBBB... (Complex cleanup)
+
+- 2 open trustlines to close
+- 2 pending offers to cancel
+- 1 escrow entry to release
+- Clawback to disable
+- Final verification
+- Total: 6 steps
+
+## Running Tests
+
+```bash
+npm test
+# or
+pnpm test
+```
+
+This runs `test.ts` which validates:
+
+- Plans are returned for valid accounts
+- Steps are ordered sequentially
+- All steps are present for each account

--- a/contrib/routes/cleanup-plan-steps/package.json
+++ b/contrib/routes/cleanup-plan-steps/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cleanup-plan-steps",
+  "version": "1.0.0",
+  "description": "Mock route module for cleanup plans with blocker resolution steps",
+  "private": true,
+  "scripts": {
+    "test": "node --loader tsx ./test.ts",
+    "test:check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/contrib/routes/cleanup-plan-steps/planner.ts
+++ b/contrib/routes/cleanup-plan-steps/planner.ts
@@ -1,0 +1,95 @@
+/**
+ * Cleanup plan generator
+ * Creates ordered cleanup steps for accounts to resolve merge blockers
+ */
+
+import type { CleanupPlan, Step } from "./types";
+import { STEP_TYPES } from "./types";
+
+/**
+ * Generates a cleanup plan for the given account ID
+ * @param accountId The account ID to generate a cleanup plan for
+ * @returns CleanupPlan with ordered steps
+ */
+export function getCleanupPlan(accountId: string): CleanupPlan {
+  const plans: Record<string, Step[]> = {
+    GAAA2B3GRZL6XWDPJ5L3HVPFQY6A3OKDKDKJQJQJQJQJQJQJQJQJQJQJQJQJQ: [
+      {
+        order: 1,
+        type: STEP_TYPES.CLOSE_TRUSTLINE,
+        description:
+          "Close trustline to USD issued by GBUQWP3BOUZX34TOLXCI35FQ7KQJH3P25PMMOMQ5J2MABG3HQZPX5YHK",
+      },
+      {
+        order: 2,
+        type: STEP_TYPES.CANCEL_OFFER,
+        description: "Cancel pending offer #123 (selling native for USD)",
+      },
+      {
+        order: 3,
+        type: STEP_TYPES.FINALIZE,
+        description: "Verify all cleanup steps completed and account is ready for merge",
+      },
+    ],
+    GBBB2B3GRZL6XWDPJ5L3HVPFQY6A3OKDKDKJQJQJQJQJQJQJQJQJQJQJQJQJQ: [
+      {
+        order: 1,
+        type: STEP_TYPES.CLOSE_TRUSTLINE,
+        description:
+          "Close trustline to USD issued by GBUQWP3BOUZX34TOLXCI35FQ7KQJH3P25PMMOMQ5J2MABG3HQZPX5YHK (balance: 100.50)",
+      },
+      {
+        order: 2,
+        type: STEP_TYPES.CLOSE_TRUSTLINE,
+        description:
+          "Close trustline to EUR issued by GDGU6VM5PSPZTHTFIUYJQMTHEGYLOQJQJQJQJQJQJQJQJQJQJQJQJQJQJQ (balance: 50.25)",
+      },
+      {
+        order: 3,
+        type: STEP_TYPES.CANCEL_OFFER,
+        description: "Cancel pending offer #123 (selling native for USD)",
+      },
+      {
+        order: 4,
+        type: STEP_TYPES.CANCEL_OFFER,
+        description: "Cancel pending offer #456 (selling EUR for native)",
+      },
+      {
+        order: 5,
+        type: STEP_TYPES.RELEASE_ESCROW,
+        description: "Release escrow entry #escrow-456 (amount: 1000.00)",
+      },
+      {
+        order: 6,
+        type: STEP_TYPES.DISABLE_CLAWBACK,
+        description: "Disable clawback on all issued assets",
+      },
+      {
+        order: 7,
+        type: STEP_TYPES.FINALIZE,
+        description: "Verify all cleanup steps completed and account is ready for merge",
+      },
+    ],
+  };
+
+  const steps = plans[accountId] || [];
+
+  return {
+    accountId,
+    steps,
+  };
+}
+
+/**
+ * Validates that steps in a plan are properly ordered
+ * @param plan The cleanup plan to validate
+ * @returns true if steps are in correct sequential order
+ */
+export function validateStepOrder(plan: CleanupPlan): boolean {
+  for (let i = 0; i < plan.steps.length; i++) {
+    if (plan.steps[i].order !== i + 1) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/contrib/routes/cleanup-plan-steps/sample-accounts.ts
+++ b/contrib/routes/cleanup-plan-steps/sample-accounts.ts
@@ -1,0 +1,29 @@
+/**
+ * Sample account IDs for testing cleanup plans
+ */
+
+/**
+ * Sample Account 1: Simple cleanup
+ * ID: GAAA2B3GRZL6XWDPJ5L3HVPFQY6A3OKDKDKJQJQJQJQJQJQJQJQJQJQJQJQJQ
+ *
+ * Plan:
+ * - Close 1 trustline
+ * - Cancel 1 offer
+ * - Final verification
+ * Total: 3 steps
+ */
+export const simpleAccountId = "GAAA2B3GRZL6XWDPJ5L3HVPFQY6A3OKDKDKJQJQJQJQJQJQJQJQJQJQJQJQJQ";
+
+/**
+ * Sample Account 2: Complex cleanup
+ * ID: GBBB2B3GRZL6XWDPJ5L3HVPFQY6A3OKDKDKJQJQJQJQJQJQJQJQJQJQJQJQJQ
+ *
+ * Plan:
+ * - Close 2 trustlines
+ * - Cancel 2 offers
+ * - Release 1 escrow entry
+ * - Disable clawback
+ * - Final verification
+ * Total: 7 steps
+ */
+export const complexAccountId = "GBBB2B3GRZL6XWDPJ5L3HVPFQY6A3OKDKDKJQJQJQJQJQJQJQJQJQJQJQJQJQ";

--- a/contrib/routes/cleanup-plan-steps/test.ts
+++ b/contrib/routes/cleanup-plan-steps/test.ts
@@ -1,0 +1,93 @@
+/**
+ * Test suite for cleanup plan generator
+ * Validates that plans are generated correctly and steps are properly ordered
+ */
+
+import { getCleanupPlan, validateStepOrder } from "./planner";
+import { simpleAccountId, complexAccountId } from "./sample-accounts";
+import { STEP_TYPES } from "./types";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    console.error(`❌ FAILED: ${message}`);
+    process.exit(1);
+  }
+  console.log(`✓ ${message}`);
+}
+
+function runTests(): void {
+  console.log("🧪 Running cleanup plan tests...\n");
+
+  // Test 1: Simple account plan
+  console.log("Test 1: Simple Account Cleanup Plan");
+  const simplePlan = getCleanupPlan(simpleAccountId);
+  assert(simplePlan.accountId === simpleAccountId, "Plan should have correct account ID");
+  assert(simplePlan.steps.length === 3, "Simple plan should have 3 steps");
+  console.log();
+
+  // Test 2: Complex account plan
+  console.log("Test 2: Complex Account Cleanup Plan");
+  const complexPlan = getCleanupPlan(complexAccountId);
+  assert(complexPlan.accountId === complexAccountId, "Plan should have correct account ID");
+  assert(complexPlan.steps.length === 7, "Complex plan should have 7 steps");
+  console.log();
+
+  // Test 3: Steps are ordered sequentially
+  console.log("Test 3: Step Ordering");
+  assert(validateStepOrder(simplePlan), "Simple plan steps should be in correct order");
+  assert(validateStepOrder(complexPlan), "Complex plan steps should be in correct order");
+  console.log();
+
+  // Test 4: All steps have required fields
+  console.log("Test 4: Step Structure");
+  simplePlan.steps.forEach((step, index) => {
+    assert(step.order === index + 1, `Step ${index + 1} should have correct order value`);
+    assert(step.type !== "", `Step ${index + 1} should have a type`);
+    assert(step.description !== "", `Step ${index + 1} should have a description`);
+  });
+  console.log();
+
+  // Test 5: Verify step types
+  console.log("Test 5: Step Types");
+  assert(
+    simplePlan.steps[0].type === STEP_TYPES.CLOSE_TRUSTLINE,
+    "First step of simple plan should be CLOSE_TRUSTLINE",
+  );
+  assert(
+    simplePlan.steps[1].type === STEP_TYPES.CANCEL_OFFER,
+    "Second step of simple plan should be CANCEL_OFFER",
+  );
+  assert(simplePlan.steps[2].type === STEP_TYPES.FINALIZE, "Last step should be FINALIZE");
+
+  assert(
+    complexPlan.steps[4].type === STEP_TYPES.RELEASE_ESCROW,
+    "Complex plan should have RELEASE_ESCROW step",
+  );
+  assert(
+    complexPlan.steps[5].type === STEP_TYPES.DISABLE_CLAWBACK,
+    "Complex plan should have DISABLE_CLAWBACK step",
+  );
+  console.log();
+
+  // Test 6: Unknown account returns empty plan
+  console.log("Test 6: Unknown Account Handling");
+  const unknownPlan = getCleanupPlan("GZZZZ...");
+  assert(unknownPlan.steps.length === 0, "Unknown account should return empty steps array");
+  console.log();
+
+  console.log("✅ All tests passed!\n");
+  console.log("Results Summary:");
+  console.log(`\n  Simple Account (${simpleAccountId}):`);
+  console.log(`    - Steps: ${simplePlan.steps.length}`);
+  simplePlan.steps.forEach((step) => {
+    console.log(`      ${step.order}. [${step.type}] ${step.description}`);
+  });
+
+  console.log(`\n  Complex Account (${complexAccountId}):`);
+  console.log(`    - Steps: ${complexPlan.steps.length}`);
+  complexPlan.steps.forEach((step) => {
+    console.log(`      ${step.order}. [${step.type}] ${step.description}`);
+  });
+}
+
+runTests();

--- a/contrib/routes/cleanup-plan-steps/tsconfig.json
+++ b/contrib/routes/cleanup-plan-steps/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "target": "es2022"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/contrib/routes/cleanup-plan-steps/types.ts
+++ b/contrib/routes/cleanup-plan-steps/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Type definitions for cleanup plan generation
+ */
+
+export interface Step {
+  order: number;
+  type: string;
+  description: string;
+}
+
+export interface CleanupPlan {
+  accountId: string;
+  steps: Step[];
+}
+
+/**
+ * Step types for cleanup actions
+ */
+export const STEP_TYPES = {
+  CLOSE_TRUSTLINE: "CLOSE_TRUSTLINE",
+  CANCEL_OFFER: "CANCEL_OFFER",
+  RELEASE_ESCROW: "RELEASE_ESCROW",
+  DISABLE_CLAWBACK: "DISABLE_CLAWBACK",
+  VERIFY_SEQUENCE: "VERIFY_SEQUENCE",
+  FINALIZE: "FINALIZE",
+} as const;
+
+export type StepType = (typeof STEP_TYPES)[keyof typeof STEP_TYPES];

--- a/contrib/routes/merge-eligibility-reasons/README.md
+++ b/contrib/routes/merge-eligibility-reasons/README.md
@@ -1,0 +1,91 @@
+# Merge Eligibility Reasons Mock Route
+
+A self-contained mock route module for checking merge eligibility for accounts and returning structured reason codes when ineligible.
+
+## Overview
+
+This module provides a mock implementation of merge eligibility checks that returns structured reason codes explaining why an account cannot be merged. It's designed to be a standalone utility that can be tested and extended.
+
+## Reason Codes
+
+Reason codes are short, uppercase strings that identify why an account is ineligible for merging:
+
+- `OPEN_TRUSTLINES` - Account has open trustlines that must be closed
+- `PENDING_OFFERS` - Account has pending offers that must be resolved
+- `ESCROW_ENTRIES` - Account has active escrow entries
+- `CLAWBACK_ENABLED` - Account has clawback enabled on issued assets
+- `SEQUENCE_MISMATCH` - Account sequence number indicates pending operations
+
+## API
+
+### `checkMergeEligibility(account: Account): EligibilityResult`
+
+Checks if an account is eligible for merging.
+
+**Parameters:**
+
+- `account`: Account object with id, trustlines, offers, escrow, and clawback properties
+
+**Returns:**
+
+```typescript
+{
+  eligible: boolean;
+  reasons: string[];  // Empty if eligible, populated with reason codes if not
+}
+```
+
+## Usage
+
+```typescript
+import { checkMergeEligibility } from "./checker";
+
+const account = {
+  id: "G...",
+  trustlines: [],
+  offers: [],
+  escrow: [],
+  clawbackEnabled: false,
+};
+
+const result = checkMergeEligibility(account);
+console.log(result);
+// { eligible: true, reasons: [] }
+```
+
+## Sample Accounts
+
+### Account 1: Eligible Account
+
+```
+ID: GAAA
+- No open trustlines
+- No pending offers
+- No escrow entries
+- Clawback disabled
+Result: eligible = true, reasons = []
+```
+
+### Account 2: Ineligible Account
+
+```
+ID: GBBB
+- 2 open trustlines
+- 1 pending offer
+- 1 escrow entry
+Result: eligible = false, reasons = [
+  'OPEN_TRUSTLINES',
+  'PENDING_OFFERS',
+  'ESCROW_ENTRIES'
+]
+```
+
+## Running Tests
+
+```bash
+npm test
+# or
+pnpm test
+```
+
+This runs `test.ts` which validates both sample accounts produce expected results.

--- a/contrib/routes/merge-eligibility-reasons/checker.ts
+++ b/contrib/routes/merge-eligibility-reasons/checker.ts
@@ -1,0 +1,41 @@
+/**
+ * Merge eligibility checker
+ * Validates if an account is eligible for merging and returns reason codes if not
+ */
+
+import type { Account, EligibilityResult, ReasonCode } from "./types";
+import { REASON_CODES } from "./types";
+
+/**
+ * Checks if an account is eligible for merging
+ * @param account The account to check
+ * @returns EligibilityResult with eligible status and reason codes if ineligible
+ */
+export function checkMergeEligibility(account: Account): EligibilityResult {
+  const reasons: ReasonCode[] = [];
+
+  // Check for open trustlines
+  if (account.trustlines.length > 0) {
+    reasons.push(REASON_CODES.OPEN_TRUSTLINES);
+  }
+
+  // Check for pending offers
+  if (account.offers.length > 0) {
+    reasons.push(REASON_CODES.PENDING_OFFERS);
+  }
+
+  // Check for escrow entries
+  if (account.escrow.length > 0) {
+    reasons.push(REASON_CODES.ESCROW_ENTRIES);
+  }
+
+  // Check if clawback is enabled
+  if (account.clawbackEnabled) {
+    reasons.push(REASON_CODES.CLAWBACK_ENABLED);
+  }
+
+  return {
+    eligible: reasons.length === 0,
+    reasons,
+  };
+}

--- a/contrib/routes/merge-eligibility-reasons/package.json
+++ b/contrib/routes/merge-eligibility-reasons/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "merge-eligibility-reasons",
+  "version": "1.0.0",
+  "description": "Mock route module for merge eligibility checks with reason codes",
+  "private": true,
+  "scripts": {
+    "test": "node --loader tsx ./test.ts",
+    "test:check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/contrib/routes/merge-eligibility-reasons/sample-accounts.ts
+++ b/contrib/routes/merge-eligibility-reasons/sample-accounts.ts
@@ -1,0 +1,55 @@
+/**
+ * Sample accounts for testing merge eligibility
+ */
+
+import type { Account } from "./types";
+
+/**
+ * Sample Account 1: Eligible for merging
+ * - No open trustlines
+ * - No pending offers
+ * - No escrow entries
+ * - Clawback disabled
+ */
+export const eligibleAccount: Account = {
+  id: "GAAA2B3GRZL6XWDPJ5L3HVPFQY6A3OKDKDKJQJQJQJQJQJQJQJQJQJQJQJQJQ",
+  trustlines: [],
+  offers: [],
+  escrow: [],
+  clawbackEnabled: false,
+};
+
+/**
+ * Sample Account 2: Ineligible for merging
+ * - 2 open trustlines
+ * - 1 pending offer
+ * - 1 escrow entry
+ * - Clawback disabled (but other issues exist)
+ */
+export const ineligibleAccount: Account = {
+  id: "GBBB2B3GRZL6XWDPJ5L3HVPFQY6A3OKDKDKJQJQJQJQJQJQJQJQJQJQJQJQJQ",
+  trustlines: [
+    {
+      asset: "USD:GBUQWP3BOUZX34TOLXCI35FQ7KQJH3P25PMMOMQ5J2MABG3HQZPX5YHK",
+      balance: "100.50",
+    },
+    {
+      asset: "EUR:GDGU6VM5PSPZTHTFIUYJQMTHEGYLOQJQJQJQJQJQJQJQJQJQJQJQJQJQJQ",
+      balance: "50.25",
+    },
+  ],
+  offers: [
+    {
+      id: "offer-123",
+      selling: "native",
+      buying: "USD:GBUQWP3BOUZX34TOLXCI35FQ7KQJH3P25PMMOMQ5J2MABG3HQZPX5YHK",
+    },
+  ],
+  escrow: [
+    {
+      id: "escrow-456",
+      amount: "1000.00",
+    },
+  ],
+  clawbackEnabled: false,
+};

--- a/contrib/routes/merge-eligibility-reasons/test.ts
+++ b/contrib/routes/merge-eligibility-reasons/test.ts
@@ -1,0 +1,68 @@
+/**
+ * Test suite for merge eligibility checker
+ * Validates that reason codes match expected results for sample accounts
+ */
+
+import { checkMergeEligibility } from "./checker";
+import { eligibleAccount, ineligibleAccount } from "./sample-accounts";
+import { REASON_CODES } from "./types";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    console.error(`❌ FAILED: ${message}`);
+    process.exit(1);
+  }
+  console.log(`✓ ${message}`);
+}
+
+function runTests(): void {
+  console.log("🧪 Running merge eligibility tests...\n");
+
+  // Test 1: Eligible account
+  console.log("Test 1: Eligible Account");
+  const eligibleResult = checkMergeEligibility(eligibleAccount);
+  assert(eligibleResult.eligible === true, "Eligible account should have eligible=true");
+  assert(eligibleResult.reasons.length === 0, "Eligible account should have no reasons");
+  console.log();
+
+  // Test 2: Ineligible account has expected reason codes
+  console.log("Test 2: Ineligible Account");
+  const ineligibleResult = checkMergeEligibility(ineligibleAccount);
+  assert(ineligibleResult.eligible === false, "Ineligible account should have eligible=false");
+  assert(ineligibleResult.reasons.length === 3, "Ineligible account should have 3 reason codes");
+
+  // Test 3: Verify specific reason codes
+  console.log("\nTest 3: Reason Code Validation");
+  assert(
+    ineligibleResult.reasons.includes(REASON_CODES.OPEN_TRUSTLINES),
+    `Should include ${REASON_CODES.OPEN_TRUSTLINES} reason`,
+  );
+  assert(
+    ineligibleResult.reasons.includes(REASON_CODES.PENDING_OFFERS),
+    `Should include ${REASON_CODES.PENDING_OFFERS} reason`,
+  );
+  assert(
+    ineligibleResult.reasons.includes(REASON_CODES.ESCROW_ENTRIES),
+    `Should include ${REASON_CODES.ESCROW_ENTRIES} reason`,
+  );
+
+  // Test 4: Reason codes order is deterministic
+  console.log("\nTest 4: Consistent Results");
+  const secondCheck = checkMergeEligibility(ineligibleAccount);
+  assert(
+    JSON.stringify(ineligibleResult.reasons) === JSON.stringify(secondCheck.reasons),
+    "Same account should produce identical results",
+  );
+
+  console.log("\n✅ All tests passed!\n");
+  console.log("Results Summary:");
+  console.log(`  Eligible Account (${eligibleAccount.id}):`);
+  console.log(`    - Eligible: ${eligibleResult.eligible}`);
+  console.log(`    - Reasons: ${eligibleResult.reasons.join(", ") || "None"}`);
+  console.log();
+  console.log(`  Ineligible Account (${ineligibleAccount.id}):`);
+  console.log(`    - Eligible: ${ineligibleResult.eligible}`);
+  console.log(`    - Reasons: ${ineligibleResult.reasons.join(", ")}`);
+}
+
+runTests();

--- a/contrib/routes/merge-eligibility-reasons/tsconfig.json
+++ b/contrib/routes/merge-eligibility-reasons/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "target": "es2022"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/contrib/routes/merge-eligibility-reasons/types.ts
+++ b/contrib/routes/merge-eligibility-reasons/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Type definitions for merge eligibility checking
+ */
+
+export interface Trustline {
+  asset: string;
+  balance: string;
+}
+
+export interface Offer {
+  id: string;
+  selling: string;
+  buying: string;
+}
+
+export interface EscrowEntry {
+  id: string;
+  amount: string;
+}
+
+export interface Account {
+  id: string;
+  trustlines: Trustline[];
+  offers: Offer[];
+  escrow: EscrowEntry[];
+  clawbackEnabled: boolean;
+}
+
+export interface EligibilityResult {
+  eligible: boolean;
+  reasons: string[];
+}
+
+/**
+ * Reason codes for ineligibility
+ */
+export const REASON_CODES = {
+  OPEN_TRUSTLINES: "OPEN_TRUSTLINES",
+  PENDING_OFFERS: "PENDING_OFFERS",
+  ESCROW_ENTRIES: "ESCROW_ENTRIES",
+  CLAWBACK_ENABLED: "CLAWBACK_ENABLED",
+  SEQUENCE_MISMATCH: "SEQUENCE_MISMATCH",
+} as const;
+
+export type ReasonCode = (typeof REASON_CODES)[keyof typeof REASON_CODES];

--- a/contrib/routes/wallet-create-handshake/README.md
+++ b/contrib/routes/wallet-create-handshake/README.md
@@ -1,0 +1,138 @@
+# Wallet Creation Handshake Mock Route
+
+A self-contained mock route module simulating a two-step handshake for registering and confirming wallet creation.
+
+## Overview
+
+This module provides a mock implementation of a wallet creation flow with a two-step handshake:
+
+1. **Register** - Initiates wallet creation and returns a pending wallet ID with a challenge
+2. **Confirm** - Confirms wallet creation with the pending wallet ID
+
+The handshake ensures that wallet creation follows a predictable, verifiable sequence.
+
+## API
+
+### Register Endpoint
+
+**Function:** `registerWallet()`
+
+Initiates wallet creation and returns a pending wallet ID with a challenge string.
+
+**Returns:**
+
+```typescript
+{
+  walletId: string;
+  challenge: string;
+  status: "pending";
+}
+```
+
+**Example:**
+
+```typescript
+const registration = registerWallet();
+// {
+//   walletId: 'wallet_abc123def456',
+//   challenge: 'challenge_xyz789',
+//   status: 'pending'
+// }
+```
+
+### Confirm Endpoint
+
+**Function:** `confirmWallet(walletId: string): ConfirmResult`
+
+Confirms wallet creation for the given pending wallet ID.
+
+**Parameters:**
+
+- `walletId`: The pending wallet ID from the register step
+
+**Returns:**
+
+```typescript
+{
+  walletId: string;
+  status: 'created' | 'error';
+  message?: string;
+}
+```
+
+**Example:**
+
+```typescript
+const confirmation = confirmWallet("wallet_abc123def456");
+// {
+//   walletId: 'wallet_abc123def456',
+//   status: 'created',
+//   message: 'Wallet successfully created'
+// }
+```
+
+## Usage
+
+### Complete Handshake Flow
+
+```typescript
+import { registerWallet, confirmWallet } from "./handshake";
+
+// Step 1: Register
+const registration = registerWallet();
+console.log(`Wallet ID: ${registration.walletId}`);
+console.log(`Challenge: ${registration.challenge}`);
+
+// Step 2: Confirm
+const confirmation = confirmWallet(registration.walletId);
+console.log(`Status: ${confirmation.status}`);
+// Status: created
+```
+
+## Data Model
+
+### RegisterResponse
+
+| Field     | Type      | Description                       |
+| --------- | --------- | --------------------------------- |
+| walletId  | string    | Unique pending wallet identifier  |
+| challenge | string    | Challenge string for verification |
+| status    | 'pending' | Current status is always pending  |
+
+### ConfirmResult
+
+| Field    | Type                 | Description                   |
+| -------- | -------------------- | ----------------------------- |
+| walletId | string               | The wallet ID being confirmed |
+| status   | 'created' \| 'error' | Result of confirmation        |
+| message  | string               | Optional message with details |
+
+## Handshake Flow
+
+```
+1. Client calls registerWallet()
+   ↓
+   ✓ Returns: walletId (pending), challenge string
+
+2. Client calls confirmWallet(walletId)
+   ↓
+   ✓ Returns: status = 'created'
+
+3. Wallet is ready to use
+```
+
+## Running Tests
+
+```bash
+npm test
+# or
+pnpm test
+```
+
+Tests cover:
+
+- Register endpoint returns required fields
+- Challenge string is generated
+- Confirm endpoint accepts valid wallet ID
+- Full handshake sequence (register → confirm)
+- Multiple concurrent registrations

--- a/contrib/routes/wallet-create-handshake/handshake.ts
+++ b/contrib/routes/wallet-create-handshake/handshake.ts
@@ -1,0 +1,116 @@
+/**
+ * Wallet creation handshake handler
+ * Manages two-step registration and confirmation flow
+ */
+
+import type { RegisterResponse, ConfirmResult, WalletState } from "./types";
+
+/**
+ * In-memory storage for pending and created wallets
+ * In production, this would be a database
+ */
+const walletStorage = new Map<string, WalletState>();
+
+/**
+ * Generates a unique wallet ID
+ */
+function generateWalletId(): string {
+  return `wallet_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Generates a challenge string for verification
+ */
+function generateChallenge(): string {
+  return `challenge_${Math.random().toString(36).slice(2, 15)}${Math.random().toString(36).slice(2, 15)}`;
+}
+
+/**
+ * Initiates wallet creation - Step 1 of handshake
+ * Returns a pending wallet ID and challenge string
+ *
+ * @returns RegisterResponse with pending walletId and challenge
+ */
+export function registerWallet(): RegisterResponse {
+  const walletId = generateWalletId();
+  const challenge = generateChallenge();
+
+  const walletState: WalletState = {
+    walletId,
+    challenge,
+    status: "pending",
+    createdAt: Date.now(),
+  };
+
+  walletStorage.set(walletId, walletState);
+
+  return {
+    walletId,
+    challenge,
+    status: "pending",
+  };
+}
+
+/**
+ * Confirms wallet creation - Step 2 of handshake
+ * Accepts a pending wallet ID and marks it as created
+ *
+ * @param walletId The pending wallet ID from register step
+ * @returns ConfirmResult with created status or error
+ */
+export function confirmWallet(walletId: string): ConfirmResult {
+  const wallet = walletStorage.get(walletId);
+
+  if (!wallet) {
+    return {
+      walletId,
+      status: "error",
+      message: "Wallet not found or already confirmed",
+    };
+  }
+
+  if (wallet.status === "created") {
+    return {
+      walletId,
+      status: "error",
+      message: "Wallet already created",
+    };
+  }
+
+  if (wallet.status === "expired") {
+    return {
+      walletId,
+      status: "error",
+      message: "Wallet registration expired",
+    };
+  }
+
+  // Mark wallet as created
+  wallet.status = "created";
+  walletStorage.set(walletId, wallet);
+
+  return {
+    walletId,
+    status: "created",
+    message: "Wallet successfully created",
+  };
+}
+
+/**
+ * Retrieves the current state of a wallet
+ * Useful for testing and debugging
+ *
+ * @param walletId The wallet ID to retrieve
+ * @returns The wallet state or undefined if not found
+ */
+export function getWalletState(walletId: string): WalletState | undefined {
+  return walletStorage.get(walletId);
+}
+
+/**
+ * Clears all wallets from storage
+ * Useful for resetting state between tests
+ */
+export function clearWalletStorage(): void {
+  walletStorage.clear();
+}

--- a/contrib/routes/wallet-create-handshake/package.json
+++ b/contrib/routes/wallet-create-handshake/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wallet-create-handshake",
+  "version": "1.0.0",
+  "description": "Mock route module for wallet creation two-step handshake",
+  "private": true,
+  "scripts": {
+    "test": "node --loader tsx ./test.ts",
+    "test:check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/contrib/routes/wallet-create-handshake/test.ts
+++ b/contrib/routes/wallet-create-handshake/test.ts
@@ -1,0 +1,116 @@
+/**
+ * Test suite for wallet creation handshake
+ * Validates the two-step register and confirm flow
+ */
+
+import { registerWallet, confirmWallet, getWalletState, clearWalletStorage } from "./handshake";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    console.error(`❌ FAILED: ${message}`);
+    process.exit(1);
+  }
+  console.log(`✓ ${message}`);
+}
+
+function runTests(): void {
+  console.log("🧪 Running wallet creation handshake tests...\n");
+
+  // Test 1: Register endpoint returns required fields
+  console.log("Test 1: Register Endpoint");
+  const registration = registerWallet();
+  assert(registration.walletId !== "", "Register should return a walletId");
+  assert(registration.challenge !== "", "Register should return a challenge");
+  assert(registration.status === "pending", "Register should return status=pending");
+  console.log();
+
+  // Test 2: Confirm endpoint succeeds with valid walletId
+  console.log("Test 2: Confirm Endpoint");
+  const confirmation = confirmWallet(registration.walletId);
+  assert(
+    confirmation.walletId === registration.walletId,
+    "Confirm should return the same walletId",
+  );
+  assert(confirmation.status === "created", "Confirm should return status=created");
+  assert(confirmation.message !== "", "Confirm should return a success message");
+  console.log();
+
+  // Test 3: Full handshake sequence
+  console.log("Test 3: Complete Handshake Flow");
+  const reg2 = registerWallet();
+  assert(
+    reg2.walletId !== registration.walletId,
+    "Each register call should produce a unique walletId",
+  );
+  const conf2 = confirmWallet(reg2.walletId);
+  assert(conf2.status === "created", "Second handshake should also succeed");
+  console.log();
+
+  // Test 4: Cannot confirm already confirmed wallet
+  console.log("Test 4: Cannot Double-Confirm");
+  const doubleConfirm = confirmWallet(registration.walletId);
+  assert(
+    doubleConfirm.status === "error",
+    "Confirming an already confirmed wallet should return error",
+  );
+  assert(
+    doubleConfirm.message === "Wallet already created",
+    'Should return "already created" error message',
+  );
+  console.log();
+
+  // Test 5: Confirm fails with invalid walletId
+  console.log("Test 5: Invalid Wallet ID");
+  const invalidConfirm = confirmWallet("invalid_wallet_id");
+  assert(invalidConfirm.status === "error", "Confirming invalid wallet should return error");
+  assert(invalidConfirm.message !== "", "Error confirmation should have message");
+  console.log();
+
+  // Test 6: Wallet state tracking
+  console.log("Test 6: Wallet State Tracking");
+  clearWalletStorage();
+  const reg3 = registerWallet();
+  const pendingState = getWalletState(reg3.walletId);
+  assert(pendingState !== undefined, "Should be able to retrieve pending wallet state");
+  assert(pendingState?.status === "pending", "Pending wallet should have status=pending");
+  assert(
+    pendingState?.challenge === reg3.challenge,
+    "Retrieved state should have matching challenge",
+  );
+
+  confirmWallet(reg3.walletId);
+  const createdState = getWalletState(reg3.walletId);
+  assert(createdState?.status === "created", "Confirmed wallet should have status=created");
+  console.log();
+
+  // Test 7: Multiple concurrent registrations
+  console.log("Test 7: Multiple Concurrent Registrations");
+  clearWalletStorage();
+  const regs = [registerWallet(), registerWallet(), registerWallet()];
+  const ids = new Set(regs.map((r) => r.walletId));
+  assert(ids.size === 3, "Each registration should produce a unique walletId");
+
+  const confs = regs.map((r) => confirmWallet(r.walletId));
+  const allCreated = confs.every((c) => c.status === "created");
+  assert(allCreated, "All concurrent registrations should confirm successfully");
+  console.log();
+
+  // Test 8: Challenge strings are unique
+  console.log("Test 8: Unique Challenge Strings");
+  clearWalletStorage();
+  const reg4 = registerWallet();
+  const reg5 = registerWallet();
+  assert(reg4.challenge !== reg5.challenge, "Each registration should produce a unique challenge");
+  console.log();
+
+  console.log("✅ All tests passed!\n");
+  console.log("Handshake Flow Summary:");
+  console.log("  1. registerWallet()");
+  console.log("     ✓ Returns pending walletId and challenge");
+  console.log("  2. confirmWallet(walletId)");
+  console.log("     ✓ Confirms wallet creation");
+  console.log("     ✓ Returns status=created");
+  console.log("     ✓ Cannot be called twice on same wallet");
+}
+
+runTests();

--- a/contrib/routes/wallet-create-handshake/tsconfig.json
+++ b/contrib/routes/wallet-create-handshake/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "target": "es2022"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/contrib/routes/wallet-create-handshake/types.ts
+++ b/contrib/routes/wallet-create-handshake/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Type definitions for wallet creation handshake
+ */
+
+export interface RegisterResponse {
+  walletId: string;
+  challenge: string;
+  status: "pending";
+}
+
+export interface ConfirmResult {
+  walletId: string;
+  status: "created" | "error";
+  message?: string;
+}
+
+/**
+ * Internal wallet state for tracking pending and created wallets
+ */
+export interface WalletState {
+  walletId: string;
+  challenge: string;
+  status: "pending" | "created" | "expired";
+  createdAt: number;
+}

--- a/contrib/routes/wallet-reconnect/README.md
+++ b/contrib/routes/wallet-reconnect/README.md
@@ -1,0 +1,123 @@
+# Wallet Reconnect Mock Route
+
+A self-contained mock route module simulating reconnection to an existing wallet using a stored key identifier.
+
+## Overview
+
+This module provides a mock implementation of wallet reconnection that allows users to reconnect to their existing wallets by providing a stored key identifier. The endpoint matches the provided keyId against a sample dataset and returns the corresponding walletId or a 404-style error.
+
+## API
+
+### Reconnect Endpoint
+
+**Function:** `reconnectWallet(keyId: string): ReconnectResult`
+
+Attempts to reconnect to a wallet using a stored key identifier.
+
+**Parameters:**
+
+- `keyId`: The stored identifier for the wallet key
+
+**Returns:**
+
+```typescript
+// Success (200):
+{
+  success: true;
+  walletId: string;
+  keyId: string;
+}
+
+// Not Found (404):
+{
+  success: false;
+  error: "NOT_FOUND";
+  message: string;
+}
+```
+
+**Example - Known Key:**
+
+```typescript
+const result = reconnectWallet("key_user_001");
+// {
+//   success: true,
+//   walletId: 'wallet_abc123def456',
+//   keyId: 'key_user_001'
+// }
+```
+
+**Example - Unknown Key:**
+
+```typescript
+const result = reconnectWallet("key_unknown");
+// {
+//   success: false,
+//   error: 'NOT_FOUND',
+//   message: 'Key not found in wallet registry'
+// }
+```
+
+## Sample Dataset
+
+The module includes a predefined set of key-to-wallet mappings:
+
+| keyId          | walletId               |
+| -------------- | ---------------------- |
+| `key_user_001` | `wallet_alice_primary` |
+| `key_user_002` | `wallet_bob_primary`   |
+| `key_user_003` | `wallet_carol_primary` |
+
+## Usage
+
+```typescript
+import { reconnectWallet } from "./reconnector";
+
+// Known key
+const knownResult = reconnectWallet("key_user_001");
+if (knownResult.success) {
+  console.log(`Connected to ${knownResult.walletId}`);
+}
+
+// Unknown key
+const unknownResult = reconnectWallet("key_invalid");
+if (!unknownResult.success) {
+  console.log(`Error: ${unknownResult.message}`);
+}
+```
+
+## Data Model
+
+### ReconnectResult
+
+#### Success Response
+
+| Field    | Type   | Description                           |
+| -------- | ------ | ------------------------------------- |
+| success  | true   | Indicates successful reconnection     |
+| walletId | string | The wallet ID associated with the key |
+| keyId    | string | The key ID that was looked up         |
+
+#### Error Response
+
+| Field   | Type        | Description                  |
+| ------- | ----------- | ---------------------------- |
+| success | false       | Indicates lookup failure     |
+| error   | 'NOT_FOUND' | Error code                   |
+| message | string      | Human-readable error message |
+
+## Running Tests
+
+```bash
+npm test
+# or
+pnpm test
+```
+
+Tests cover:
+
+- Reconnecting with a known keyId
+- Retrieving the correct walletId
+- Handling unknown keyId (404 style error)
+- Consistent results across multiple calls
+- All sample keys are accessible

--- a/contrib/routes/wallet-reconnect/package.json
+++ b/contrib/routes/wallet-reconnect/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wallet-reconnect",
+  "version": "1.0.0",
+  "description": "Mock route module for wallet reconnection with key ID lookup",
+  "private": true,
+  "scripts": {
+    "test": "node --loader tsx ./test.ts",
+    "test:check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/contrib/routes/wallet-reconnect/reconnector.ts
+++ b/contrib/routes/wallet-reconnect/reconnector.ts
@@ -1,0 +1,62 @@
+/**
+ * Wallet reconnection handler
+ * Matches key IDs to wallet IDs from the sample registry
+ */
+
+import type { ReconnectResult } from "./types";
+import { walletLookupMap } from "./sample-registry";
+
+/**
+ * Attempts to reconnect to a wallet using a stored key identifier
+ * Returns the matching walletId or a 404-style error
+ *
+ * @param keyId The stored key identifier
+ * @returns ReconnectResult with walletId on success or NOT_FOUND error
+ */
+export function reconnectWallet(keyId: string): ReconnectResult {
+  // Validate input
+  if (!keyId || keyId.trim() === "") {
+    return {
+      success: false,
+      error: "NOT_FOUND",
+      message: "Invalid key ID provided",
+    };
+  }
+
+  // Look up the wallet ID
+  const walletId = walletLookupMap.get(keyId);
+
+  if (!walletId) {
+    return {
+      success: false,
+      error: "NOT_FOUND",
+      message: "Key not found in wallet registry",
+    };
+  }
+
+  return {
+    success: true,
+    walletId,
+    keyId,
+  };
+}
+
+/**
+ * Retrieves all registered key IDs
+ * Useful for testing and debugging
+ *
+ * @returns Array of all known key IDs
+ */
+export function getAllRegisteredKeys(): string[] {
+  return Array.from(walletLookupMap.keys());
+}
+
+/**
+ * Checks if a key ID is registered
+ *
+ * @param keyId The key ID to check
+ * @returns true if the key is registered, false otherwise
+ */
+export function isKeyRegistered(keyId: string): boolean {
+  return walletLookupMap.has(keyId);
+}

--- a/contrib/routes/wallet-reconnect/sample-registry.ts
+++ b/contrib/routes/wallet-reconnect/sample-registry.ts
@@ -1,0 +1,41 @@
+/**
+ * Sample key-to-wallet registry
+ * In production, this would be stored in a database
+ */
+
+import type { KeyWalletMapping } from "./types";
+
+/**
+ * Predefined mappings of key IDs to wallet IDs
+ */
+export const walletRegistry: KeyWalletMapping[] = [
+  {
+    keyId: "key_user_001",
+    walletId: "wallet_alice_primary",
+  },
+  {
+    keyId: "key_user_002",
+    walletId: "wallet_bob_primary",
+  },
+  {
+    keyId: "key_user_003",
+    walletId: "wallet_carol_primary",
+  },
+];
+
+/**
+ * Creates a lookup map for O(1) access
+ */
+export const walletLookupMap = new Map<string, string>(
+  walletRegistry.map((entry) => [entry.keyId, entry.walletId]),
+);
+
+/**
+ * Known key IDs for testing
+ */
+export const knownKeyIds = walletRegistry.map((entry) => entry.keyId);
+
+/**
+ * Sample unknown key ID for testing error cases
+ */
+export const unknownKeyId = "key_unknown_999";

--- a/contrib/routes/wallet-reconnect/test.ts
+++ b/contrib/routes/wallet-reconnect/test.ts
@@ -1,0 +1,127 @@
+/**
+ * Test suite for wallet reconnection
+ * Validates key matching and error handling
+ */
+
+import { reconnectWallet, getAllRegisteredKeys, isKeyRegistered } from "./reconnector";
+import { knownKeyIds, unknownKeyId, walletRegistry } from "./sample-registry";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    console.error(`❌ FAILED: ${message}`);
+    process.exit(1);
+  }
+  console.log(`✓ ${message}`);
+}
+
+function runTests(): void {
+  console.log("🧪 Running wallet reconnect tests...\n");
+
+  // Test 1: Reconnect with known key ID
+  console.log("Test 1: Known Key ID Reconnection");
+  const knownKey = knownKeyIds[0];
+  const knownResult = reconnectWallet(knownKey);
+  assert(knownResult.success === true, "Should successfully reconnect with known key");
+  assert("walletId" in knownResult && knownResult.walletId !== "", "Should return a walletId");
+  assert(
+    "keyId" in knownResult && knownResult.keyId === knownKey,
+    "Should return the matching keyId",
+  );
+  console.log();
+
+  // Test 2: Verify wallet ID matches registry
+  console.log("Test 2: Correct Wallet ID Returned");
+  const registryEntry = walletRegistry.find((e) => e.keyId === knownKey);
+  assert(
+    "walletId" in knownResult && registryEntry && knownResult.walletId === registryEntry.walletId,
+    "Returned walletId should match registry",
+  );
+  console.log();
+
+  // Test 3: Unknown key returns 404 error
+  console.log("Test 3: Unknown Key ID (404 Error)");
+  const unknownResult = reconnectWallet(unknownKeyId);
+  assert(unknownResult.success === false, "Should fail with unknown key");
+  assert(
+    !("walletId" in unknownResult) && unknownResult.error === "NOT_FOUND",
+    "Should return NOT_FOUND error",
+  );
+  assert("message" in unknownResult && unknownResult.message !== "", "Should return error message");
+  console.log();
+
+  // Test 4: Empty key ID returns error
+  console.log("Test 4: Empty Key ID Handling");
+  const emptyResult = reconnectWallet("");
+  assert(emptyResult.success === false, "Empty key should return error");
+  assert(emptyResult.error === "NOT_FOUND", "Empty key should return NOT_FOUND error");
+  console.log();
+
+  // Test 5: Whitespace-only key ID returns error
+  console.log("Test 5: Whitespace Key ID Handling");
+  const whitespaceResult = reconnectWallet("   ");
+  assert(whitespaceResult.success === false, "Whitespace key should return error");
+  console.log();
+
+  // Test 6: All sample keys are accessible
+  console.log("Test 6: All Sample Keys Are Accessible");
+  knownKeyIds.forEach((keyId, index) => {
+    const result = reconnectWallet(keyId);
+    assert(result.success === true, `Sample key ${index + 1} (${keyId}) should be accessible`);
+  });
+  console.log();
+
+  // Test 7: Consistent results across multiple calls
+  console.log("Test 7: Consistent Results");
+  const firstCall = reconnectWallet(knownKey);
+  const secondCall = reconnectWallet(knownKey);
+  assert(
+    "walletId" in firstCall &&
+      "walletId" in secondCall &&
+      firstCall.walletId === secondCall.walletId,
+    "Same key should return same walletId",
+  );
+  console.log();
+
+  // Test 8: getAllRegisteredKeys returns all keys
+  console.log("Test 8: Get All Registered Keys");
+  const allKeys = getAllRegisteredKeys();
+  assert(allKeys.length === knownKeyIds.length, "Should return all registered keys");
+  assert(
+    allKeys.every((key) => knownKeyIds.includes(key)),
+    "Should only return known keys",
+  );
+  console.log();
+
+  // Test 9: isKeyRegistered works correctly
+  console.log("Test 9: Key Registration Check");
+  assert(isKeyRegistered(knownKey), "Known key should be registered");
+  assert(!isKeyRegistered(unknownKeyId), "Unknown key should not be registered");
+  console.log();
+
+  // Test 10: Different keys return different wallets
+  console.log("Test 10: Different Keys Map to Different Wallets");
+  if (knownKeyIds.length >= 2) {
+    const result1 = reconnectWallet(knownKeyIds[0]);
+    const result2 = reconnectWallet(knownKeyIds[1]);
+    assert(
+      "walletId" in result1 && "walletId" in result2 && result1.walletId !== result2.walletId,
+      "Different keys should map to different wallets",
+    );
+  }
+  console.log();
+
+  console.log("✅ All tests passed!\n");
+  console.log("Reconnection Summary:");
+  console.log(`  Registered Keys: ${knownKeyIds.length}`);
+  knownKeyIds.forEach((keyId) => {
+    const result = reconnectWallet(keyId);
+    if (result.success) {
+      console.log(`    • ${keyId} → ${result.walletId}`);
+    }
+  });
+  console.log();
+  console.log("Error Handling:");
+  console.log(`  Unknown Key "${unknownKeyId}": ${unknownResult.message}`);
+}
+
+runTests();

--- a/contrib/routes/wallet-reconnect/tsconfig.json
+++ b/contrib/routes/wallet-reconnect/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "target": "es2022"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/contrib/routes/wallet-reconnect/types.ts
+++ b/contrib/routes/wallet-reconnect/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Type definitions for wallet reconnection
+ */
+
+export interface ReconnectSuccess {
+  success: true;
+  walletId: string;
+  keyId: string;
+}
+
+export interface ReconnectError {
+  success: false;
+  error: "NOT_FOUND";
+  message: string;
+}
+
+export type ReconnectResult = ReconnectSuccess | ReconnectError;
+
+/**
+ * Internal key-to-wallet mapping
+ */
+export interface KeyWalletMapping {
+  keyId: string;
+  walletId: string;
+}


### PR DESCRIPTION
Description:
## Summary
This PR adds four self-contained mock route modules under `contrib/routes/` that simulate wallet and account management flows.

Closes #66 
Closes #65 
Closes #67 
Closes #68 

## Changes

### 66. Merge Eligibility Reasons (`contrib/routes/merge-eligibility-reasons/`)
- Checks merge eligibility for sample accounts
- Returns structured reason codes when ineligible: `OPEN_TRUSTLINES`, `PENDING_OFFERS`, `ESCROW_ENTRIES`, `CLAWBACK_ENABLED`
- Includes 2 sample accounts (one eligible, one with multiple blockers)
- Full TypeScript types and comprehensive tests

### 65. Cleanup Plan Steps (`contrib/routes/cleanup-plan-steps/`)
- Generates ordered cleanup plans to resolve merge blockers
- Each step includes: `order`, `type`, and `description` fields
- Supports 2 different sample accounts with different plan complexities
- Step types: `CLOSE_TRUSTLINE`, `CANCEL_OFFER`, `RELEASE_ESCROW`, `DISABLE_CLAWBACK`, `FINALIZE`
- Includes step order validation and full test coverage

### 67. Wallet Create Handshake (`contrib/routes/wallet-create-handshake/`)
- Simulates two-step wallet creation: `register` and `confirm`
- Register endpoint returns pending `walletId` and `challenge` string
- Confirm endpoint marks wallet as created
- Prevents double-confirmation and handles invalid wallet IDs
- Full handshake flow tests with concurrent registration support

### 68. Wallet Reconnect (`contrib/routes/wallet-reconnect/`)
- Reconnects to existing wallets using stored `keyId`
- Returns matching `walletId` from sample registry
- Returns 404-style `NOT_FOUND` error for unknown keys
- Includes 3 sample key-to-wallet mappings
- Tests for known/unknown keys, error handling, and consistency

## Testing
All modules include comprehensive test suites:
```bash
cd contrib/routes/merge-eligibility-reasons && npm test
cd contrib/routes/cleanup-plan-steps && npm test
cd contrib/routes/wallet-create-handshake && npm test
cd contrib/routes/wallet-reconnect && npm test
