### PR TITLE
feat: Add Contrib Route Modules (Payment, Spend, WASM Hash, Multisig)

### DIFF
--- a/contrib/routes/multisig-threshold/README.md
+++ b/contrib/routes/multisig-threshold/README.md
@@ -1,0 +1,25 @@
+# Multisig Threshold
+
+A self-contained route module with endpoints to set a multisig threshold for a sample account and to read the current configuration.
+
+## Endpoints
+
+- `GET /config`
+  - Returns the current threshold and the signer count.
+- `POST /config`
+  - Body: `{ "threshold": number }`
+  - Sets a new threshold. Validates that the threshold does not exceed the number of signers.
+
+## Usage
+
+```sh
+node index.js
+```
+
+## Testing
+
+Run the test script covering a valid set and an invalid over threshold set:
+
+```sh
+node test.js
+```

--- a/contrib/routes/multisig-threshold/index.js
+++ b/contrib/routes/multisig-threshold/index.js
@@ -1,0 +1,71 @@
+const http = require('http');
+
+// Dummy database for a sample account
+const accountConfig = {
+  signers: ['alice', 'bob', 'charlie'],
+  threshold: 2
+};
+
+const handlers = {
+  get: (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      threshold: accountConfig.threshold,
+      signerCount: accountConfig.signers.length
+    }));
+  },
+  set: (req, res) => {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      let threshold;
+      try {
+        const payload = JSON.parse(body);
+        threshold = parseInt(payload.threshold, 10);
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+      
+      if (isNaN(threshold) || threshold <= 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid threshold' }));
+        return;
+      }
+
+      if (threshold > accountConfig.signers.length) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Threshold cannot exceed number of signers' }));
+        return;
+      }
+
+      accountConfig.threshold = threshold;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true, threshold }));
+    });
+  }
+};
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  const parts = url.pathname.split('/').filter(Boolean);
+  
+  if (parts[0] === 'config' && req.method === 'GET') {
+    return handlers.get(req, res);
+  }
+  if (parts[0] === 'config' && req.method === 'POST') {
+    return handlers.set(req, res);
+  }
+  
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+module.exports = server;
+
+if (require.main === module) {
+  server.listen(3003, () => {
+    console.log('Server running on port 3003');
+  });
+}

--- a/contrib/routes/multisig-threshold/test.js
+++ b/contrib/routes/multisig-threshold/test.js
@@ -1,0 +1,41 @@
+const server = require('./index');
+const http = require('http');
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const baseUrl = `http://localhost:${port}`;
+  
+  const request = (method, path, body) => new Promise((resolve, reject) => {
+    const req = http.request(`${baseUrl}${path}`, { method, headers: { 'Content-Type': 'application/json' } }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ status: res.statusCode, data: JSON.parse(data) }));
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+
+  try {
+    console.log('1. Get current config');
+    let res = await request('GET', '/config');
+    console.log('Response:', res);
+
+    console.log('\n2. Set valid threshold (3)');
+    res = await request('POST', '/config', { threshold: 3 });
+    console.log('Response:', res);
+    
+    console.log('\n3. Set invalid threshold (4) - exceeds signers');
+    res = await request('POST', '/config', { threshold: 4 });
+    console.log('Response:', res);
+    
+    console.log('\n4. Get updated config');
+    res = await request('GET', '/config');
+    console.log('Response:', res);
+
+  } catch (err) {
+    console.error(err);
+  } finally {
+    server.close();
+  }
+});

--- a/contrib/routes/payment-lifecycle-suite/README.md
+++ b/contrib/routes/payment-lifecycle-suite/README.md
@@ -1,0 +1,29 @@
+# Payment Lifecycle Suite
+
+A self-contained set of route handlers that track a mock payment through its lifecycle.
+
+## Endpoints
+
+- `POST /build`
+  - Creates a new payment.
+- `POST /review/:id`
+  - Transitions a payment to reviewed status.
+- `POST /submit/:id`
+  - Submits a payment and sets status to pending.
+- `GET /status/:id`
+  - Gets the status of a payment.
+  - Automatically transitions a `pending` payment to `settled` after 3 status checks.
+
+## Usage
+
+```sh
+node index.js
+```
+
+## Testing
+
+Run the provided test script to walk through the sequence:
+
+```sh
+node test.js
+```

--- a/contrib/routes/payment-lifecycle-suite/index.js
+++ b/contrib/routes/payment-lifecycle-suite/index.js
@@ -1,0 +1,72 @@
+const http = require('http');
+const crypto = require('crypto');
+
+const payments = new Map();
+
+const handlers = {
+  build: (req, res) => {
+    const id = crypto.randomUUID();
+    payments.set(id, { id, status: 'built', polls: 0 });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ id, status: 'built' }));
+  },
+  review: (req, res, id) => {
+    const payment = payments.get(id);
+    if (!payment) return send404(res);
+    payment.status = 'reviewed';
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(payment));
+  },
+  submit: (req, res, id) => {
+    const payment = payments.get(id);
+    if (!payment) return send404(res);
+    payment.status = 'pending';
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(payment));
+  },
+  status: (req, res, id) => {
+    const payment = payments.get(id);
+    if (!payment) return send404(res);
+    if (payment.status === 'pending') {
+      payment.polls += 1;
+      if (payment.polls >= 3) {
+        payment.status = 'settled';
+      }
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(payment));
+  }
+};
+
+function send404(res) {
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  const parts = url.pathname.split('/').filter(Boolean);
+  
+  if (parts[0] === 'build' && req.method === 'POST') {
+    return handlers.build(req, res);
+  }
+  if (parts[0] === 'review' && parts[1] && req.method === 'POST') {
+    return handlers.review(req, res, parts[1]);
+  }
+  if (parts[0] === 'submit' && parts[1] && req.method === 'POST') {
+    return handlers.submit(req, res, parts[1]);
+  }
+  if (parts[0] === 'status' && parts[1] && req.method === 'GET') {
+    return handlers.status(req, res, parts[1]);
+  }
+  
+  send404(res);
+});
+
+module.exports = server;
+
+if (require.main === module) {
+  server.listen(3000, () => {
+    console.log('Server running on port 3000');
+  });
+}

--- a/contrib/routes/payment-lifecycle-suite/test.js
+++ b/contrib/routes/payment-lifecycle-suite/test.js
@@ -1,0 +1,41 @@
+const server = require('./index');
+const http = require('http');
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const baseUrl = `http://localhost:${port}`;
+  
+  const request = (method, path) => new Promise((resolve, reject) => {
+    const req = http.request(`${baseUrl}${path}`, { method }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve(JSON.parse(data)));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+
+  try {
+    console.log('1. Build Payment');
+    const built = await request('POST', '/build');
+    console.log('Built:', built);
+    
+    console.log('\n2. Review Payment');
+    const reviewed = await request('POST', `/review/${built.id}`);
+    console.log('Reviewed:', reviewed);
+    
+    console.log('\n3. Submit Payment');
+    const submitted = await request('POST', `/submit/${built.id}`);
+    console.log('Submitted:', submitted);
+    
+    console.log('\n4. Poll Status (needs 3 polls to settle)');
+    for (let i = 1; i <= 4; i++) {
+      const status = await request('GET', `/status/${built.id}`);
+      console.log(`Poll ${i}:`, status);
+    }
+  } catch (err) {
+    console.error(err);
+  } finally {
+    server.close();
+  }
+});

--- a/contrib/routes/rolling-window-spend/README.md
+++ b/contrib/routes/rolling-window-spend/README.md
@@ -1,0 +1,29 @@
+# Rolling Window Spend
+
+A self-contained route module that tracks cumulative sample spend for an account within a rolling time window.
+
+## Endpoints
+
+- `GET /allowance/:accountId`
+  - Returns the remaining allowance given a fixed limit and window length.
+- `POST /spend/:accountId`
+  - Body: `{ "amount": number }`
+  - Accepts a spend amount and adds it to an in-memory running total. Fails if the limit is exceeded.
+
+## Configuration
+
+The limit is fixed at `1000` and the window is 60 seconds.
+
+## Usage
+
+```sh
+node index.js
+```
+
+## Testing
+
+Run the test script to see a scenario where the limit is exceeded:
+
+```sh
+node test.js
+```

--- a/contrib/routes/rolling-window-spend/index.js
+++ b/contrib/routes/rolling-window-spend/index.js
@@ -1,0 +1,90 @@
+const http = require('http');
+
+// In-memory state: accountId -> array of { timestamp, amount }
+const spends = new Map();
+
+// Configuration
+const LIMIT = 1000;
+const WINDOW_MS = 60 * 1000; // 60 seconds rolling window
+
+const handlers = {
+  spend: (req, res, accountId) => {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      let amount;
+      try {
+        const payload = JSON.parse(body);
+        amount = parseFloat(payload.amount);
+      } catch (e) {
+        return sendError(res, 400, 'Invalid JSON');
+      }
+      if (isNaN(amount) || amount <= 0) {
+        return sendError(res, 400, 'Invalid amount');
+      }
+
+      const now = Date.now();
+      const accountSpends = spends.get(accountId) || [];
+      
+      // Clean up old spends
+      const validSpends = accountSpends.filter(s => now - s.timestamp <= WINDOW_MS);
+      const currentTotal = validSpends.reduce((acc, s) => acc + s.amount, 0);
+
+      if (currentTotal + amount > LIMIT) {
+        return sendError(res, 429, 'Spend limit exceeded');
+      }
+
+      validSpends.push({ timestamp: now, amount });
+      spends.set(accountId, validSpends);
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true, remaining: LIMIT - (currentTotal + amount) }));
+    });
+  },
+  allowance: (req, res, accountId) => {
+    const now = Date.now();
+    const accountSpends = spends.get(accountId) || [];
+    
+    // Clean up old spends
+    const validSpends = accountSpends.filter(s => now - s.timestamp <= WINDOW_MS);
+    spends.set(accountId, validSpends); // update memory
+    
+    const currentTotal = validSpends.reduce((acc, s) => acc + s.amount, 0);
+    const remaining = Math.max(0, LIMIT - currentTotal);
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ limit: LIMIT, remaining }));
+  }
+};
+
+function sendError(res, status, message) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: message }));
+}
+
+function send404(res) {
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  const parts = url.pathname.split('/').filter(Boolean);
+  
+  if (parts[0] === 'spend' && parts[1] && req.method === 'POST') {
+    return handlers.spend(req, res, parts[1]);
+  }
+  if (parts[0] === 'allowance' && parts[1] && req.method === 'GET') {
+    return handlers.allowance(req, res, parts[1]);
+  }
+  
+  send404(res);
+});
+
+module.exports = server;
+
+if (require.main === module) {
+  server.listen(3001, () => {
+    console.log('Server running on port 3001');
+  });
+}

--- a/contrib/routes/rolling-window-spend/test.js
+++ b/contrib/routes/rolling-window-spend/test.js
@@ -1,0 +1,46 @@
+const server = require('./index');
+const http = require('http');
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const baseUrl = `http://localhost:${port}`;
+  
+  const request = (method, path, body) => new Promise((resolve, reject) => {
+    const req = http.request(`${baseUrl}${path}`, { method, headers: { 'Content-Type': 'application/json' } }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ status: res.statusCode, data: JSON.parse(data) }));
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+
+  try {
+    const account = 'acc_123';
+    console.log('1. Check initial allowance');
+    let res = await request('GET', `/allowance/${account}`);
+    console.log('Response:', res);
+
+    console.log('\n2. Spend 400');
+    res = await request('POST', `/spend/${account}`, { amount: 400 });
+    console.log('Response:', res);
+    
+    console.log('\n3. Spend 500');
+    res = await request('POST', `/spend/${account}`, { amount: 500 });
+    console.log('Response:', res);
+    
+    console.log('\n4. Spend 200 (should fail, limit is 1000)');
+    res = await request('POST', `/spend/${account}`, { amount: 200 });
+    console.log('Response:', res);
+    
+    console.log('\n5. Final allowance');
+    res = await request('GET', `/allowance/${account}`);
+    console.log('Response:', res);
+
+  } catch (err) {
+    console.error(err);
+  } finally {
+    server.close();
+  }
+});

--- a/contrib/routes/wasm-hash-compare/README.md
+++ b/contrib/routes/wasm-hash-compare/README.md
@@ -1,0 +1,25 @@
+# WASM Hash Compare
+
+A self-contained route module to look up a sample contract WASM hash and to compare two hashes for equality.
+
+## Endpoints
+
+- `GET /lookup/:contractId`
+  - Returns the hash for a contract ID. Returns a 404 payload for unknown IDs.
+- `POST /compare`
+  - Body: `{ "hash1": "...", "hash2": "..." }`
+  - Accepts two hash strings and returns a match boolean.
+
+## Usage
+
+```sh
+node index.js
+```
+
+## Testing
+
+Run the test script covering known/unknown lookups and matching/non-matching comparisons:
+
+```sh
+node test.js
+```

--- a/contrib/routes/wasm-hash-compare/index.js
+++ b/contrib/routes/wasm-hash-compare/index.js
@@ -1,0 +1,69 @@
+const http = require('http');
+
+// Dummy database of wasm hashes
+const db = {
+  'contract-1': 'a3f01b3c',
+  'contract-2': 'b7d2f9e4'
+};
+
+const handlers = {
+  lookup: (req, res, id) => {
+    const hash = db[id];
+    if (!hash) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unknown contract ID' }));
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ id, hash }));
+  },
+  compare: (req, res) => {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      let hash1, hash2;
+      try {
+        const payload = JSON.parse(body);
+        hash1 = payload.hash1;
+        hash2 = payload.hash2;
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+      
+      if (!hash1 || !hash2) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Missing hash1 or hash2' }));
+        return;
+      }
+
+      const match = hash1 === hash2;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ match }));
+    });
+  }
+};
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  const parts = url.pathname.split('/').filter(Boolean);
+  
+  if (parts[0] === 'lookup' && parts[1] && req.method === 'GET') {
+    return handlers.lookup(req, res, parts[1]);
+  }
+  if (parts[0] === 'compare' && req.method === 'POST') {
+    return handlers.compare(req, res);
+  }
+  
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+module.exports = server;
+
+if (require.main === module) {
+  server.listen(3002, () => {
+    console.log('Server running on port 3002');
+  });
+}

--- a/contrib/routes/wasm-hash-compare/test.js
+++ b/contrib/routes/wasm-hash-compare/test.js
@@ -1,0 +1,41 @@
+const server = require('./index');
+const http = require('http');
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const baseUrl = `http://localhost:${port}`;
+  
+  const request = (method, path, body) => new Promise((resolve, reject) => {
+    const req = http.request(`${baseUrl}${path}`, { method, headers: { 'Content-Type': 'application/json' } }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ status: res.statusCode, data: JSON.parse(data) }));
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+
+  try {
+    console.log('1. Lookup known contract');
+    let res = await request('GET', '/lookup/contract-1');
+    console.log('Response:', res);
+
+    console.log('\n2. Lookup unknown contract');
+    res = await request('GET', '/lookup/contract-x');
+    console.log('Response:', res);
+    
+    console.log('\n3. Compare matching hashes');
+    res = await request('POST', '/compare', { hash1: 'a3f01b3c', hash2: 'a3f01b3c' });
+    console.log('Response:', res);
+    
+    console.log('\n4. Compare non-matching hashes');
+    res = await request('POST', '/compare', { hash1: 'a3f01b3c', hash2: 'b7d2f9e4' });
+    console.log('Response:', res);
+
+  } catch (err) {
+    console.error(err);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
closes #77 
closes #79 
closes #76 
closes #91 

### Description
This PR introduces four new self-contained route modules under the `contrib/routes/` directory to address the requested features. Each module includes a small native Node.js HTTP server for mock routing, an accompanying `README.md`, and a standalone test script to walk through the respective functionality.

### Changes Included:

1. **Payment Lifecycle Suite** (`contrib/routes/payment-lifecycle-suite/`)
   - Implemented an in-memory mock payment lifecycle with endpoints for `build`, `review`, `submit`, and `status`.
   - Included a sequence test script (`test.js`) that validates transitions from `built` to `settled` over repeated status polls.
2. **Rolling Window Spend** (`contrib/routes/rolling-window-spend/`)
   - Added a module to track cumulative spend for an account within a 60-second rolling window.
   - Includes endpoints to retrieve remaining allowance and submit spends. Automatically rejects transactions when the fixed limit is exceeded.
3. **WASM Hash Compare** (`contrib/routes/wasm-hash-compare/`)
   - Introduced a mock database with endpoints to lookup contract WASM hashes (returns 404 for unknown IDs).
   - Added a compare endpoint to evaluate hash equality. Includes tests covering matching and non-matching states.
4. **Multisig Threshold Configuration** (`contrib/routes/multisig-threshold/`)
   - Created endpoints to retrieve and configure a multisig threshold for a sample account.
   - Added validation to ensure the requested threshold cannot be set higher than the number of existing signers.

### Testing
- No external frameworks (like Express) were used, meaning these can be tested out-of-the-box using the native `node` runtime.
- For each module, you can spin up the mock server with `node index.js` or directly execute the end-to-end tests using `node test.js`.
