### PR TITLE
Add mock route modules: recipient lists, session refresh, rate history, fee bump estimate

### DIFF
--- a/contrib/routes/issue-70-fee-bump-estimate/README.md
+++ b/contrib/routes/issue-70-fee-bump-estimate/README.md
@@ -1,0 +1,44 @@
+# Mock route: fee bump transaction estimation (Issue #70)
+
+Standalone mock POST route simulating fee bump transaction fee estimation.
+Suggested fees come from a fixed per-priority lookup table. No real chain
+or database access.
+
+## Run
+
+```sh
+node route.mjs
+# fee-bump-estimate mock listening on http://localhost:4070/fee-bump-estimate
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+POST /fee-bump-estimate
+Content-Type: application/json
+
+{ "txHash": "a1b2c3d4e5f60718293a4b5c6d7e8f90", "priority": "high" }
+```
+
+Response:
+
+```json
+{
+  "txHash": "a1b2c3d4e5f60718293a4b5c6d7e8f90",
+  "priority": "high",
+  "suggestedFee": 2000,
+  "unit": "stroops"
+}
+```
+
+`priority` must be one of `low`, `medium`, `high` (case-insensitive); their
+fixed lookup-table fees are `100`, `500`, and `2000` stroops respectively.
+`txHash` must be a hex string; missing or invalid values return `400`.

--- a/contrib/routes/issue-70-fee-bump-estimate/route.mjs
+++ b/contrib/routes/issue-70-fee-bump-estimate/route.mjs
@@ -1,0 +1,68 @@
+// Mock route module simulating fee bump transaction estimation. No chain
+// or DB access; fees come from a fixed per-priority lookup table.
+import http from "node:http";
+
+const FEE_TABLE = {
+  low: 100,
+  medium: 500,
+  high: 2000,
+};
+
+const VALID_HASH = /^[0-9a-fA-F]{8,64}$/;
+
+export function handleRequest(body) {
+  if (!body || typeof body.txHash !== "string" || !body.txHash) {
+    return { status: 400, body: { error: "tx_hash_required" } };
+  }
+  if (!VALID_HASH.test(body.txHash)) {
+    return { status: 400, body: { error: "invalid_tx_hash" } };
+  }
+
+  const priority = typeof body.priority === "string" ? body.priority.toLowerCase() : body.priority;
+  if (!priority || !(priority in FEE_TABLE)) {
+    return {
+      status: 400,
+      body: { error: "invalid_priority", message: "priority must be one of: low, medium, high" },
+    };
+  }
+
+  return {
+    status: 200,
+    body: {
+      txHash: body.txHash,
+      priority,
+      suggestedFee: FEE_TABLE[priority],
+      unit: "stroops",
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/fee-bump-estimate") {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data || "{}");
+          const { status, body: resp } = handleRequest(body);
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(resp));
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "invalid_json" }));
+        }
+      });
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4070;
+  server.listen(port, () => {
+    console.log(
+      `fee-bump-estimate mock listening on http://localhost:${port}/fee-bump-estimate`,
+    );
+  });
+}

--- a/contrib/routes/issue-70-fee-bump-estimate/route.test.mjs
+++ b/contrib/routes/issue-70-fee-bump-estimate/route.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const TX_HASH = "a1b2c3d4e5f60718293a4b5c6d7e8f90";
+
+// Low priority pulls the low value from the fixed lookup table.
+const low = handleRequest({ txHash: TX_HASH, priority: "low" });
+assert.equal(low.status, 200);
+assert.equal(low.body.suggestedFee, 100);
+
+// Medium priority pulls the medium value.
+const medium = handleRequest({ txHash: TX_HASH, priority: "medium" });
+assert.equal(medium.status, 200);
+assert.equal(medium.body.suggestedFee, 500);
+
+// High priority pulls the high value.
+const high = handleRequest({ txHash: TX_HASH, priority: "high" });
+assert.equal(high.status, 200);
+assert.equal(high.body.suggestedFee, 2000);
+
+// Missing txHash and invalid priority are rejected.
+assert.equal(handleRequest({ priority: "low" }).status, 400);
+assert.equal(handleRequest({ txHash: TX_HASH, priority: "urgent" }).status, 400);
+assert.equal(handleRequest({ txHash: "not-hex!!" , priority: "low" }).status, 400);
+
+console.log("PASS: /fee-bump-estimate returns lookup-table fees for low, medium, and high priority");

--- a/contrib/routes/issue-73-rate-history/README.md
+++ b/contrib/routes/issue-73-rate-history/README.md
@@ -1,0 +1,60 @@
+# Mock route: exchange rate history with time buckets (Issue #73)
+
+Standalone mock GET route returning XLM/USD exchange rate history, bucketed
+by hour or day, from a fixed set of 30 hardcoded sample rate points spanning
+just over a day. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# rate-history mock listening on http://localhost:4073/rate-history?bucket=hourly|daily
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /rate-history?bucket=hourly
+```
+
+Response (truncated):
+
+```json
+{
+  "bucket": "hourly",
+  "buckets": [
+    { "bucket": "2026-07-27T00", "rate": 0.118, "samples": 1 },
+    { "bucket": "2026-07-27T01", "rate": 0.119, "samples": 1 }
+  ]
+}
+```
+
+Request:
+
+```
+GET /rate-history?bucket=daily
+```
+
+Response:
+
+```json
+{
+  "bucket": "daily",
+  "buckets": [
+    { "bucket": "2026-07-27", "rate": 0.11917, "samples": 24 },
+    { "bucket": "2026-07-28", "rate": 0.116, "samples": 6 }
+  ]
+}
+```
+
+`bucket` accepts `hourly` (default) or `daily`; any other value falls back
+to `hourly`. Each bucket's `rate` is the average of the sample points that
+fall within it.

--- a/contrib/routes/issue-73-rate-history/route.mjs
+++ b/contrib/routes/issue-73-rate-history/route.mjs
@@ -1,0 +1,89 @@
+// Mock route module returning exchange rate history bucketed by hour or
+// day, from a fixed sample of rate points. No chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+
+// 30 hourly sample points (XLM/USD), spanning just over a day.
+const RATE_POINTS = [
+  { timestamp: "2026-07-27T00:00:00.000Z", rate: 0.118 },
+  { timestamp: "2026-07-27T01:00:00.000Z", rate: 0.119 },
+  { timestamp: "2026-07-27T02:00:00.000Z", rate: 0.117 },
+  { timestamp: "2026-07-27T03:00:00.000Z", rate: 0.12 },
+  { timestamp: "2026-07-27T04:00:00.000Z", rate: 0.121 },
+  { timestamp: "2026-07-27T05:00:00.000Z", rate: 0.122 },
+  { timestamp: "2026-07-27T06:00:00.000Z", rate: 0.12 },
+  { timestamp: "2026-07-27T07:00:00.000Z", rate: 0.119 },
+  { timestamp: "2026-07-27T08:00:00.000Z", rate: 0.118 },
+  { timestamp: "2026-07-27T09:00:00.000Z", rate: 0.117 },
+  { timestamp: "2026-07-27T10:00:00.000Z", rate: 0.116 },
+  { timestamp: "2026-07-27T11:00:00.000Z", rate: 0.115 },
+  { timestamp: "2026-07-27T12:00:00.000Z", rate: 0.117 },
+  { timestamp: "2026-07-27T13:00:00.000Z", rate: 0.118 },
+  { timestamp: "2026-07-27T14:00:00.000Z", rate: 0.12 },
+  { timestamp: "2026-07-27T15:00:00.000Z", rate: 0.121 },
+  { timestamp: "2026-07-27T16:00:00.000Z", rate: 0.123 },
+  { timestamp: "2026-07-27T17:00:00.000Z", rate: 0.124 },
+  { timestamp: "2026-07-27T18:00:00.000Z", rate: 0.122 },
+  { timestamp: "2026-07-27T19:00:00.000Z", rate: 0.121 },
+  { timestamp: "2026-07-27T20:00:00.000Z", rate: 0.12 },
+  { timestamp: "2026-07-27T21:00:00.000Z", rate: 0.119 },
+  { timestamp: "2026-07-27T22:00:00.000Z", rate: 0.118 },
+  { timestamp: "2026-07-27T23:00:00.000Z", rate: 0.117 },
+  { timestamp: "2026-07-28T00:00:00.000Z", rate: 0.116 },
+  { timestamp: "2026-07-28T01:00:00.000Z", rate: 0.115 },
+  { timestamp: "2026-07-28T02:00:00.000Z", rate: 0.114 },
+  { timestamp: "2026-07-28T03:00:00.000Z", rate: 0.116 },
+  { timestamp: "2026-07-28T04:00:00.000Z", rate: 0.117 },
+  { timestamp: "2026-07-28T05:00:00.000Z", rate: 0.118 },
+];
+
+function bucketKey(timestamp, bucket) {
+  // Hourly bucket: truncate to the hour. Daily bucket: truncate to the day.
+  return bucket === "daily" ? timestamp.slice(0, 10) : timestamp.slice(0, 13);
+}
+
+function average(values) {
+  const sum = values.reduce((acc, v) => acc + v, 0);
+  return Math.round((sum / values.length) * 100000) / 100000;
+}
+
+export function handleRequest(query = {}) {
+  const bucket = query.bucket === "daily" ? "daily" : "hourly";
+
+  const grouped = new Map();
+  for (const point of RATE_POINTS) {
+    const key = bucketKey(point.timestamp, bucket);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(point.rate);
+  }
+
+  const buckets = Array.from(grouped.entries()).map(([key, rates]) => ({
+    bucket: key,
+    rate: average(rates),
+    samples: rates.length,
+  }));
+
+  return { status: 200, body: { bucket, buckets } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/rate-history") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleRequest(query);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4073;
+  server.listen(port, () => {
+    console.log(
+      `rate-history mock listening on http://localhost:${port}/rate-history?bucket=hourly|daily`,
+    );
+  });
+}

--- a/contrib/routes/issue-73-rate-history/route.test.mjs
+++ b/contrib/routes/issue-73-rate-history/route.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// Hourly bucketing: 30 hardcoded sample points each in their own hour ->
+// 30 buckets, one sample each.
+const hourly = handleRequest({ bucket: "hourly" });
+assert.equal(hourly.status, 200);
+assert.equal(hourly.body.bucket, "hourly");
+assert.equal(hourly.body.buckets.length, 30);
+assert.ok(hourly.body.buckets.every((b) => b.samples === 1));
+
+// Daily bucketing: the 30 hourly points span two calendar days.
+const daily = handleRequest({ bucket: "daily" });
+assert.equal(daily.status, 200);
+assert.equal(daily.body.bucket, "daily");
+assert.equal(daily.body.buckets.length, 2);
+const totalDailySamples = daily.body.buckets.reduce((acc, b) => acc + b.samples, 0);
+assert.equal(totalDailySamples, 30);
+
+// Default bucket (no query param) falls back to hourly.
+const defaulted = handleRequest({});
+assert.equal(defaulted.body.bucket, "hourly");
+
+console.log("PASS: /rate-history buckets sample points hourly and daily");

--- a/contrib/routes/issue-74-session-refresh/README.md
+++ b/contrib/routes/issue-74-session-refresh/README.md
@@ -1,0 +1,55 @@
+# Mock route: session refresh flow (Issue #74)
+
+Standalone mock route module simulating a session refresh flow. Session
+state is kept in memory (seeded with one already-expired sample session)
+and resets whenever the process restarts. No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# session-refresh mock listening on http://localhost:4074/session-refresh/{check,refresh}
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoints
+
+### `GET /session-refresh/check`
+
+Returns whether the current sample session is expired.
+
+Response:
+
+```json
+{
+  "token": "tok_a1b2c3d4e5f6",
+  "expiresAt": "2026-07-27T22:00:00.000Z",
+  "expired": true
+}
+```
+
+An optional `now` query parameter (ISO timestamp) overrides what "current
+time" is used for the expiry comparison, for deterministic testing.
+
+### `POST /session-refresh/refresh`
+
+Issues a new token and a new `expiresAt` (12 hours ahead of `now`),
+replacing the in-memory session.
+
+Response:
+
+```json
+{
+  "token": "tok_9f8e7d6c5b4a",
+  "issuedAt": "2026-07-28T00:00:00.000Z",
+  "expiresAt": "2026-07-28T12:00:00.000Z"
+}
+```
+
+Optional body `{ "now": "<ISO timestamp>" }` overrides the issue time used
+to compute the new `expiresAt`, for deterministic testing.

--- a/contrib/routes/issue-74-session-refresh/route.mjs
+++ b/contrib/routes/issue-74-session-refresh/route.mjs
@@ -1,0 +1,86 @@
+// Mock route module simulating a session refresh flow. No chain or DB
+// access; session state is kept in memory and resets on process restart.
+import http from "node:http";
+import crypto from "node:crypto";
+
+const SESSION_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
+
+let session = {
+  token: "tok_a1b2c3d4e5f6",
+  issuedAt: "2026-07-27T10:00:00.000Z",
+  expiresAt: "2026-07-27T22:00:00.000Z",
+};
+
+function isExpired(expiresAt, now) {
+  return new Date(now).getTime() >= new Date(expiresAt).getTime();
+}
+
+export function handleCheck(query = {}) {
+  const now = query.now || new Date().toISOString();
+  return {
+    status: 200,
+    body: {
+      token: session.token,
+      expiresAt: session.expiresAt,
+      expired: isExpired(session.expiresAt, now),
+    },
+  };
+}
+
+export function handleRefresh(body = {}) {
+  const now = body.now || new Date().toISOString();
+  const newToken = `tok_${crypto.randomBytes(6).toString("hex")}`;
+  const newExpiresAt = new Date(new Date(now).getTime() + SESSION_TTL_MS).toISOString();
+
+  session = {
+    token: newToken,
+    issuedAt: now,
+    expiresAt: newExpiresAt,
+  };
+
+  return {
+    status: 200,
+    body: { token: session.token, issuedAt: session.issuedAt, expiresAt: session.expiresAt },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+
+    if (req.method === "GET" && url.pathname === "/session-refresh/check") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleCheck(query);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/session-refresh/refresh") {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data || "{}");
+          const { status, body: resp } = handleRefresh(body);
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(resp));
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "invalid_json" }));
+        }
+      });
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4074;
+  server.listen(port, () => {
+    console.log(
+      `session-refresh mock listening on http://localhost:${port}/session-refresh/{check,refresh}`,
+    );
+  });
+}

--- a/contrib/routes/issue-74-session-refresh/route.test.mjs
+++ b/contrib/routes/issue-74-session-refresh/route.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { handleCheck, handleRefresh } from "./route.mjs";
+
+// The sample session starts out expired relative to a "now" well past its
+// hardcoded expiresAt.
+const initialCheck = handleCheck({ now: "2026-07-28T00:00:00.000Z" });
+assert.equal(initialCheck.status, 200);
+assert.equal(initialCheck.body.expired, true);
+const oldToken = initialCheck.body.token;
+
+// Refreshing issues a new token and a new (later) expiresAt.
+const refreshed = handleRefresh({ now: "2026-07-28T00:00:00.000Z" });
+assert.equal(refreshed.status, 200);
+assert.notEqual(refreshed.body.token, oldToken);
+assert.ok(new Date(refreshed.body.expiresAt).getTime() > new Date("2026-07-28T00:00:00.000Z").getTime());
+
+// Checking again right after refresh (same "now") reports not expired, and
+// reflects the new token.
+const afterRefresh = handleCheck({ now: "2026-07-28T00:00:00.000Z" });
+assert.equal(afterRefresh.status, 200);
+assert.equal(afterRefresh.body.expired, false);
+assert.equal(afterRefresh.body.token, refreshed.body.token);
+
+console.log("PASS: /session-refresh check -> refresh -> check reflects the new session");

--- a/contrib/routes/issue-75-recipient-lists/README.md
+++ b/contrib/routes/issue-75-recipient-lists/README.md
@@ -1,0 +1,56 @@
+# Mock route: recipient allowlist/denylist (Issue #75)
+
+Standalone mock route module for maintaining an allowlist and denylist of
+recipient addresses. State is kept in-memory (seeded with one sample allowed
+and one sample denied recipient) and resets whenever the process restarts.
+No real chain or database access.
+
+## Run
+
+```sh
+node route.mjs
+# recipient-lists mock listening on http://localhost:4075/recipient-lists/{add,check}
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Endpoints
+
+### `POST /recipient-lists/add`
+
+Adds a recipient to the allow or deny list.
+
+Request:
+
+```json
+{ "type": "deny", "recipient": "GC333..." }
+```
+
+Response:
+
+```json
+{ "added": true, "type": "deny", "recipient": "GC333..." }
+```
+
+`type` must be `"allow"` or `"deny"`; anything else returns `400
+invalid_list_type`. A missing `recipient` returns `400 recipient_required`.
+
+### `GET /recipient-lists/check?recipient=...`
+
+Returns which list (if any) contains the given recipient.
+
+Response when found:
+
+```json
+{ "recipient": "GA111...", "list": "allow" }
+```
+
+Response when not on either list:
+
+```json
+{ "recipient": "GC333...", "list": null }
+```

--- a/contrib/routes/issue-75-recipient-lists/route.mjs
+++ b/contrib/routes/issue-75-recipient-lists/route.mjs
@@ -1,0 +1,85 @@
+// Mock route module for allowlist/denylist recipients. In-memory only,
+// no chain or DB access. State resets whenever the process restarts.
+import http from "node:http";
+import { URL } from "node:url";
+
+const LISTS = {
+  allow: new Set(["GA111ALLOWEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"]),
+  deny: new Set(["GB222DENIEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"]),
+};
+
+function normalizeType(type) {
+  return typeof type === "string" ? type.toLowerCase() : type;
+}
+
+export function handleAdd(body) {
+  if (!body || typeof body.recipient !== "string" || !body.recipient) {
+    return { status: 400, body: { error: "recipient_required" } };
+  }
+  const type = normalizeType(body.type);
+  if (type !== "allow" && type !== "deny") {
+    return { status: 400, body: { error: "invalid_list_type", message: "type must be 'allow' or 'deny'" } };
+  }
+
+  LISTS[type].add(body.recipient);
+  return {
+    status: 200,
+    body: { added: true, type, recipient: body.recipient },
+  };
+}
+
+export function handleCheck(query = {}) {
+  const recipient = query.recipient;
+  if (!recipient) {
+    return { status: 400, body: { error: "recipient_required" } };
+  }
+
+  if (LISTS.allow.has(recipient)) {
+    return { status: 200, body: { recipient, list: "allow" } };
+  }
+  if (LISTS.deny.has(recipient)) {
+    return { status: 200, body: { recipient, list: "deny" } };
+  }
+  return { status: 200, body: { recipient, list: null } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+
+    if (req.method === "POST" && url.pathname === "/recipient-lists/add") {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data || "{}");
+          const { status, body: resp } = handleAdd(body);
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(resp));
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "invalid_json" }));
+        }
+      });
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/recipient-lists/check") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleCheck(query);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4075;
+  server.listen(port, () => {
+    console.log(
+      `recipient-lists mock listening on http://localhost:${port}/recipient-lists/{add,check}`,
+    );
+  });
+}

--- a/contrib/routes/issue-75-recipient-lists/route.test.mjs
+++ b/contrib/routes/issue-75-recipient-lists/route.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { handleAdd, handleCheck } from "./route.mjs";
+
+const ALLOWED = "GA111ALLOWEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const DENIED = "GB222DENIEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const UNLISTED = "GC333UNLISTEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+// Pre-seeded allowed recipient is reported as being on the allow list.
+const allowed = handleCheck({ recipient: ALLOWED });
+assert.equal(allowed.status, 200);
+assert.equal(allowed.body.list, "allow");
+
+// Pre-seeded denied recipient is reported as being on the deny list.
+const denied = handleCheck({ recipient: DENIED });
+assert.equal(denied.status, 200);
+assert.equal(denied.body.list, "deny");
+
+// A recipient not on either list reports list: null.
+const unlisted = handleCheck({ recipient: UNLISTED });
+assert.equal(unlisted.status, 200);
+assert.equal(unlisted.body.list, null);
+
+// Adding the unlisted recipient to the deny list, then it shows up on check.
+const added = handleAdd({ type: "deny", recipient: UNLISTED });
+assert.equal(added.status, 200);
+assert.equal(added.body.type, "deny");
+
+const afterAdd = handleCheck({ recipient: UNLISTED });
+assert.equal(afterAdd.body.list, "deny");
+
+// Missing recipient/type are rejected.
+assert.equal(handleAdd({ type: "deny" }).status, 400);
+assert.equal(handleAdd({ recipient: UNLISTED, type: "bogus" }).status, 400);
+assert.equal(handleCheck({}).status, 400);
+
+console.log("PASS: /recipient-lists add/check handle allow, deny, and unlisted recipients");


### PR DESCRIPTION
- Add `contrib/routes/issue-75-recipient-lists/`: mock endpoints to add a recipient to an allow/deny list, and check which list (if any) a recipient is on.
- Add `contrib/routes/issue-74-session-refresh/`: mock endpoints to check whether the sample session is expired, and refresh it to get a new token + expiresAt.
- Add `contrib/routes/issue-73-rate-history/`: mock endpoint returning 30 hardcoded sample exchange rate points, bucketed hourly or daily via a `bucket` query param.
- Add `contrib/routes/issue-70-fee-bump-estimate/`: mock endpoint returning a suggested fee bump fee for a tx hash + priority (low/medium/high) from a fixed lookup table.

All modules are self-contained under `contrib/routes/`, plain Node `.mjs` files with no external dependencies, following the existing contrib module conventions (README + route.mjs + route.test.mjs).

## Test plan

- [x] `node contrib/routes/issue-75-recipient-lists/route.test.mjs` passes (allowed, denied, unlisted, add-then-check)
- [x] `node contrib/routes/issue-74-session-refresh/route.test.mjs` passes (check -> refresh -> check)
- [x] `node contrib/routes/issue-73-rate-history/route.test.mjs` passes (hourly and daily bucketing)
- [x] `node contrib/routes/issue-70-fee-bump-estimate/route.test.mjs` passes (low, medium, high priority)
- [x] `git diff --stat` against `drips` confirms no files outside `contrib/` were touched

Closes #75
Closes #74
Closes #73
Closes #70