### PR TITLE
feat(contrib): add mock permission-grant route

### DIFF
--- a/contrib/routes/issue-45-permission-grant/README.md
+++ b/contrib/routes/issue-45-permission-grant/README.md
@@ -1,0 +1,75 @@
+# Mock route: permission grant (Issue #45)
+
+Standalone mock POST route that accepts a body granting a dApp origin
+permission and echoes back a confirmation record.
+
+The handler validates that `origin` is present and parses as an `http(s)` URL,
+normalizes it down to a bare origin (scheme + host + port), and returns a
+granted record containing the origin, the granted scopes, a grant id, and a
+`grantedAt` timestamp. Nothing is persisted — this is a fixture for wiring UI
+against while the real permission service is being built.
+
+## Run
+
+```sh
+node route.mjs
+# permission-grant mock listening on http://localhost:4145/permission-grant
+```
+
+The port is 4145 rather than 4045: 4045 is on the WHATWG blocked-port list, so
+browsers and `fetch()` refuse to connect to it. Override with `PORT` if needed.
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+Covers the success case (including scope deduplication and origin
+normalization) and the failure cases: missing origin, absent body, a
+non-URL origin, a non-`http(s)` scheme, a non-string origin, and an unknown
+scope.
+
+## Request
+
+```
+POST /permission-grant
+Content-Type: application/json
+
+{
+  "origin": "https://app.example.com/dashboard",
+  "scopes": ["accounts:read", "payments:sign"]
+}
+```
+
+`scopes` is optional and defaults to `["accounts:read"]`. Valid scopes are
+`accounts:read`, `payments:sign`, and `policies:read`.
+
+## Response
+
+`201 Created`:
+
+```json
+{
+  "granted": true,
+  "grantId": "grant_2f0a1c5e-9c1c-4a4a-8f1a-4a6f1f4b9d21",
+  "origin": "https://app.example.com",
+  "scopes": ["accounts:read", "payments:sign"],
+  "grantedAt": "2026-07-29T12:00:00.000Z"
+}
+```
+
+## Errors
+
+All errors return `400` with an `error` code:
+
+| Code                             | When                                         |
+| -------------------------------- | -------------------------------------------- |
+| `origin_required`                | `origin` missing or empty (or no body)       |
+| `origin_must_be_string`          | `origin` is not a string                     |
+| `invalid_origin`                 | `origin` is not a parseable `http(s)` URL    |
+| `scopes_must_be_non_empty_array` | `scopes` given but not a non-empty array     |
+| `invalid_scope`                  | `scopes` contains an unsupported value       |
+| `invalid_json`                   | request body is not valid JSON (server only) |
+
+Any other method or path returns `404` with `{ "error": "not_found" }`.

--- a/contrib/routes/issue-45-permission-grant/route.mjs
+++ b/contrib/routes/issue-45-permission-grant/route.mjs
@@ -1,0 +1,114 @@
+// Mock POST route accepting a permission grant for a dApp origin and echoing
+// back a confirmation record. No chain, DB, or persistence.
+import http from "node:http";
+import { pathToFileURL } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const ALLOWED_SCOPES = ["accounts:read", "payments:sign", "policies:read"];
+const DEFAULT_SCOPES = ["accounts:read"];
+
+// Only web origins can hold a grant — `javascript:`, `data:` and friends are
+// rejected outright.
+const ALLOWED_PROTOCOLS = ["http:", "https:"];
+
+function normalizeOrigin(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (!ALLOWED_PROTOCOLS.includes(url.protocol) || !url.hostname) return null;
+  return url.origin;
+}
+
+export function handleRequest(body) {
+  if (!body || typeof body !== "object") {
+    return { status: 400, body: { error: "origin_required" } };
+  }
+
+  const { origin, scopes } = body;
+
+  if (typeof origin === "undefined" || origin === null || origin === "") {
+    return { status: 400, body: { error: "origin_required" } };
+  }
+
+  if (typeof origin !== "string") {
+    return { status: 400, body: { error: "origin_must_be_string" } };
+  }
+
+  const normalizedOrigin = normalizeOrigin(origin.trim());
+  if (!normalizedOrigin) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_origin",
+        message: `"${origin}" is not an http(s) origin URL`,
+      },
+    };
+  }
+
+  let grantedScopes = DEFAULT_SCOPES;
+  if (typeof scopes !== "undefined") {
+    if (!Array.isArray(scopes) || scopes.length === 0) {
+      return { status: 400, body: { error: "scopes_must_be_non_empty_array" } };
+    }
+    const unknown = scopes.filter((s) => !ALLOWED_SCOPES.includes(s));
+    if (unknown.length > 0) {
+      return {
+        status: 400,
+        body: {
+          error: "invalid_scope",
+          message: `Unknown scope(s): ${unknown.join(", ")}. Must be one of: ${ALLOWED_SCOPES.join(", ")}`,
+        },
+      };
+    }
+    grantedScopes = [...new Set(scopes)];
+  }
+
+  return {
+    status: 201,
+    body: {
+      granted: true,
+      grantId: `grant_${randomUUID()}`,
+      origin: normalizedOrigin,
+      scopes: grantedScopes,
+      grantedAt: new Date().toISOString(),
+    },
+  };
+}
+
+export { ALLOWED_SCOPES, DEFAULT_SCOPES };
+
+// pathToFileURL keeps the entrypoint check correct on Windows and with
+// relative argv paths, where a raw `file://` + argv[1] concatenation never
+// matches import.meta.url.
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/permission-grant") {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(data);
+          const { status, body: resp } = handleRequest(body);
+          res.writeHead(status, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(resp));
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "invalid_json" }));
+        }
+      });
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  // 4045 (the issue number) is on the WHATWG blocked-port list, so browsers
+  // and `fetch()` refuse to talk to it — 4145 keeps the same digits and works.
+  const port = process.env.PORT || 4145;
+  server.listen(port, () => {
+    console.log(`permission-grant mock listening on http://localhost:${port}/permission-grant`);
+  });
+}

--- a/contrib/routes/issue-45-permission-grant/route.test.mjs
+++ b/contrib/routes/issue-45-permission-grant/route.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { handleRequest, DEFAULT_SCOPES } from "./route.mjs";
+
+// Success: a valid origin is granted and echoed back, normalized.
+let { status, body } = handleRequest({ origin: "https://app.example.com/dashboard" });
+assert.equal(status, 201);
+assert.equal(body.granted, true);
+assert.equal(body.origin, "https://app.example.com");
+assert.deepEqual(body.scopes, DEFAULT_SCOPES);
+assert.match(body.grantId, /^grant_/);
+assert.ok(!Number.isNaN(Date.parse(body.grantedAt)), "grantedAt must be a valid timestamp");
+
+// Success: explicit scopes are echoed back, deduplicated.
+({ status, body } = handleRequest({
+  origin: "https://dapp.example.org",
+  scopes: ["accounts:read", "payments:sign", "accounts:read"],
+}));
+assert.equal(status, 201);
+assert.deepEqual(body.scopes, ["accounts:read", "payments:sign"]);
+
+// Missing origin.
+({ status, body } = handleRequest({ scopes: ["accounts:read"] }));
+assert.equal(status, 400);
+assert.equal(body.error, "origin_required");
+
+// Missing body entirely.
+({ status, body } = handleRequest());
+assert.equal(status, 400);
+assert.equal(body.error, "origin_required");
+
+// Origin present but not a URL.
+({ status, body } = handleRequest({ origin: "not-a-url" }));
+assert.equal(status, 400);
+assert.equal(body.error, "invalid_origin");
+
+// Non-web protocols are rejected.
+({ status, body } = handleRequest({ origin: "javascript:alert(1)" }));
+assert.equal(status, 400);
+assert.equal(body.error, "invalid_origin");
+
+// Wrong type for origin.
+({ status, body } = handleRequest({ origin: 42 }));
+assert.equal(status, 400);
+assert.equal(body.error, "origin_must_be_string");
+
+// Unknown scope.
+({ status, body } = handleRequest({ origin: "https://app.example.com", scopes: ["root"] }));
+assert.equal(status, 400);
+assert.equal(body.error, "invalid_scope");
+
+console.log("PASS: /permission-grant handles valid grants, missing origin, and bad input");


### PR DESCRIPTION
closes #45

## What

Adds a standalone mock POST route under
`contrib/routes/issue-45-permission-grant/` that accepts a body granting a dApp
origin permission and echoes back a confirmation record.

## Files

- `contrib/routes/issue-45-permission-grant/route.mjs` - `handleRequest(body)` plus a `node:http` server when run directly (`POST /permission-grant`, port 4145, `PORT` overridable).
- `contrib/routes/issue-45-permission-grant/route.test.mjs` - `node:assert` test.
- `contrib/routes/issue-45-permission-grant/README.md` - request/response docs and the error-code table.

## Behaviour

`origin` is required and must parse as an `http(s)` URL. It is normalized down
to a bare origin (scheme + host + port) before being echoed, so
`https://app.example.com/dashboard` comes back as `https://app.example.com`.
Non-web schemes such as `javascript:` and `data:` are rejected rather than
accepted as merely parseable.

`scopes` is optional, defaults to `["accounts:read"]`, is validated against the
supported set (`accounts:read`, `payments:sign`, `policies:read`), and is
deduplicated.

Success returns `201`:

```json
{
  "granted": true,
  "grantId": "grant_2f0a1c5e-9c1c-4a4a-8f1a-4a6f1f4b9d21",
  "origin": "https://app.example.com",
  "scopes": ["accounts:read", "payments:sign"],
  "grantedAt": "2026-07-29T12:00:00.000Z"
}
```

Errors are `400` with a code: `origin_required`, `origin_must_be_string`,
`invalid_origin`, `scopes_must_be_non_empty_array`, `invalid_scope`, and
`invalid_json` from the server wrapper.

## Verification

```
node contrib/routes/issue-45-permission-grant/route.test.mjs
PASS: /permission-grant handles valid grants, missing origin, and bad input
```

Covers the success case (including normalization and scope deduplication), the
missing-origin case required by the issue, an absent body, a non-URL origin, a
`javascript:` scheme, a non-string origin, and an unknown scope. The server was
also exercised over HTTP for the `201`, `400 origin_required`,
`400 invalid_json`, and `404 not_found` paths.

## Notes

Two small deviations from the older `contrib/routes/` modules, both deliberate:

- The port default is `4145`, not `4045`. Port 4045 is on the WHATWG
  blocked-port list, so browsers and the Node `fetch()` implementation refuse to
  connect to it, which makes a mock on that port unreachable from anything that
  respects the list. There is a comment in the file explaining it.
- The entrypoint guard uses `pathToFileURL(process.argv[1]).href` rather than
  the `file://` + `argv[1]` string concatenation used elsewhere, which never
  matches `import.meta.url` on Windows or with a relative `argv[1]`, so
  `node route.mjs` exits without starting the server.

Happy to align either back if you would rather fix them repo-wide separately.

## Scope

All changes are inside `contrib/`. Base branch is `drips`.
