### PR TITLE
Issue 58 56 60 61 mocks

### DIFF
--- a/contrib/routes/account-inspect/README.md
+++ b/contrib/routes/account-inspect/README.md
@@ -1,0 +1,21 @@
+# Account Inspect Route
+
+Self contained mock route module for account inspection and blocker detection.
+
+## Endpoints
+- `GET /:accountId`: Returns a list of blockers for the given `accountId`.
+
+## Usage
+Mount this router in an express application:
+```javascript
+const express = require('express');
+const accountInspectRoute = require('./contrib/routes/account-inspect');
+const app = express();
+app.use('/account-inspect', accountInspectRoute);
+```
+
+## Testing
+Run the included test script:
+```bash
+node test.js
+```

--- a/contrib/routes/account-inspect/index.js
+++ b/contrib/routes/account-inspect/index.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const router = express.Router();
+
+const blockersByAccount = {
+  'account_1': [
+    { type: 'open_trustline', description: 'Account has open trustlines.' }
+  ],
+  'account_2': [
+    { type: 'open_offer', description: 'Account has active offers.' },
+    { type: 'data_entry', description: 'Account has data entries.' }
+  ],
+  'account_3': [
+    { type: 'open_trustline', description: 'Account has open trustlines.' },
+    { type: 'signer', description: 'Account has additional signers.' },
+    { type: 'open_offer', description: 'Account has active offers.' }
+  ]
+};
+
+router.get('/:accountId', (req, res) => {
+  const accountId = req.params.accountId;
+  const blockers = blockersByAccount[accountId] || [];
+  res.json({ accountId, blockers });
+});
+
+module.exports = router;

--- a/contrib/routes/account-inspect/test.js
+++ b/contrib/routes/account-inspect/test.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const route = require('./index');
+const http = require('http');
+
+const app = express();
+app.use('/inspect', route);
+const server = http.createServer(app);
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const baseUrl = `http://localhost:${port}/inspect`;
+  
+  console.log('Testing account with blockers (account_1):');
+  const res1 = await fetch(`${baseUrl}/account_1`);
+  console.log(await res1.json());
+  
+  console.log('\nTesting account with no blockers (account_clear):');
+  const res2 = await fetch(`${baseUrl}/account_clear`);
+  console.log(await res2.json());
+  
+  server.close();
+});

--- a/contrib/routes/device-session-crud/README.md
+++ b/contrib/routes/device-session-crud/README.md
@@ -1,0 +1,22 @@
+# Device Session CRUD Route
+
+Self contained mock route module for device session list and revoke.
+
+## Endpoints
+- `GET /sessions`: Lists all active mock device sessions.
+- `POST /sessions/:id/revoke`: Revokes a session by `id`, removing it from the in-memory list.
+
+## Usage
+Mount this router in an express application:
+```javascript
+const express = require('express');
+const deviceSessionCrudRoute = require('./contrib/routes/device-session-crud');
+const app = express();
+app.use('/device-session-crud', deviceSessionCrudRoute);
+```
+
+## Testing
+Run the included test script:
+```bash
+node test.js
+```

--- a/contrib/routes/device-session-crud/index.js
+++ b/contrib/routes/device-session-crud/index.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const router = express.Router();
+
+// Seed the module with at least 3 sample sessions on startup
+let deviceSessions = [
+  { id: 'session_1', deviceName: 'iPhone 13', lastActive: new Date().toISOString() },
+  { id: 'session_2', deviceName: 'MacBook Pro', lastActive: new Date().toISOString() },
+  { id: 'session_3', deviceName: 'Windows PC', lastActive: new Date().toISOString() }
+];
+
+router.use(express.json());
+
+router.get('/sessions', (req, res) => {
+  res.json({ sessions: deviceSessions });
+});
+
+router.post('/sessions/:id/revoke', (req, res) => {
+  const sessionId = req.params.id;
+  const initialLength = deviceSessions.length;
+  
+  deviceSessions = deviceSessions.filter(session => session.id !== sessionId);
+  
+  if (deviceSessions.length === initialLength) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+  
+  res.status(200).json({ message: 'Session revoked successfully' });
+});
+
+module.exports = router;

--- a/contrib/routes/device-session-crud/test.js
+++ b/contrib/routes/device-session-crud/test.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const route = require('./index');
+const http = require('http');
+
+const app = express();
+app.use('/', route);
+const server = http.createServer(app);
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const baseUrl = `http://localhost:${port}`;
+  
+  console.log('Listing sessions initially:');
+  const res1 = await fetch(`${baseUrl}/sessions`);
+  console.log(await res1.json());
+  
+  console.log('\nRevoking session_2:');
+  const res2 = await fetch(`${baseUrl}/sessions/session_2/revoke`, {
+    method: 'POST'
+  });
+  console.log('Revoke response status:', res2.status);
+  console.log(await res2.json());
+  
+  console.log('\nListing sessions after revocation:');
+  const res3 = await fetch(`${baseUrl}/sessions`);
+  console.log(await res3.json());
+  
+  server.close();
+});

--- a/contrib/routes/permission-grant-revoke/README.md
+++ b/contrib/routes/permission-grant-revoke/README.md
@@ -1,0 +1,22 @@
+# Permission Grant and Revoke Route
+
+Self contained mock route module for origin permission grant and revoke.
+
+## Endpoints
+- `POST /grant`: Grants an origin permission. Requires `origin` in the request body. Stores the origin and a `grantedAt` timestamp in memory.
+- `POST /revoke`: Revokes a previously granted origin. Requires `origin` in the request body. Returns a 404 error if the origin has no active grant.
+
+## Usage
+Mount this router in an express application:
+```javascript
+const express = require('express');
+const permissionGrantRevokeRoute = require('./contrib/routes/permission-grant-revoke');
+const app = express();
+app.use('/permission-grant-revoke', permissionGrantRevokeRoute);
+```
+
+## Testing
+Run the included test script:
+```bash
+node test.js
+```

--- a/contrib/routes/permission-grant-revoke/index.js
+++ b/contrib/routes/permission-grant-revoke/index.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const router = express.Router();
+
+// In-memory storage for granted origins
+const grantedOrigins = {};
+
+router.use(express.json());
+
+router.post('/grant', (req, res) => {
+  const { origin } = req.body;
+  if (!origin) {
+    return res.status(400).json({ error: 'origin is required' });
+  }
+
+  grantedOrigins[origin] = {
+    origin,
+    grantedAt: new Date().toISOString()
+  };
+
+  res.status(201).json(grantedOrigins[origin]);
+});
+
+router.post('/revoke', (req, res) => {
+  const { origin } = req.body;
+  if (!origin) {
+    return res.status(400).json({ error: 'origin is required' });
+  }
+
+  if (!grantedOrigins[origin]) {
+    return res.status(404).json({ error: 'No active grant found for origin' });
+  }
+
+  delete grantedOrigins[origin];
+  res.status(200).json({ message: 'Origin permission revoked successfully' });
+});
+
+module.exports = router;

--- a/contrib/routes/permission-grant-revoke/test.js
+++ b/contrib/routes/permission-grant-revoke/test.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const route = require('./index');
+const http = require('http');
+
+const app = express();
+app.use('/', route);
+const server = http.createServer(app);
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const baseUrl = `http://localhost:${port}`;
+  
+  console.log('Granting origin: https://example.com');
+  const res1 = await fetch(`${baseUrl}/grant`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ origin: 'https://example.com' })
+  });
+  console.log('Grant response status:', res1.status);
+  console.log(await res1.json());
+  
+  console.log('\nRevoking origin: https://example.com');
+  const res2 = await fetch(`${baseUrl}/revoke`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ origin: 'https://example.com' })
+  });
+  console.log('Revoke response status:', res2.status);
+  console.log(await res2.json());
+  
+  console.log('\nRevoking again: https://example.com');
+  const res3 = await fetch(`${baseUrl}/revoke`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ origin: 'https://example.com' })
+  });
+  console.log('Repeat revoke response status:', res3.status);
+  console.log(await res3.json());
+  
+  server.close();
+});

--- a/contrib/routes/spending-policy-crud/README.md
+++ b/contrib/routes/spending-policy-crud/README.md
@@ -1,0 +1,22 @@
+# Spending Policy CRUD Route
+
+Self contained mock route module for creating and listing spending policies.
+
+## Endpoints
+- `POST /policies`: Creates a new spending policy. Requires `limit` and `windowSeconds` (must be positive numbers) in the request body.
+- `GET /policies`: Lists all policies created in the current process memory.
+
+## Usage
+Mount this router in an express application:
+```javascript
+const express = require('express');
+const spendingPolicyCrudRoute = require('./contrib/routes/spending-policy-crud');
+const app = express();
+app.use('/spending-policy-crud', spendingPolicyCrudRoute);
+```
+
+## Testing
+Run the included test script:
+```bash
+node test.js
+```

--- a/contrib/routes/spending-policy-crud/index.js
+++ b/contrib/routes/spending-policy-crud/index.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+
+// In-memory storage for spending policies
+const policies = [];
+
+router.use(express.json());
+
+router.post('/policies', (req, res) => {
+  const { limit, windowSeconds } = req.body;
+  
+  if (typeof limit !== 'number' || limit <= 0) {
+    return res.status(400).json({ error: 'limit must be a positive number' });
+  }
+  
+  if (typeof windowSeconds !== 'number' || windowSeconds <= 0) {
+    return res.status(400).json({ error: 'windowSeconds must be a positive number' });
+  }
+  
+  const policy = {
+    id: policies.length + 1,
+    limit,
+    windowSeconds,
+    createdAt: new Date().toISOString()
+  };
+  
+  policies.push(policy);
+  res.status(201).json(policy);
+});
+
+router.get('/policies', (req, res) => {
+  res.json({ policies });
+});
+
+module.exports = router;

--- a/contrib/routes/spending-policy-crud/test.js
+++ b/contrib/routes/spending-policy-crud/test.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const route = require('./index');
+const http = require('http');
+
+const app = express();
+app.use('/', route);
+const server = http.createServer(app);
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const baseUrl = `http://localhost:${port}`;
+  
+  console.log('Creating policy 1:');
+  const res1 = await fetch(`${baseUrl}/policies`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ limit: 100, windowSeconds: 3600 })
+  });
+  console.log(await res1.json());
+  
+  console.log('\nCreating policy 2:');
+  const res2 = await fetch(`${baseUrl}/policies`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ limit: 50, windowSeconds: 1800 })
+  });
+  console.log(await res2.json());
+  
+  console.log('\nListing all policies:');
+  const res3 = await fetch(`${baseUrl}/policies`);
+  console.log(await res3.json());
+  
+  server.close();
+});


### PR DESCRIPTION
## Summary
This PR adds four self-contained mock route modules under `contrib/routes/` for development and testing purposes. Each module operates entirely in-memory and includes a local test script for validation.

## Changes Included
* **Account Inspection:** Added the `account-inspect` route to inspect sample account IDs and return a list of mock blockers preventing further actions (such as open trustlines or active offers).
* **Spending Policy CRUD:** Added the `spending-policy-crud` route with endpoints to create spending policies (with positive number validation for `limit` and `windowSeconds`) and list all created policies.
* **Permission Grant & Revoke:** Added the `permission-grant-revoke` route with endpoints to grant an origin permission (storing the origin and timestamp) and to revoke an active grant, returning a 404 payload for inactive grants.
* **Device Session CRUD:** Added the `device-session-crud` route seeded with sample active mock device sessions, including endpoints to list all sessions and revoke a session by its ID.

Closes #58
Closes #56
Closes #60
Closes #61

## Testing
Each module contains a self-contained test script (`test.js`) that validates its specific endpoints against the requirements. They can be executed directly using Node (e.g. `node contrib/routes/account-inspect/test.js`).