### PR TITLE
contrib(routes): add transactions-by-date mock route

### DIFF
--- a/contrib/routes/issue-55-transactions-by-date/README.md
+++ b/contrib/routes/issue-55-transactions-by-date/README.md
@@ -1,0 +1,91 @@
+# Mock route: transactions by date range (Issue #55)
+
+Standalone mock GET route listing sample transactions, filtered by an optional
+start and end date. No real chain or database access.
+
+The sample set holds 12 transactions spread across January to August 2026, so a
+range filter has something to actually narrow.
+
+## Run
+
+```sh
+node route.mjs
+# transactions-by-date mock listening on http://localhost:4055/transactions-by-date
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Query parameters
+
+| Parameter | Required | Meaning                                              |
+| --------- | -------- | ---------------------------------------------------- |
+| `from`    | no       | Lower bound, inclusive. Omit to leave it open-ended. |
+| `to`      | no       | Upper bound, inclusive. Omit to leave it open-ended. |
+
+Both bounds accept either a bare `YYYY-MM-DD` date or a full ISO 8601
+timestamp such as `2026-03-01T23:59:59Z`. Bare dates are read as UTC.
+
+Both bounds are inclusive. A bare date in `to` is widened to the end of that
+day, so `to=2026-03-01` includes a transaction stamped `2026-03-01T23:59:59Z`
+rather than only the midnight tick. `from=X&to=X` therefore means "everything
+that happened on day X".
+
+Results come back oldest first, whatever order the underlying sample data is
+stored in.
+
+## Example
+
+Request:
+
+```
+GET /transactions-by-date?from=2026-03-01&to=2026-03-22
+```
+
+Response:
+
+```json
+[
+  {
+    "id": "tx_03",
+    "amount": "200.0000000",
+    "asset": "XLM",
+    "timestamp": "2026-03-01T00:00:00Z"
+  },
+  {
+    "id": "tx_04",
+    "amount": "3.2500000",
+    "asset": "USDC",
+    "timestamp": "2026-03-01T23:59:59Z"
+  },
+  {
+    "id": "tx_05",
+    "amount": "75.0000000",
+    "asset": "XLM",
+    "timestamp": "2026-03-22T18:03:00Z"
+  }
+]
+```
+
+## Empty results are not errors
+
+This route always answers `200` with an array. A window that matches nothing
+comes back as `[]`:
+
+```
+GET /transactions-by-date?from=2027-01-01&to=2027-12-31
+```
+
+```json
+[]
+```
+
+That covers an inverted range (`from` later than `to`) as well, which is empty
+by definition rather than a rejection.
+
+An unparseable bound is dropped instead of rejected, for the same reason: the
+route still answers with a list, it just does not narrow on that side. So
+`?from=yesterday&to=2026-02-28` behaves as `?to=2026-02-28`.

--- a/contrib/routes/issue-55-transactions-by-date/route.mjs
+++ b/contrib/routes/issue-55-transactions-by-date/route.mjs
@@ -1,7 +1,7 @@
 // Mock GET route listing sample transactions filtered by a date range. No
 // chain or DB access.
 import http from "node:http";
-import { URL } from "node:url";
+import { pathToFileURL, URL } from "node:url";
 
 // Deliberately unsorted and spread across several months so range filtering
 // has something to actually do.
@@ -55,7 +55,9 @@ export function handleRequest({ query = {} } = {}) {
   return { status: 200, body: transactions };
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+// pathToFileURL rather than a `file://` template: on Windows argv[1] is a
+// drive path, which does not compare equal to import.meta.url otherwise.
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, "http://localhost");

--- a/contrib/routes/issue-55-transactions-by-date/route.mjs
+++ b/contrib/routes/issue-55-transactions-by-date/route.mjs
@@ -1,0 +1,78 @@
+// Mock GET route listing sample transactions filtered by a date range. No
+// chain or DB access.
+import http from "node:http";
+import { URL } from "node:url";
+
+// Deliberately unsorted and spread across several months so range filtering
+// has something to actually do.
+const TRANSACTIONS = [
+  { id: "tx_05", amount: "75.0000000", asset: "XLM", timestamp: "2026-03-22T18:03:00Z" },
+  { id: "tx_11", amount: "22.1000000", asset: "XLM", timestamp: "2026-07-19T08:05:00Z" },
+  { id: "tx_01", amount: "50.0000000", asset: "XLM", timestamp: "2026-01-04T09:15:00Z" },
+  { id: "tx_04", amount: "3.2500000", asset: "USDC", timestamp: "2026-03-01T23:59:59Z" },
+  { id: "tx_08", amount: "96.4000000", asset: "USDC", timestamp: "2026-06-11T11:59:00Z" },
+  { id: "tx_02", amount: "12.5000000", asset: "USDC", timestamp: "2026-02-17T14:32:00Z" },
+  { id: "tx_12", amount: "64.8000000", asset: "USDC", timestamp: "2026-08-02T13:37:00Z" },
+  { id: "tx_06", amount: "410.7500000", asset: "USDC", timestamp: "2026-04-09T06:44:00Z" },
+  { id: "tx_03", amount: "200.0000000", asset: "XLM", timestamp: "2026-03-01T00:00:00Z" },
+  { id: "tx_09", amount: "5.0000000", asset: "XLM", timestamp: "2026-06-28T02:47:00Z" },
+  { id: "tx_07", amount: "18.0000000", asset: "XLM", timestamp: "2026-05-30T21:10:00Z" },
+  { id: "tx_10", amount: "150.0000000", asset: "USDC", timestamp: "2026-07-03T16:20:00Z" },
+];
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+// Parses a bound into epoch milliseconds, or returns null when the value is
+// absent or unusable. A bare YYYY-MM-DD is read as UTC midnight; for the upper
+// bound it is widened to the end of that day so `to=2026-03-01` includes
+// everything that happened on the 1st rather than only the midnight tick.
+function parseBound(rawValue, { endOfDay = false } = {}) {
+  if (typeof rawValue !== "string" || rawValue === "") return null;
+
+  if (DATE_ONLY.test(rawValue)) {
+    const suffix = endOfDay ? "T23:59:59.999Z" : "T00:00:00.000Z";
+    const parsed = Date.parse(`${rawValue}${suffix}`);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  const parsed = Date.parse(rawValue);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function handleRequest({ query = {} } = {}) {
+  // An unparseable bound is dropped rather than rejected: this route always
+  // answers with a list, so an unusable filter simply does not narrow it.
+  const from = parseBound(query.from);
+  const to = parseBound(query.to, { endOfDay: true });
+
+  const transactions = TRANSACTIONS.filter((tx) => {
+    const at = Date.parse(tx.timestamp);
+    if (from !== null && at < from) return false;
+    if (to !== null && at > to) return false;
+    return true;
+  }).sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+
+  return { status: 200, body: transactions };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    if (req.method === "GET" && url.pathname === "/transactions-by-date") {
+      const query = Object.fromEntries(url.searchParams);
+      const { status, body } = handleRequest({ query });
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4055;
+  server.listen(port, () => {
+    console.log(
+      `transactions-by-date mock listening on http://localhost:${port}/transactions-by-date`,
+    );
+  });
+}

--- a/contrib/routes/issue-55-transactions-by-date/route.test.mjs
+++ b/contrib/routes/issue-55-transactions-by-date/route.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { handleRequest } from "./route.mjs";
+
+const ids = (result) => result.body.map((tx) => tx.id);
+
+// No bounds: the whole sample set, oldest first.
+const all = handleRequest({ query: {} });
+assert.equal(all.status, 200);
+assert.ok(Array.isArray(all.body));
+assert.equal(all.body.length, 12);
+assert.deepEqual(
+  ids(all),
+  [...all.body].sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp)).map((tx) => tx.id),
+);
+
+// In range: both bounds set, and both are inclusive. tx_03 sits exactly on the
+// lower bound and tx_05 exactly on the upper one.
+const inRange = handleRequest({ query: { from: "2026-03-01", to: "2026-03-22" } });
+assert.equal(inRange.status, 200);
+assert.deepEqual(ids(inRange), ["tx_03", "tx_04", "tx_05"]);
+
+// A date-only upper bound covers the whole day, not just its midnight tick:
+// tx_04 happened at 23:59:59 on the 1st.
+const singleDay = handleRequest({ query: { from: "2026-03-01", to: "2026-03-01" } });
+assert.deepEqual(ids(singleDay), ["tx_03", "tx_04"]);
+
+// Out of range: a window with no records is an empty array and a 200, never
+// an error.
+const empty = handleRequest({ query: { from: "2027-01-01", to: "2027-12-31" } });
+assert.equal(empty.status, 200);
+assert.deepEqual(empty.body, []);
+
+// An inverted range is empty too, still without erroring.
+const inverted = handleRequest({ query: { from: "2026-08-01", to: "2026-01-01" } });
+assert.equal(inverted.status, 200);
+assert.deepEqual(inverted.body, []);
+
+// Each bound is optional on its own.
+const fromOnly = handleRequest({ query: { from: "2026-07-01" } });
+assert.deepEqual(ids(fromOnly), ["tx_10", "tx_11", "tx_12"]);
+
+const toOnly = handleRequest({ query: { to: "2026-02-28" } });
+assert.deepEqual(ids(toOnly), ["tx_01", "tx_02"]);
+
+// Full ISO timestamps work as bounds as well, to the second.
+const precise = handleRequest({
+  query: { from: "2026-03-01T00:00:01Z", to: "2026-03-01T23:59:59Z" },
+});
+assert.deepEqual(ids(precise), ["tx_04"]);
+
+// An unusable bound is dropped rather than rejected: the route still answers
+// with a list, just an unfiltered one on that side.
+const garbage = handleRequest({ query: { from: "yesterday", to: "2026-02-28" } });
+assert.equal(garbage.status, 200);
+assert.deepEqual(ids(garbage), ["tx_01", "tx_02"]);
+
+console.log("PASS: /transactions-by-date filters on the from and to bounds");


### PR DESCRIPTION
## Summary

Adds a self-contained route module under `contrib/routes/` that lists sample transactions and filters them by an optional start and end date. No chain or database access.

closes #55

## What is in the module

`contrib/routes/issue-55-transactions-by-date/`

| File | Purpose |
| --- | --- |
| `README.md` | How to run and test it, the parameter table, the inclusivity rules and the empty-result contract |
| `route.mjs` | `handleRequest` plus a small `node:http` server behind an `isMain` guard |
| `route.test.mjs` | Assertions, runnable with plain `node`, no test runner or dependencies |

The shape follows the existing sibling modules (`issue-26-transaction-history`, `issue-41-transaction-detail` and friends): a pure `handleRequest` returning `{ status, body }`, exported for direct testing, with the server only started when the file is executed rather than imported.

## Sample data

12 hardcoded transactions spread across January to August 2026, so a range filter has something to actually narrow. They are stored **unsorted** on purpose: the route sorts its output, and data that arrived pre-sorted would let a broken sort pass the tests unnoticed.

## Behaviour

| Parameter | Required | Meaning |
| --- | --- | --- |
| `from` | no | Lower bound, inclusive. Omit to leave it open-ended. |
| `to` | no | Upper bound, inclusive. Omit to leave it open-ended. |

Both accept either a bare `YYYY-MM-DD` (read as UTC) or a full ISO 8601 timestamp such as `2026-03-01T23:59:59Z`. Results come back oldest first.

```
GET /transactions-by-date?from=2026-03-01&to=2026-03-22
```

```json
[
  { "id": "tx_03", "amount": "200.0000000", "asset": "XLM", "timestamp": "2026-03-01T00:00:00Z" },
  { "id": "tx_04", "amount": "3.2500000", "asset": "USDC", "timestamp": "2026-03-01T23:59:59Z" },
  { "id": "tx_05", "amount": "75.0000000", "asset": "XLM", "timestamp": "2026-03-22T18:03:00Z" }
]
```

## Notes on the two judgement calls

**A bare date in `to` is widened to the end of that day.** Read literally, `to=2026-03-01` means UTC midnight, so it would exclude everything that actually happened on the 1st and `from=X&to=X` would return an empty list for a day full of activity. That is a classic off-by-one-day bug, and it is the interpretation nobody types a date range expecting. The sample set has a transaction stamped `2026-03-01T23:59:59Z` specifically so a regression here is caught. Both bounds being inclusive is stated in the README.

**An unparseable bound is dropped rather than rejected.** The issue asks for an empty array and never an error when nothing falls in range, so this route always answers `200` with a list. Rejecting a malformed bound would contradict that for a caller who cannot tell the two situations apart, so `?from=yesterday&to=2026-02-28` behaves as `?to=2026-02-28` and is documented as doing so. An inverted range (`from` later than `to`) is likewise empty by definition rather than a rejection.

## Testing

```sh
node contrib/routes/issue-55-transactions-by-date/route.test.mjs
# PASS: /transactions-by-date filters on the from and to bounds
```

Covers the in-range and out-of-range cases the issue asks for plus the edges around them:

- no bounds: full set, asserted to be in ascending timestamp order
- in range with both bounds, with transactions sitting exactly on each bound to prove inclusivity
- single day, proving a date-only `to` covers the whole day
- out of range: empty array with status 200
- inverted range: empty, still no error
- each bound on its own
- full ISO timestamps as bounds, resolving to the second
- an unparseable bound, still answering 200 with the other bound applied

## One thing worth flagging for review

**The `isMain` guard differs slightly from the sibling modules.** They use ``import.meta.url === `file://${process.argv[1]}` ``, which never matches on Windows, where `argv[1]` is a drive path such as `C:\...` rather than `/...`. The practical effect is that `node route.mjs` exits 0 without listening and prints nothing. This module uses `pathToFileURL(process.argv[1]).href`, which is correct on every platform. I have kept the change inside my own folder and have not touched the existing modules, but the same one-line fix would apply to all of them if you want it as a separate sweep.

## Scope

Entirely inside `contrib/`, three new files in one new folder, nothing outside it added, edited, renamed, or deleted. Branched from `drips` and targeting `drips`.
