### PR TITLE
feat(contrib): add mock signer-list route

### DIFF
--- a/contrib/routes/issue-44-signer-list/README.md
+++ b/contrib/routes/issue-44-signer-list/README.md
@@ -1,0 +1,63 @@
+# Mock route: signer list (Issue #44)
+
+Standalone mock GET route returning a fixed array of sample signer entries for
+a smart account. Each entry carries a `keyType` (`ed25519` or `secp256r1`) and a
+`weight`, alongside a stable id, label, public key, and creation timestamp.
+
+No chain, network, or database access — the data is a hard-coded fixture, so
+the route is safe to point a UI at while the real signer service is being
+built.
+
+## Run
+
+```sh
+node route.mjs
+# signer-list mock listening on http://localhost:4044/signer-list
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+The test asserts the response shape: `signers` is an array of at least three
+entries, every `keyType` is one of the supported values, every `weight` is a
+positive number, ids are unique, and the fixture covers more than one key type.
+
+## Example
+
+Request:
+
+```
+GET /signer-list
+```
+
+Response:
+
+```json
+{
+  "accountId": "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+  "signers": [
+    {
+      "id": "sig_001",
+      "label": "Primary device",
+      "keyType": "ed25519",
+      "publicKey": "GCKFBEIYV2V5BVZ6Q7V7QV7QV7QV7QV7QV7QV7QV7QV7QV7QV7",
+      "weight": 10,
+      "addedAt": "2026-01-14T09:20:00.000Z"
+    },
+    {
+      "id": "sig_002",
+      "label": "Passkey (browser)",
+      "keyType": "secp256r1",
+      "publicKey": "PBKDF1234567890ABCDEF1234567890ABCDEF1234567890ABCD",
+      "weight": 5,
+      "addedAt": "2026-02-02T17:45:00.000Z"
+    }
+  ],
+  "threshold": 10
+}
+```
+
+Any other method or path returns `404` with `{ "error": "not_found" }`.

--- a/contrib/routes/issue-44-signer-list/route.mjs
+++ b/contrib/routes/issue-44-signer-list/route.mjs
@@ -1,0 +1,75 @@
+// Mock GET route returning a fixed list of signers for a smart account. No
+// chain or DB access.
+import http from "node:http";
+import { pathToFileURL } from "node:url";
+
+const KEY_TYPES = ["ed25519", "secp256r1"];
+
+const MOCK_SIGNERS = [
+  {
+    id: "sig_001",
+    label: "Primary device",
+    keyType: "ed25519",
+    publicKey: "GCKFBEIYV2V5BVZ6Q7V7QV7QV7QV7QV7QV7QV7QV7QV7QV7QV7",
+    weight: 10,
+    addedAt: "2026-01-14T09:20:00.000Z",
+  },
+  {
+    id: "sig_002",
+    label: "Passkey (browser)",
+    keyType: "secp256r1",
+    publicKey: "PBKDF1234567890ABCDEF1234567890ABCDEF1234567890ABCD",
+    weight: 5,
+    addedAt: "2026-02-02T17:45:00.000Z",
+  },
+  {
+    id: "sig_003",
+    label: "Passkey (mobile)",
+    keyType: "secp256r1",
+    publicKey: "PBKD0987654321FEDCBA0987654321FEDCBA0987654321FEDC",
+    weight: 5,
+    addedAt: "2026-03-11T11:05:00.000Z",
+  },
+  {
+    id: "sig_004",
+    label: "Recovery key",
+    keyType: "ed25519",
+    publicKey: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+    weight: 1,
+    addedAt: "2026-03-28T08:00:00.000Z",
+  },
+];
+
+export { KEY_TYPES, MOCK_SIGNERS };
+
+export function handleRequest() {
+  return {
+    status: 200,
+    body: {
+      accountId: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+      signers: MOCK_SIGNERS,
+      threshold: 10,
+    },
+  };
+}
+
+// pathToFileURL keeps the entrypoint check correct on Windows and with
+// relative argv paths, where a raw `file://` + argv[1] concatenation never
+// matches import.meta.url.
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/signer-list") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4044;
+  server.listen(port, () => {
+    console.log(`signer-list mock listening on http://localhost:${port}/signer-list`);
+  });
+}

--- a/contrib/routes/issue-44-signer-list/route.test.mjs
+++ b/contrib/routes/issue-44-signer-list/route.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { handleRequest, KEY_TYPES } from "./route.mjs";
+
+const { status, body } = handleRequest();
+
+assert.equal(status, 200);
+assert.equal(typeof body.accountId, "string");
+assert.ok(Array.isArray(body.signers));
+assert.ok(body.signers.length >= 3, "at least three sample signers");
+
+for (const signer of body.signers) {
+  assert.equal(typeof signer.id, "string");
+  assert.equal(typeof signer.label, "string");
+  assert.equal(typeof signer.publicKey, "string");
+  assert.ok(KEY_TYPES.includes(signer.keyType), `unexpected keyType: ${signer.keyType}`);
+  assert.equal(typeof signer.weight, "number");
+  assert.ok(signer.weight > 0, "weight must be positive");
+  assert.ok(!Number.isNaN(Date.parse(signer.addedAt)), "addedAt must be a valid timestamp");
+}
+
+const ids = body.signers.map((s) => s.id);
+assert.equal(new Set(ids).size, ids.length, "signer ids must be unique");
+
+const usedKeyTypes = new Set(body.signers.map((s) => s.keyType));
+assert.ok(usedKeyTypes.size >= 2, "sample data must cover varied key types");
+
+console.log("PASS: /signer-list returns a well-formed signer array");


### PR DESCRIPTION
closes #44

## What

Adds a standalone mock GET route under `contrib/routes/issue-44-signer-list/`
returning a fixed array of sample signer entries for a smart account.

## Files

- `contrib/routes/issue-44-signer-list/route.mjs` - `handleRequest()` returning the fixture, plus a `node:http` server when the file is run directly (`GET /signer-list`, port 4044, `PORT` overridable).
- `contrib/routes/issue-44-signer-list/route.test.mjs` - `node:assert` shape test.
- `contrib/routes/issue-44-signer-list/README.md` - run/test instructions and an example payload.

## Shape

Each signer carries a `keyType` (`ed25519` or `secp256r1`) and a positive
`weight`, alongside a stable `id`, `label`, `publicKey`, and `addedAt`
timestamp. Four sample entries are included - two `ed25519` and two
`secp256r1`, with varying weights so a threshold check has something meaningful
to work against. The response wraps them with the `accountId` and the account
`threshold`.

## Verification

```
node contrib/routes/issue-44-signer-list/route.test.mjs
PASS: /signer-list returns a well-formed signer array
```

The test asserts `signers` is an array of at least three entries, every
`keyType` is one of the supported values, every `weight` is a positive number,
`addedAt` parses as a date, ids are unique, and the fixture covers more than one
key type.

The server was also exercised over HTTP: `GET /signer-list` returns `200` with
the payload, and any other method or path returns `404 {"error":"not_found"}`.

## Notes

The module follows the existing `contrib/routes/` convention (`route.mjs` /
`route.test.mjs` / `README.md`, exported `handleRequest`, run-directly server)
with one deviation: the entrypoint guard uses
`pathToFileURL(process.argv[1]).href` instead of the `file://` + `argv[1]`
string concatenation the older modules use. That concatenation never matches
`import.meta.url` on Windows (drive letter and backslashes) or when `argv[1]` is
a relative path, so `node route.mjs` silently exits without starting the server.
Happy to switch back for consistency if you would rather fix that repo-wide in a
separate pass.

## Scope

All changes are inside `contrib/`. Base branch is `drips`.
