### PR TITLE
feat(contrib): add mock permission-status route

### DIFF
--- a/contrib/routes/issue-46-permission-status/README.md
+++ b/contrib/routes/issue-46-permission-status/README.md
@@ -1,0 +1,71 @@
+# Mock route: origin permission status (Issue #46)
+
+Standalone mock GET route reporting whether a given dApp origin currently holds
+an active permission grant. The origin is passed as a query parameter and
+looked up against a fixed sample dataset — no chain or database access.
+
+An unknown origin is not an error: the route answers `200` with
+`granted: false`, so callers can treat "no grant" and "grant" with the same
+response shape.
+
+## Run
+
+```sh
+node route.mjs
+# permission-status mock listening on http://localhost:4046/permission-status
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+Covers a known origin, a known origin supplied with a path (normalization), an
+unknown origin, a missing `origin` parameter, and a malformed one.
+
+## Request
+
+```
+GET /permission-status?origin=https://app.example.com
+```
+
+The value is normalized to a bare origin (scheme + host + port) before lookup,
+so `https://app.example.com/settings` resolves to the same record.
+
+Sample dataset origins: `https://app.example.com`, `https://dapp.example.org`,
+`http://localhost:3000`.
+
+## Response
+
+Known origin:
+
+```json
+{
+  "origin": "https://app.example.com",
+  "granted": true,
+  "grantId": "grant_4f1c1a20",
+  "scopes": ["accounts:read", "payments:sign"],
+  "grantedAt": "2026-05-02T10:12:00.000Z"
+}
+```
+
+Unknown origin:
+
+```json
+{
+  "origin": "https://unknown.example.net",
+  "granted": false,
+  "scopes": [],
+  "grantedAt": null
+}
+```
+
+## Errors
+
+| Status | Code              | When                                      |
+| ------ | ----------------- | ----------------------------------------- |
+| 400    | `origin_required` | `origin` query parameter missing or empty |
+| 400    | `invalid_origin`  | `origin` is not a parseable http(s) URL   |
+
+Any other method or path returns `404` with `{ "error": "not_found" }`.

--- a/contrib/routes/issue-46-permission-status/route.mjs
+++ b/contrib/routes/issue-46-permission-status/route.mjs
@@ -1,0 +1,93 @@
+// Mock GET route reporting whether a dApp origin holds an active permission
+// grant. Reads from a fixed sample dataset — no chain or DB access.
+import http from "node:http";
+import { pathToFileURL } from "node:url";
+
+const GRANTS = {
+  "https://app.example.com": {
+    grantId: "grant_4f1c1a20",
+    scopes: ["accounts:read", "payments:sign"],
+    grantedAt: "2026-05-02T10:12:00.000Z",
+  },
+  "https://dapp.example.org": {
+    grantId: "grant_88ba90d3",
+    scopes: ["accounts:read"],
+    grantedAt: "2026-06-18T08:30:00.000Z",
+  },
+  "http://localhost:3000": {
+    grantId: "grant_local_dev",
+    scopes: ["accounts:read", "policies:read"],
+    grantedAt: "2026-07-01T14:00:00.000Z",
+  },
+};
+
+// A grant is looked up by bare origin, so `https://app.example.com/some/path`
+// and `https://app.example.com` resolve to the same record.
+function normalizeOrigin(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.hostname ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+export function handleRequest({ query = {} } = {}) {
+  const raw = query.origin;
+
+  if (typeof raw !== "string" || raw.trim() === "") {
+    return { status: 400, body: { error: "origin_required" } };
+  }
+
+  const origin = normalizeOrigin(raw.trim());
+  if (!origin) {
+    return {
+      status: 400,
+      body: { error: "invalid_origin", message: `"${raw}" is not an http(s) origin URL` },
+    };
+  }
+
+  const grant = GRANTS[origin];
+  if (!grant) {
+    // Unknown origins are not an error — they simply have no grant.
+    return { status: 200, body: { origin, granted: false, scopes: [], grantedAt: null } };
+  }
+
+  return {
+    status: 200,
+    body: {
+      origin,
+      granted: true,
+      grantId: grant.grantId,
+      scopes: grant.scopes,
+      grantedAt: grant.grantedAt,
+    },
+  };
+}
+
+export { GRANTS };
+
+// pathToFileURL keeps the entrypoint check correct on Windows and with
+// relative argv paths, where a raw `file://` + argv[1] concatenation never
+// matches import.meta.url.
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/permission-status") {
+      const { status, body } = handleRequest({
+        query: { origin: url.searchParams.get("origin") ?? undefined },
+      });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4046;
+  server.listen(port, () => {
+    console.log(`permission-status mock listening on http://localhost:${port}/permission-status`);
+  });
+}

--- a/contrib/routes/issue-46-permission-status/route.test.mjs
+++ b/contrib/routes/issue-46-permission-status/route.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { handleRequest, GRANTS } from "./route.mjs";
+
+// Known origin: reports the grant.
+let { status, body } = handleRequest({ query: { origin: "https://app.example.com" } });
+assert.equal(status, 200);
+assert.equal(body.granted, true);
+assert.equal(body.origin, "https://app.example.com");
+assert.equal(body.grantId, GRANTS["https://app.example.com"].grantId);
+assert.ok(Array.isArray(body.scopes) && body.scopes.length > 0);
+assert.ok(!Number.isNaN(Date.parse(body.grantedAt)));
+
+// Known origin with a path: normalized to the bare origin before lookup.
+({ status, body } = handleRequest({ query: { origin: "https://app.example.com/settings" } }));
+assert.equal(status, 200);
+assert.equal(body.granted, true);
+assert.equal(body.origin, "https://app.example.com");
+
+// Unknown origin: granted is false, not an error.
+({ status, body } = handleRequest({ query: { origin: "https://unknown.example.net" } }));
+assert.equal(status, 200);
+assert.equal(body.granted, false);
+assert.deepEqual(body.scopes, []);
+assert.equal(body.grantedAt, null);
+
+// Missing origin parameter.
+({ status, body } = handleRequest({ query: {} }));
+assert.equal(status, 400);
+assert.equal(body.error, "origin_required");
+
+({ status, body } = handleRequest());
+assert.equal(status, 400);
+assert.equal(body.error, "origin_required");
+
+// Malformed origin.
+({ status, body } = handleRequest({ query: { origin: "not-a-url" } }));
+assert.equal(status, 400);
+assert.equal(body.error, "invalid_origin");
+
+console.log("PASS: /permission-status handles known, unknown, missing, and malformed origins");


### PR DESCRIPTION
closes #46

## What

Adds a standalone mock GET route under
`contrib/routes/issue-46-permission-status/` reporting whether a given dApp
origin holds an active permission grant.

## Files

- `contrib/routes/issue-46-permission-status/route.mjs` - `handleRequest({ query })` plus a `node:http` server when run directly (`GET /permission-status?origin=...`, port 4046, `PORT` overridable).
- `contrib/routes/issue-46-permission-status/route.test.mjs` - `node:assert` test.
- `contrib/routes/issue-46-permission-status/README.md` - dataset, request/response examples, error table.

## Behaviour

The `origin` query parameter is normalized to a bare origin (scheme + host +
port) before lookup, so `https://app.example.com/settings` resolves to the same
record as `https://app.example.com`.

An unknown origin is deliberately not an error - it returns `200` with
`granted: false`, an empty `scopes` array, and `grantedAt: null`, so callers get
one response shape whether or not a grant exists:

```json
{
  "origin": "https://unknown.example.net",
  "granted": false,
  "scopes": [],
  "grantedAt": null
}
```

A known origin adds `grantId`, `scopes`, and `grantedAt`. Sample dataset
origins: `https://app.example.com`, `https://dapp.example.org`,
`http://localhost:3000`.

A missing or malformed `origin` returns `400` with `origin_required` or
`invalid_origin`.

## Verification

```
node contrib/routes/issue-46-permission-status/route.test.mjs
PASS: /permission-status handles known, unknown, missing, and malformed origins
```

Covers the known and unknown origins required by the issue, plus a known origin
supplied with a path (normalization), a missing parameter, and a non-URL value.
The server was also exercised over HTTP.

## Notes

Follows the existing `contrib/routes/` convention, with one deviation: the
entrypoint guard uses `pathToFileURL(process.argv[1]).href` rather than the
`file://` + `argv[1]` string concatenation used by older modules, which never
matches `import.meta.url` on Windows or with a relative `argv[1]`, so
`node route.mjs` silently exits without starting the server. Happy to switch
back if you would rather address that repo-wide.

## Scope

All changes are inside `contrib/`. Base branch is `drips`.
