### PR TITLE
contrib(routes): add policy-dry-run mock route

### DIFF
--- a/contrib/routes/issue-72-policy-dry-run/README.md
+++ b/contrib/routes/issue-72-policy-dry-run/README.md
@@ -1,0 +1,85 @@
+# Mock route: policy dry run (Issue #72)
+
+Standalone mock POST route that simulates a proposed policy against a set of
+sample transactions and reports which ones would pass and which would fail.
+
+Nothing is persisted and no chain or database is touched. The response is the
+entire result, and it says so: every successful response carries
+`"persisted": false`.
+
+## Run
+
+```sh
+node route.mjs
+# policy-dry-run mock listening on http://localhost:4072/policy/dry-run
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Request
+
+```json
+{
+  "policy": { "maxAmount": 100, "allowedAssets": ["XLM"] },
+  "transactions": [
+    { "id": "tx_a", "amount": "25.0000000", "asset": "XLM", "recipient": "GAAA", "memo": "rent" },
+    { "id": "tx_b", "amount": "900.0000000", "asset": "XLM", "recipient": "GAAA", "memo": "pay" }
+  ]
+}
+```
+
+`policy` is required. `transactions` is optional -- omit it to run against the
+built-in sample set exported as `SAMPLE_TRANSACTIONS`.
+
+## Supported policy rules
+
+Every rule is optional. A policy with no rules passes everything.
+
+| Rule                | Type       | A transaction fails when                        |
+| ------------------- | ---------- | ----------------------------------------------- |
+| `maxAmount`         | number     | its `amount` is greater than the cap            |
+| `allowedAssets`     | `string[]` | its `asset` is not in the list                  |
+| `allowedRecipients` | `string[]` | its `recipient` is not in the list              |
+| `requireMemo`       | boolean    | `true` and its `memo` is absent, empty or blank |
+
+Rule names follow the parameter vocabulary of the policy templates route.
+
+## Response
+
+```json
+{
+  "persisted": false,
+  "summary": { "simulated": 2, "passed": 1, "failed": 1 },
+  "results": [
+    { "index": 0, "id": "tx_a", "decision": "pass", "violations": [] },
+    {
+      "index": 1,
+      "id": "tx_b",
+      "decision": "fail",
+      "violations": [{ "rule": "maxAmount", "reason": "amount 900 exceeds maxAmount 100" }]
+    }
+  ]
+}
+```
+
+Results come back in the order they were submitted, one entry per transaction.
+`index` is the position in the submitted list; `id` is the transaction's own id,
+or `null` if it did not carry one. `violations` is always an array, empty on a
+pass, and lists _every_ rule a transaction breaks rather than stopping at the
+first -- the point of a dry run is to see all the damage in one pass.
+
+## Rejected requests
+
+- `policy` missing or not an object, `transactions` present but not an array,
+  or an entry in it that is not an object: `400 invalid_request`.
+- A rule name the route does not implement: `400 unsupported_rule`, listing
+  both the offending names and the supported ones.
+
+That last one is deliberate. A misspelled rule such as `maxAmmount` would
+otherwise be silently ignored, and the dry run would report a clean pass for a
+policy that enforces nothing -- the worst possible answer from a tool whose only
+job is to tell you what a policy would do.

--- a/contrib/routes/issue-72-policy-dry-run/route.mjs
+++ b/contrib/routes/issue-72-policy-dry-run/route.mjs
@@ -1,0 +1,191 @@
+// Mock POST route simulating a proposed policy against a set of sample
+// transactions. Nothing is persisted and no chain or DB is touched: the
+// response is the whole result.
+import http from "node:http";
+import { pathToFileURL } from "node:url";
+
+// Each rule reports the violations it finds on one transaction. Rule names
+// follow the parameter vocabulary used by the policy templates route.
+const RULES = {
+  maxAmount(limit, tx) {
+    const amount = Number(tx.amount);
+    if (!Number.isFinite(amount)) {
+      return [`amount ${JSON.stringify(tx.amount ?? null)} is not a number`];
+    }
+    const max = Number(limit);
+    if (!Number.isFinite(max)) return [];
+    return amount > max ? [`amount ${amount} exceeds maxAmount ${max}`] : [];
+  },
+
+  allowedAssets(assets, tx) {
+    if (!Array.isArray(assets)) return [];
+    if (assets.includes(tx.asset)) return [];
+    return [`asset ${JSON.stringify(tx.asset ?? null)} is not on the allowed list`];
+  },
+
+  allowedRecipients(recipients, tx) {
+    if (!Array.isArray(recipients)) return [];
+    return recipients.includes(tx.recipient)
+      ? []
+      : [`recipient ${JSON.stringify(tx.recipient ?? null)} is not on the allowed list`];
+  },
+
+  requireMemo(required, tx) {
+    if (required !== true) return [];
+    const memo = tx.memo;
+    return typeof memo === "string" && memo.trim() !== "" ? [] : ["memo is required but missing"];
+  },
+};
+
+const SUPPORTED_RULES = Object.keys(RULES);
+
+// Used when the caller sends a policy but no transactions, so a policy can be
+// tried against a known set without assembling one first.
+export const SAMPLE_TRANSACTIONS = [
+  {
+    id: "tx_01",
+    amount: "50.0000000",
+    asset: "XLM",
+    recipient: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+    memo: "invoice-2201",
+  },
+  {
+    id: "tx_02",
+    amount: "1200.0000000",
+    asset: "USDC",
+    recipient: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+    memo: "hardware batch",
+  },
+  {
+    id: "tx_03",
+    amount: "8.5000000",
+    asset: "XLM",
+    recipient: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+    memo: "",
+  },
+  {
+    id: "tx_04",
+    amount: "310.0000000",
+    asset: "EURC",
+    recipient: "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
+    memo: "contractor payout",
+  },
+];
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function evaluate(policy, tx, index) {
+  const violations = [];
+  for (const [rule, config] of Object.entries(policy)) {
+    for (const reason of RULES[rule](config, tx)) {
+      violations.push({ rule, reason });
+    }
+  }
+  return {
+    index,
+    id: typeof tx.id === "string" ? tx.id : null,
+    decision: violations.length === 0 ? "pass" : "fail",
+    violations,
+  };
+}
+
+export function handleRequest({ body = {} } = {}) {
+  const { policy } = body;
+  // Omitting transactions falls back to the built-in sample set; sending
+  // something that is not a list is a mistake, not a request for the default.
+  const transactions = body.transactions === undefined ? SAMPLE_TRANSACTIONS : body.transactions;
+
+  if (!isPlainObject(policy)) {
+    return {
+      status: 400,
+      body: { error: "invalid_request", message: "policy must be an object" },
+    };
+  }
+  if (!Array.isArray(transactions)) {
+    return {
+      status: 400,
+      body: { error: "invalid_request", message: "transactions must be an array" },
+    };
+  }
+
+  // A misspelled rule would otherwise be ignored, and the dry run would report
+  // a clean pass for a policy that does not do what the caller wrote. For a
+  // tool whose only job is to tell you what a policy would do, that is the
+  // worst possible failure mode, so reject it up front.
+  const unsupported = Object.keys(policy).filter((rule) => !SUPPORTED_RULES.includes(rule));
+  if (unsupported.length > 0) {
+    return {
+      status: 400,
+      body: {
+        error: "unsupported_rule",
+        message: `Unsupported policy rule(s): ${unsupported.join(", ")}`,
+        unsupportedRules: unsupported,
+        supportedRules: SUPPORTED_RULES,
+      },
+    };
+  }
+
+  const nonObject = transactions.findIndex((tx) => !isPlainObject(tx));
+  if (nonObject !== -1) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_request",
+        message: `transactions[${nonObject}] must be an object`,
+      },
+    };
+  }
+
+  const results = transactions.map((tx, index) => evaluate(policy, tx, index));
+  const failed = results.filter((result) => result.decision === "fail").length;
+
+  return {
+    status: 200,
+    body: {
+      // Stated explicitly so a caller can never mistake a dry run for a commit.
+      persisted: false,
+      summary: {
+        simulated: results.length,
+        passed: results.length - failed,
+        failed,
+      },
+      results,
+    },
+  };
+}
+
+// pathToFileURL rather than a `file://` template: on Windows argv[1] is a
+// drive path, which does not compare equal to import.meta.url otherwise.
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/policy/dry-run") {
+      let raw = "";
+      req.on("data", (chunk) => (raw += chunk));
+      req.on("end", () => {
+        let body = {};
+        try {
+          body = raw ? JSON.parse(raw) : {};
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ error: "invalid_json", message: "Request body must be valid JSON" }),
+          );
+          return;
+        }
+        const { status, body: responseBody } = handleRequest({ body });
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(responseBody));
+      });
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+  const port = process.env.PORT || 4072;
+  server.listen(port, () => {
+    console.log(`policy-dry-run mock listening on http://localhost:${port}/policy/dry-run`);
+  });
+}

--- a/contrib/routes/issue-72-policy-dry-run/route.test.mjs
+++ b/contrib/routes/issue-72-policy-dry-run/route.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { handleRequest, SAMPLE_TRANSACTIONS } from "./route.mjs";
+
+const TRANSACTIONS = [
+  { id: "tx_a", amount: "25.0000000", asset: "XLM", recipient: "GAAA", memo: "rent" },
+  { id: "tx_b", amount: "900.0000000", asset: "XLM", recipient: "GAAA", memo: "payroll" },
+  { id: "tx_c", amount: "10.0000000", asset: "USDC", recipient: "GBBB", memo: "" },
+];
+
+// A maxAmount policy rejects the one transaction over the cap and passes the
+// rest, reporting why.
+const capped = handleRequest({
+  body: { policy: { maxAmount: 100 }, transactions: TRANSACTIONS },
+});
+assert.equal(capped.status, 200);
+assert.equal(capped.body.persisted, false);
+assert.deepEqual(capped.body.summary, { simulated: 3, passed: 2, failed: 1 });
+assert.deepEqual(
+  capped.body.results.map((r) => r.decision),
+  ["pass", "fail", "pass"],
+);
+
+const rejected = capped.body.results[1];
+assert.equal(rejected.id, "tx_b");
+assert.equal(rejected.index, 1);
+assert.equal(rejected.violations.length, 1);
+assert.equal(rejected.violations[0].rule, "maxAmount");
+assert.match(rejected.violations[0].reason, /exceeds maxAmount/);
+
+// Passing transactions carry an empty violations array, not a missing key.
+assert.deepEqual(capped.body.results[0].violations, []);
+
+// Several rules at once: every violation on a transaction is reported, not
+// just the first one to trip.
+const strict = handleRequest({
+  body: {
+    policy: { maxAmount: 100, allowedAssets: ["XLM"], allowedRecipients: ["GAAA"] },
+    transactions: TRANSACTIONS,
+  },
+});
+assert.deepEqual(strict.body.summary, { simulated: 3, passed: 1, failed: 2 });
+assert.deepEqual(
+  strict.body.results[2].violations.map((v) => v.rule).sort(),
+  ["allowedAssets", "allowedRecipients"],
+);
+
+// requireMemo treats a blank memo as missing.
+const memoed = handleRequest({
+  body: { policy: { requireMemo: true }, transactions: TRANSACTIONS },
+});
+assert.deepEqual(memoed.body.summary, { simulated: 3, passed: 2, failed: 1 });
+assert.equal(memoed.body.results[2].violations[0].rule, "requireMemo");
+
+// An empty policy has nothing to enforce, so everything passes.
+const permissive = handleRequest({ body: { policy: {}, transactions: TRANSACTIONS } });
+assert.deepEqual(permissive.body.summary, { simulated: 3, passed: 3, failed: 0 });
+
+// An empty transaction list is a valid, if uninteresting, simulation.
+const nothing = handleRequest({ body: { policy: { maxAmount: 1 }, transactions: [] } });
+assert.equal(nothing.status, 200);
+assert.deepEqual(nothing.body.summary, { simulated: 0, passed: 0, failed: 0 });
+
+// Omitting transactions falls back to the built-in sample set.
+const defaulted = handleRequest({ body: { policy: { maxAmount: 100 } } });
+assert.equal(defaulted.body.summary.simulated, SAMPLE_TRANSACTIONS.length);
+assert.ok(defaulted.body.summary.failed > 0);
+
+// A misspelled rule is rejected rather than ignored, so the dry run can never
+// report a clean pass for a policy that enforces nothing.
+const typo = handleRequest({
+  body: { policy: { maxAmmount: 100 }, transactions: TRANSACTIONS },
+});
+assert.equal(typo.status, 400);
+assert.equal(typo.body.error, "unsupported_rule");
+assert.deepEqual(typo.body.unsupportedRules, ["maxAmmount"]);
+
+// Malformed input is rejected before any simulation happens.
+assert.equal(handleRequest({ body: {} }).status, 400);
+assert.equal(handleRequest({ body: { policy: {}, transactions: "nope" } }).status, 400);
+assert.equal(handleRequest({ body: { policy: {}, transactions: [null] } }).status, 400);
+
+// The simulation is read-only: the caller's inputs come back untouched.
+const before = JSON.stringify(TRANSACTIONS);
+handleRequest({ body: { policy: { maxAmount: 1 }, transactions: TRANSACTIONS } });
+assert.equal(JSON.stringify(TRANSACTIONS), before);
+
+console.log("PASS: /policy/dry-run reports pass and fail per sample transaction");


### PR DESCRIPTION
## Summary

Adds a self-contained route module under `contrib/routes/` that runs a dry-run simulation of a proposed policy against a set of sample transactions and reports which would pass and which would fail. Nothing is persisted, and no chain or database is touched.

closes #72

## What is in the module

`contrib/routes/issue-72-policy-dry-run/`

| File | Purpose |
| --- | --- |
| `README.md` | How to run and test it, the request shape, every supported rule, and the failure modes |
| `route.mjs` | `handleRequest` plus a small `node:http` server behind an `isMain` guard |
| `route.test.mjs` | Assertions, runnable with plain `node`, no test runner or dependencies |

The shape follows the existing sibling modules, in particular the POST-body handling in `issue-27-payment-request`: a pure `handleRequest` returning `{ status, body }`, exported for direct testing, with the server only started when the file is executed rather than imported.

## Request

```json
{
  "policy": { "maxAmount": 100, "allowedAssets": ["XLM"] },
  "transactions": [
    { "id": "tx_a", "amount": "25.0000000", "asset": "XLM", "recipient": "GAAA", "memo": "rent" },
    { "id": "tx_b", "amount": "900.0000000", "asset": "XLM", "recipient": "GAAA", "memo": "pay" }
  ]
}
```

`policy` is required. `transactions` is optional: omit it to run against a built-in sample set, also exported as `SAMPLE_TRANSACTIONS`, so a policy can be tried without assembling a list first.

## Supported policy rules

Every rule is optional; a policy with no rules passes everything.

| Rule | Type | A transaction fails when |
| --- | --- | --- |
| `maxAmount` | number | its `amount` is greater than the cap |
| `allowedAssets` | `string[]` | its `asset` is not in the list |
| `allowedRecipients` | `string[]` | its `recipient` is not in the list |
| `requireMemo` | boolean | `true` and its `memo` is absent, empty or blank |

Rule names reuse the parameter vocabulary already established by `issue-64-policy-templates` (`maxAmount`, `allowedRecipients`) rather than inventing a second dialect for the same concepts.

## Response

```json
{
  "persisted": false,
  "summary": { "simulated": 2, "passed": 1, "failed": 1 },
  "results": [
    { "index": 0, "id": "tx_a", "decision": "pass", "violations": [] },
    {
      "index": 1,
      "id": "tx_b",
      "decision": "fail",
      "violations": [{ "rule": "maxAmount", "reason": "amount 900 exceeds maxAmount 100" }]
    }
  ]
}
```

Results are returned in submission order, one entry per transaction. `index` is the position in the submitted list, `id` is the transaction's own id or `null` if it did not carry one, and `violations` is always an array, empty on a pass.

## Notes on the three judgement calls

**`persisted: false` is stated in the response, not just in the docs.** A dry run and a commit are one flag apart at the call site, and a response that looks identical to a real one is exactly how that mistake survives review. Saying it in the payload makes it checkable.

**Every violation is reported, not just the first to trip.** Stopping at the first failure turns evaluating a policy into a game of whack-a-mole across repeated runs. Seeing all the damage in one pass is the point of a dry run, so a transaction breaking three rules lists all three.

**An unrecognised rule name is rejected with `400 unsupported_rule`.** This is the one I would most like a second opinion on. Unknown keys are conventionally ignored, but here a typo such as `maxAmmount` would produce a confident, clean, all-green report for a policy that enforces nothing at all. For a tool whose entire job is telling you what a policy would do, a false all-clear is the worst available outcome, so the route fails fast and returns both the offending names and the supported ones.

## Testing

```sh
node contrib/routes/issue-72-policy-dry-run/route.test.mjs
# PASS: /policy/dry-run reports pass and fail per sample transaction
```

Covers the case the issue asks for, a policy that rejects at least one transaction, with the violation's rule and reason asserted rather than just the count, plus:

- multiple rules at once, asserting every violation on a transaction is reported
- `requireMemo` treating a blank memo as missing
- an empty policy passing everything, and an empty transaction list simulating cleanly
- omitting `transactions` falling back to the built-in sample set
- a misspelled rule rejected with `400 unsupported_rule`
- malformed input rejected before any simulation runs
- the caller's input transactions being byte-for-byte unchanged afterwards, since a simulation that mutates its input is not a simulation

Also smoke tested over HTTP with `node route.mjs`, including the 404 fallthrough and the invalid-JSON path.

## One thing worth flagging for review

**The `isMain` guard differs slightly from the sibling modules.** They use ``import.meta.url === `file://${process.argv[1]}` ``, which never matches on Windows, where `argv[1]` is a drive path such as `C:\...` rather than `/...`. The practical effect is that `node route.mjs` exits 0 without listening and prints nothing; I hit this while smoke testing. This module uses `pathToFileURL(process.argv[1]).href`, which is correct on every platform. I have kept the change inside my own folder and have not touched the existing modules, but the same one-line fix would apply to all of them if you want it as a separate sweep.

## Scope

Entirely inside `contrib/`, three new files in one new folder, nothing outside it added, edited, renamed, or deleted. Branched from `drips` and targeting `drips`.
