### PR TITLE
feat(contrib): add mock cleanup-plan route

### DIFF
--- a/contrib/routes/issue-47-cleanup-plan/README.md
+++ b/contrib/routes/issue-47-cleanup-plan/README.md
@@ -1,0 +1,66 @@
+# Mock route: account cleanup plan (Issue #47)
+
+Standalone mock GET route returning a fixed sample account cleanup plan — the
+set of things standing between an account and a merge.
+
+The payload carries a `blockers` array (each entry has a `type` and a
+`description`) and a `mergeReady` boolean. `mergeReady` is always derived from
+the blockers list inside `buildPlan`, never stored next to it, so the flag
+cannot drift out of sync with the data it summarizes.
+
+No chain or database access — the plan is a hard-coded fixture.
+
+## Run
+
+```sh
+node route.mjs
+# cleanup-plan mock listening on http://localhost:4047/cleanup-plan
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+The test checks the response shape and asserts the `mergeReady` logic in both
+directions: false for the sample plan and for a plan with a single blocker,
+true only when `blockers` is empty.
+
+## Blocker types
+
+`trustline`, `offer`, `data_entry`, `signer`, `balance`.
+
+## Example
+
+Request:
+
+```
+GET /cleanup-plan
+```
+
+Response:
+
+```json
+{
+  "accountId": "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+  "generatedAt": "2026-07-20T09:00:00.000Z",
+  "blockers": [
+    {
+      "type": "trustline",
+      "description": "Trustline to USDC must be removed before the account can be merged."
+    },
+    {
+      "type": "offer",
+      "description": "One open offer (XLM for EURC) is still on the order book."
+    },
+    {
+      "type": "data_entry",
+      "description": "Managed data entry \"vellar:device\" must be deleted."
+    }
+  ],
+  "mergeReady": false
+}
+```
+
+Any other method or path returns `404` with `{ "error": "not_found" }`.

--- a/contrib/routes/issue-47-cleanup-plan/route.mjs
+++ b/contrib/routes/issue-47-cleanup-plan/route.mjs
@@ -1,0 +1,59 @@
+// Mock GET route returning a fixed sample account cleanup plan. No chain or
+// DB access.
+import http from "node:http";
+import { pathToFileURL } from "node:url";
+
+const BLOCKER_TYPES = ["trustline", "offer", "data_entry", "signer", "balance"];
+
+const SAMPLE_BLOCKERS = [
+  {
+    type: "trustline",
+    description: "Trustline to USDC must be removed before the account can be merged.",
+  },
+  {
+    type: "offer",
+    description: "One open offer (XLM for EURC) is still on the order book.",
+  },
+  {
+    type: "data_entry",
+    description: 'Managed data entry "vellar:device" must be deleted.',
+  },
+];
+
+// mergeReady is always derived from the blockers list — never stored alongside
+// it — so the two can't drift apart.
+export function buildPlan(blockers) {
+  return {
+    accountId: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+    generatedAt: "2026-07-20T09:00:00.000Z",
+    blockers,
+    mergeReady: blockers.length === 0,
+  };
+}
+
+export function handleRequest() {
+  return { status: 200, body: buildPlan(SAMPLE_BLOCKERS) };
+}
+
+export { BLOCKER_TYPES, SAMPLE_BLOCKERS };
+
+// pathToFileURL keeps the entrypoint check correct on Windows and with
+// relative argv paths, where a raw `file://` + argv[1] concatenation never
+// matches import.meta.url.
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/cleanup-plan") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4047;
+  server.listen(port, () => {
+    console.log(`cleanup-plan mock listening on http://localhost:${port}/cleanup-plan`);
+  });
+}

--- a/contrib/routes/issue-47-cleanup-plan/route.test.mjs
+++ b/contrib/routes/issue-47-cleanup-plan/route.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { handleRequest, buildPlan, BLOCKER_TYPES } from "./route.mjs";
+
+const { status, body } = handleRequest();
+
+assert.equal(status, 200);
+assert.equal(typeof body.accountId, "string");
+assert.ok(!Number.isNaN(Date.parse(body.generatedAt)));
+assert.ok(Array.isArray(body.blockers));
+assert.ok(body.blockers.length > 0, "sample plan has blockers to resolve");
+
+for (const blocker of body.blockers) {
+  assert.ok(BLOCKER_TYPES.includes(blocker.type), `unexpected blocker type: ${blocker.type}`);
+  assert.equal(typeof blocker.description, "string");
+  assert.ok(blocker.description.length > 0);
+}
+
+// mergeReady must track the blockers list in both directions.
+assert.equal(typeof body.mergeReady, "boolean");
+assert.equal(body.mergeReady, false, "plan with blockers is not merge ready");
+assert.equal(body.mergeReady, body.blockers.length === 0);
+
+const clean = buildPlan([]);
+assert.equal(clean.mergeReady, true, "plan with no blockers is merge ready");
+assert.deepEqual(clean.blockers, []);
+
+const single = buildPlan([{ type: "signer", description: "Extra signer must be removed." }]);
+assert.equal(single.mergeReady, false, "a single blocker still blocks the merge");
+
+console.log("PASS: /cleanup-plan returns blockers and derives mergeReady correctly");


### PR DESCRIPTION
closes #47

## What

Adds a standalone mock GET route under `contrib/routes/issue-47-cleanup-plan/`
returning a fixed sample account cleanup plan.

## Files

- `contrib/routes/issue-47-cleanup-plan/route.mjs` - `handleRequest()` and an exported `buildPlan(blockers)`, plus a `node:http` server when run directly (`GET /cleanup-plan`, port 4047, `PORT` overridable).
- `contrib/routes/issue-47-cleanup-plan/route.test.mjs` - `node:assert` test.
- `contrib/routes/issue-47-cleanup-plan/README.md` - run/test instructions, blocker types, example payload.

## Shape

The payload carries a `blockers` array - each entry with a `type`
(`trustline`, `offer`, `data_entry`, `signer`, `balance`) and a human-readable
`description` - alongside `accountId`, `generatedAt`, and a `mergeReady`
boolean.

`mergeReady` is computed inside `buildPlan` as `blockers.length === 0` rather
than stored next to the list, so the flag cannot drift out of sync with the data
it summarizes. Exporting `buildPlan` also makes the derivation testable in both
directions without a second fixture.

## Verification

```
node contrib/routes/issue-47-cleanup-plan/route.test.mjs
PASS: /cleanup-plan returns blockers and derives mergeReady correctly
```

Asserts the response shape (every blocker has a known `type` and a non-empty
`description`) and the `mergeReady` logic in both directions: `false` for the
sample plan and for a plan with a single blocker, `true` only when `blockers` is
empty. The server was also exercised over HTTP.

## Notes

Follows the existing `contrib/routes/` convention, with one deviation: the
entrypoint guard uses `pathToFileURL(process.argv[1]).href` rather than the
`file://` + `argv[1]` string concatenation used by older modules, which never
matches `import.meta.url` on Windows or with a relative `argv[1]`, so
`node route.mjs` silently exits without starting the server. Happy to switch
back if you would rather address that repo-wide.

## Scope

All changes are inside `contrib/`. Base branch is `drips`.
