### PR TITLE
contrib(routes): add rate-limit-info mock route

### DIFF
--- a/contrib/routes/issue-53-rate-limit-info/README.md
+++ b/contrib/routes/issue-53-rate-limit-info/README.md
@@ -1,0 +1,61 @@
+# Mock route: rate limit info (Issue #53)
+
+Standalone mock GET route returning a JSON payload that describes sample rate
+limit values, mirroring the common `X-RateLimit-*` response headers as body
+fields. No real chain, database, or rate limiter is involved.
+
+## Run
+
+```sh
+node route.mjs
+# rate-limit-info mock listening on http://localhost:4153/rate-limit-info
+```
+
+Port 4153 is the default because 4053 is already taken by
+`contrib/routes/full-cleanup-merge-suite`. Override with `PORT=... node route.mjs`.
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example
+
+Request:
+
+```
+GET /rate-limit-info
+```
+
+Response:
+
+```json
+{
+  "limit": 1000,
+  "remaining": 987,
+  "resetAt": "2026-07-20T09:16:00.000Z"
+}
+```
+
+## Fields
+
+| Field       | Type             | Meaning                                                                 |
+| ----------- | ---------------- | ----------------------------------------------------------------------- |
+| `limit`     | number           | Calls allowed per window. Plain integer, not a string.                  |
+| `remaining` | number           | Calls left in the current window. Integer, `0 <= remaining <= limit`.   |
+| `resetAt`   | string, ISO 8601 | UTC instant the current window ends and `remaining` returns to `limit`. |
+
+The sample quota is 1000 calls per fixed 60 second window, with 13 already
+consumed. Windows are aligned to the Unix epoch rather than to the time of the
+request, so every caller inside the same window sees the same `resetAt`; a
+request landing exactly on a boundary reports the next boundary, never one that
+has already passed.
+
+`handleRequest` accepts an optional `now` (epoch milliseconds) so tests can pin
+the clock:
+
+```js
+handleRequest({ now: Date.parse("2026-07-20T09:15:37.500Z") });
+// resetAt: "2026-07-20T09:16:00.000Z"
+```

--- a/contrib/routes/issue-53-rate-limit-info/route.mjs
+++ b/contrib/routes/issue-53-rate-limit-info/route.mjs
@@ -1,6 +1,7 @@
 // Mock GET route reporting sample rate limit values as JSON body fields,
 // mirroring the usual X-RateLimit-* response headers. No chain or DB access.
 import http from "node:http";
+import { pathToFileURL } from "node:url";
 
 // Quota for the sample client: 1000 calls per fixed 60 second window.
 const LIMIT = 1000;
@@ -25,7 +26,9 @@ export function handleRequest({ now = Date.now() } = {}) {
   };
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+// pathToFileURL rather than a `file://` template: on Windows argv[1] is a
+// drive path, which does not compare equal to import.meta.url otherwise.
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   const server = http.createServer((req, res) => {
     if (req.method === "GET" && req.url === "/rate-limit-info") {

--- a/contrib/routes/issue-53-rate-limit-info/route.mjs
+++ b/contrib/routes/issue-53-rate-limit-info/route.mjs
@@ -1,0 +1,44 @@
+// Mock GET route reporting sample rate limit values as JSON body fields,
+// mirroring the usual X-RateLimit-* response headers. No chain or DB access.
+import http from "node:http";
+
+// Quota for the sample client: 1000 calls per fixed 60 second window.
+const LIMIT = 1000;
+const WINDOW_SECONDS = 60;
+const CONSUMED = 13;
+
+// Start of the window after the one containing `nowMs`. Windows are aligned to
+// the Unix epoch, so the value is stable for every caller inside a window.
+function nextWindowStart(nowMs) {
+  const windowMs = WINDOW_SECONDS * 1000;
+  return new Date(Math.floor(nowMs / windowMs) * windowMs + windowMs);
+}
+
+export function handleRequest({ now = Date.now() } = {}) {
+  return {
+    status: 200,
+    body: {
+      limit: LIMIT,
+      remaining: LIMIT - CONSUMED,
+      resetAt: nextWindowStart(now).toISOString(),
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/rate-limit-info") {
+      const { status, body } = handleRequest();
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4153;
+  server.listen(port, () => {
+    console.log(`rate-limit-info mock listening on http://localhost:${port}/rate-limit-info`);
+  });
+}

--- a/contrib/routes/issue-53-rate-limit-info/route.test.mjs
+++ b/contrib/routes/issue-53-rate-limit-info/route.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// All three documented fields are present, with the documented types.
+const { status, body } = handleRequest();
+assert.equal(status, 200);
+for (const field of ["limit", "remaining", "resetAt"]) {
+  assert.ok(Object.hasOwn(body, field), `missing field: ${field}`);
+}
+assert.equal(typeof body.limit, "number");
+assert.equal(typeof body.remaining, "number");
+assert.equal(typeof body.resetAt, "string");
+
+// remaining never exceeds limit and never goes negative.
+assert.ok(body.remaining >= 0 && body.remaining <= body.limit);
+
+// resetAt is a parseable ISO 8601 timestamp in the future.
+const resetAt = new Date(body.resetAt);
+assert.ok(!Number.isNaN(resetAt.getTime()), "resetAt is not a valid date");
+assert.equal(resetAt.toISOString(), body.resetAt);
+assert.ok(resetAt.getTime() > Date.now());
+
+// The window is aligned to the epoch, so an injected clock gives a fixed
+// answer: 09:15:37Z sits in the 09:15:00-09:16:00 window and resets at 09:16.
+const fixed = handleRequest({ now: Date.parse("2026-07-20T09:15:37.500Z") });
+assert.equal(fixed.body.resetAt, "2026-07-20T09:16:00.000Z");
+
+// A caller landing exactly on a boundary gets the *next* boundary, never one
+// that has already passed.
+const onBoundary = handleRequest({ now: Date.parse("2026-07-20T09:15:00.000Z") });
+assert.equal(onBoundary.body.resetAt, "2026-07-20T09:16:00.000Z");
+
+console.log("PASS: /rate-limit-info returns limit, remaining and resetAt");


### PR DESCRIPTION
## Summary

Adds a standalone mock GET route under `contrib/routes/` that returns a JSON payload describing sample rate limit values, mirroring the common `X-RateLimit-*` response headers as body fields. No chain, database, or real rate limiter is involved.

closes #53

## What is in the module

`contrib/routes/issue-53-rate-limit-info/`

| File | Purpose |
| --- | --- |
| `README.md` | How to run and test it, plus a field-by-field table of the response |
| `route.mjs` | `handleRequest` plus a small `node:http` server behind an `isMain` guard |
| `route.test.mjs` | Assertions, runnable with plain `node`, no test runner or dependencies |

The shape follows the existing sibling modules (`issue-33-policy-list`, `issue-64-policy-templates` and friends): a pure `handleRequest` that returns `{ status, body }`, exported so tests can call it directly, with the HTTP server only spun up when the file is executed rather than imported.

## Response fields

| Field | Type | Meaning |
| --- | --- | --- |
| `limit` | number | Calls allowed per window. Plain integer, not a string. |
| `remaining` | number | Calls left in the current window. Integer, `0 <= remaining <= limit`. |
| `resetAt` | string, ISO 8601 | UTC instant the window ends and `remaining` returns to `limit`. |

```json
{
  "limit": 1000,
  "remaining": 987,
  "resetAt": "2026-07-20T09:16:00.000Z"
}
```

The sample quota is 1000 calls per fixed 60 second window with 13 consumed. All three fields and their types are documented in the README.

## Notes on the two judgement calls

**Windows are aligned to the Unix epoch, not to the time of the request.** A per-request offset would hand two callers inside the same window two different `resetAt` values, which is the opposite of what a rate limit header means and would quietly teach a consumer the wrong retry model. Aligning to the epoch also makes the boundary case well defined: a request landing exactly on a boundary reports the *next* boundary, never one that has already passed, so `resetAt` is always in the future.

**`handleRequest` takes an optional `now`.** Otherwise the only assertion available against `resetAt` is "it parses", and the window arithmetic goes untested. With an injected clock the test pins an exact expected value:

```js
handleRequest({ now: Date.parse("2026-07-20T09:15:37.500Z") });
// resetAt: "2026-07-20T09:16:00.000Z"
```

It defaults to `Date.now()`, so the HTTP path is unaffected.

## Testing

```sh
node contrib/routes/issue-53-rate-limit-info/route.test.mjs
# PASS: /rate-limit-info returns limit, remaining and resetAt
```

Covers: all three fields present and correctly typed, `remaining` within `[0, limit]`, `resetAt` a round-trippable ISO string in the future, and the pinned-clock and exactly-on-boundary cases.

Also smoke tested over HTTP with `node route.mjs`, including the 404 fallthrough on an unknown path.

## Two things worth flagging for review

**The default port is 4153, not 4053.** Sibling modules use `4000 + issue number`, but 4053 is already taken by `contrib/routes/full-cleanup-merge-suite`. Rather than ship a collision I moved to 4153 and said why in the README. Happy to renumber if you would rather keep the convention strictly.

**The `isMain` guard differs slightly from the sibling modules.** They use ``import.meta.url === `file://${process.argv[1]}` ``, which never matches on Windows, where `argv[1]` is a drive path such as `C:\...` rather than `/...`. The practical effect is that `node route.mjs` exits 0 without listening and prints nothing, which is a confusing first experience. This module uses `pathToFileURL(process.argv[1]).href`, which is correct on every platform. I have kept the change inside my own folder and have not touched the existing modules, but the same one-line fix would apply to all of them if you want it as a separate sweep.

## Scope

Entirely inside `contrib/`, three new files in one new folder, nothing outside it added, edited, renamed, or deleted. Branched from `drips` and targeting `drips`.
