### PR TITLE
contrib(routes): add cursor-page mock route

### DIFF
--- a/contrib/routes/issue-54-cursor-page/README.md
+++ b/contrib/routes/issue-54-cursor-page/README.md
@@ -1,0 +1,84 @@
+# Mock route: cursor page (Issue #54)
+
+Standalone mock GET route returning a page of sample items together with a
+cursor pointing at the next page. No real chain or database access.
+
+The sample set holds 10 items and the page size is 4, so the data pages as
+4 + 4 + 2.
+
+## Run
+
+```sh
+node route.mjs
+# cursor-page mock listening on http://localhost:4054/cursor-page
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Query parameters
+
+| Parameter | Required | Meaning                                                          |
+| --------- | -------- | ---------------------------------------------------------------- |
+| `cursor`  | no       | Opaque marker from a previous response. Omit for the first page. |
+
+## Response
+
+| Field        | Type           | Meaning                                                 |
+| ------------ | -------------- | ------------------------------------------------------- |
+| `items`      | array          | The items on this page.                                 |
+| `nextCursor` | string or null | Cursor for the following page, `null` on the last page. |
+
+`nextCursor` is always present, so callers can loop on
+`while (nextCursor !== null)` without checking for a missing key.
+
+## Example
+
+First page:
+
+```
+GET /cursor-page
+```
+
+```json
+{
+  "items": [
+    { "id": "itm_01", "label": "Coffee subscription" },
+    { "id": "itm_02", "label": "Domain renewal" },
+    { "id": "itm_03", "label": "Cloud storage" },
+    { "id": "itm_04", "label": "Team lunch" }
+  ],
+  "nextCursor": "b2Zmc2V0OjQ"
+}
+```
+
+Last page:
+
+```
+GET /cursor-page?cursor=b2Zmc2V0Ojg
+```
+
+```json
+{
+  "items": [
+    { "id": "itm_09", "label": "Payment processor fee" },
+    { "id": "itm_10", "label": "Hardware wallet" }
+  ],
+  "nextCursor": null
+}
+```
+
+## About the cursor
+
+Treat the cursor as opaque. It happens to be a base64url encoding of
+`offset:<n>`, but that is an implementation detail: do not parse it, do not do
+arithmetic on it, and do not construct one by hand.
+
+The route enforces that. A cursor it did not issue -- malformed, or an offset
+that is out of range or off a page boundary -- gets `400 invalid_cursor` rather
+than silently restarting at the first page, which would otherwise show up as a
+pagination loop in the caller. An omitted or empty `cursor` is not an error; it
+simply means "first page".

--- a/contrib/routes/issue-54-cursor-page/route.mjs
+++ b/contrib/routes/issue-54-cursor-page/route.mjs
@@ -1,0 +1,90 @@
+// Mock GET route returning a page of sample items plus an opaque cursor
+// pointing at the next page. No chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+
+const ITEMS = [
+  { id: "itm_01", label: "Coffee subscription" },
+  { id: "itm_02", label: "Domain renewal" },
+  { id: "itm_03", label: "Cloud storage" },
+  { id: "itm_04", label: "Team lunch" },
+  { id: "itm_05", label: "Conference ticket" },
+  { id: "itm_06", label: "Design contractor" },
+  { id: "itm_07", label: "Office supplies" },
+  { id: "itm_08", label: "Analytics plan" },
+  { id: "itm_09", label: "Payment processor fee" },
+  { id: "itm_10", label: "Hardware wallet" },
+];
+
+const PAGE_SIZE = 4;
+
+// Callers must treat cursors as opaque. Encoding the offset in base64url keeps
+// that honest: the value is not a number they can guess or arithmetic on.
+function encodeCursor(offset) {
+  return Buffer.from(`offset:${offset}`, "utf8").toString("base64url");
+}
+
+// Returns the offset, or null when the cursor is not one we issued.
+function decodeCursor(rawCursor) {
+  let decoded;
+  try {
+    decoded = Buffer.from(rawCursor, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+  const match = /^offset:(\d+)$/.exec(decoded);
+  if (!match) return null;
+  const offset = Number(match[1]);
+  // An offset past the end is as meaningless as a malformed one. Offsets that
+  // do not sit on a page boundary were never issued by this route either.
+  if (offset > ITEMS.length || offset % PAGE_SIZE !== 0) return null;
+  return offset;
+}
+
+export function handleRequest({ query = {} } = {}) {
+  const rawCursor = query.cursor;
+  const hasCursor = rawCursor !== undefined && rawCursor !== null && rawCursor !== "";
+
+  const offset = hasCursor ? decodeCursor(rawCursor) : 0;
+  if (offset === null) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_cursor",
+        message: "cursor must be a value returned as nextCursor by a previous request",
+      },
+    };
+  }
+
+  const items = ITEMS.slice(offset, offset + PAGE_SIZE);
+  const nextOffset = offset + items.length;
+  const isLastPage = nextOffset >= ITEMS.length;
+
+  return {
+    status: 200,
+    body: {
+      items,
+      nextCursor: isLastPage ? null : encodeCursor(nextOffset),
+    },
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/cursor-page") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleRequest({ query });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4054;
+  server.listen(port, () => {
+    console.log(`cursor-page mock listening on http://localhost:${port}/cursor-page`);
+  });
+}

--- a/contrib/routes/issue-54-cursor-page/route.mjs
+++ b/contrib/routes/issue-54-cursor-page/route.mjs
@@ -1,7 +1,7 @@
 // Mock GET route returning a page of sample items plus an opaque cursor
 // pointing at the next page. No chain or DB access.
 import http from "node:http";
-import { URL } from "node:url";
+import { pathToFileURL, URL } from "node:url";
 
 const ITEMS = [
   { id: "itm_01", label: "Coffee subscription" },
@@ -69,7 +69,9 @@ export function handleRequest({ query = {} } = {}) {
   };
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+// pathToFileURL rather than a `file://` template: on Windows argv[1] is a
+// drive path, which does not compare equal to import.meta.url otherwise.
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, "http://localhost");

--- a/contrib/routes/issue-54-cursor-page/route.test.mjs
+++ b/contrib/routes/issue-54-cursor-page/route.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+// First page: no cursor supplied, so the route starts at the beginning.
+const first = handleRequest({ query: {} });
+assert.equal(first.status, 200);
+assert.ok(Array.isArray(first.body.items));
+assert.equal(first.body.items.length, 4);
+assert.deepEqual(
+  first.body.items.map((item) => item.id),
+  ["itm_01", "itm_02", "itm_03", "itm_04"],
+);
+assert.equal(typeof first.body.nextCursor, "string");
+
+// An empty cursor means the same thing as no cursor at all.
+assert.deepEqual(handleRequest({ query: { cursor: "" } }).body, first.body);
+
+// Second page: following nextCursor advances without repeating items.
+const second = handleRequest({ query: { cursor: first.body.nextCursor } });
+assert.equal(second.status, 200);
+assert.deepEqual(
+  second.body.items.map((item) => item.id),
+  ["itm_05", "itm_06", "itm_07", "itm_08"],
+);
+assert.equal(typeof second.body.nextCursor, "string");
+assert.notEqual(second.body.nextCursor, first.body.nextCursor);
+
+// Last page: a short page, and nextCursor is null rather than absent.
+const last = handleRequest({ query: { cursor: second.body.nextCursor } });
+assert.equal(last.status, 200);
+assert.deepEqual(
+  last.body.items.map((item) => item.id),
+  ["itm_09", "itm_10"],
+);
+assert.ok(Object.hasOwn(last.body, "nextCursor"));
+assert.equal(last.body.nextCursor, null);
+
+// Walking the pages visits every item exactly once, in order.
+const walked = [];
+let cursor;
+do {
+  const page = handleRequest({ query: cursor ? { cursor } : {} });
+  walked.push(...page.body.items);
+  cursor = page.body.nextCursor;
+} while (cursor !== null);
+assert.equal(walked.length, 10);
+assert.equal(new Set(walked.map((item) => item.id)).size, 10);
+
+// A cursor we never issued is rejected instead of silently paging from 0.
+for (const bad of ["not-a-cursor", Buffer.from("offset:3").toString("base64url")]) {
+  const rejected = handleRequest({ query: { cursor: bad } });
+  assert.equal(rejected.status, 400);
+  assert.equal(rejected.body.error, "invalid_cursor");
+}
+
+console.log("PASS: /cursor-page pages through items and ends with nextCursor null");


### PR DESCRIPTION
## Summary

Adds a standalone mock GET route under `contrib/routes/` that returns a page of sample items together with an opaque cursor pointing at the next page. No chain or database access.

closes #54

## What is in the module

`contrib/routes/issue-54-cursor-page/`

| File | Purpose |
| --- | --- |
| `README.md` | How to run and test it, the parameter and response tables, and the cursor contract |
| `route.mjs` | `handleRequest` plus a small `node:http` server behind an `isMain` guard |
| `route.test.mjs` | Assertions, runnable with plain `node`, no test runner or dependencies |

The shape follows the existing sibling modules (`issue-26-transaction-history`, `issue-59-activity-log-cursor` and friends): a pure `handleRequest` returning `{ status, body }`, exported for direct testing, with the server only started when the file is executed rather than imported.

## Behaviour

The sample set holds 10 items and the page size is 4, so it pages as **4 + 4 + 2**. The deliberately short last page means the terminal case is a real one rather than an empty page tacked on the end.

| Parameter | Required | Meaning |
| --- | --- | --- |
| `cursor` | no | Opaque marker from a previous response. Omit for the first page. |

| Field | Type | Meaning |
| --- | --- | --- |
| `items` | array | The items on this page. |
| `nextCursor` | string or null | Cursor for the following page, `null` on the last page. |

First page:

```json
{
  "items": [
    { "id": "itm_01", "label": "Coffee subscription" },
    { "id": "itm_02", "label": "Domain renewal" },
    { "id": "itm_03", "label": "Cloud storage" },
    { "id": "itm_04", "label": "Team lunch" }
  ],
  "nextCursor": "b2Zmc2V0OjQ"
}
```

Last page (`GET /cursor-page?cursor=b2Zmc2V0Ojg`):

```json
{
  "items": [
    { "id": "itm_09", "label": "Payment processor fee" },
    { "id": "itm_10", "label": "Hardware wallet" }
  ],
  "nextCursor": null
}
```

`nextCursor` is always present and explicitly `null` on the last page, never omitted, so a caller can loop on `while (nextCursor !== null)` without also having to check for a missing key.

## Notes on the two judgement calls

**The cursor is opaque, and the route enforces it.** It happens to be a base64url encoding of `offset:<n>`, but the README tells callers not to parse it or do arithmetic on it, and the decoder backs that up: a value that is malformed, out of range, or off a page boundary was never issued by this route.

**An unrecognised cursor is `400 invalid_cursor` rather than a silent fallback to page one.** Silently restarting is the tempting choice, but it turns a caller-side bug into an infinite pagination loop that looks like a hang and gives no clue where it came from. Failing loudly points straight at the bad cursor. An omitted or empty `cursor` is a different thing entirely and is not an error: it simply means "first page".

## Testing

```sh
node contrib/routes/issue-54-cursor-page/route.test.mjs
# PASS: /cursor-page pages through items and ends with nextCursor null
```

Covers the two cases the issue asks for plus the ones that catch real pagination bugs:

- first page with no cursor, and an empty cursor behaving identically
- second page advancing without repeating items
- last page: short page, `nextCursor` present and `null`
- a full walk of every page, asserting all 10 items are visited exactly once and in order, so a duplicated or skipped page cannot pass
- cursors the route never issued, rejected with `400 invalid_cursor`

Also smoke tested over HTTP with `node route.mjs`, including the 404 fallthrough on an unknown path.

## One thing worth flagging for review

**The `isMain` guard differs slightly from the sibling modules.** They use ``import.meta.url === `file://${process.argv[1]}` ``, which never matches on Windows, where `argv[1]` is a drive path such as `C:\...` rather than `/...`. The practical effect is that `node route.mjs` exits 0 without listening and prints nothing. This module uses `pathToFileURL(process.argv[1]).href`, which is correct on every platform. I have kept the change inside my own folder and have not touched the existing modules, but the same one-line fix would apply to all of them if you want it as a separate sweep.

## Scope

Entirely inside `contrib/`, three new files in one new folder, nothing outside it added, edited, renamed, or deleted. Branched from `drips` and targeting `drips`.
