### PR TITLE
feat(contrib): add 30% mock route scaffolds for issues #31, #32, #29, #73

### DIFF
--- a/contrib/routes/issue-29-transactions-by-date/README.md
+++ b/contrib/routes/issue-29-transactions-by-date/README.md
@@ -1,0 +1,20 @@
+# Mock route: transactions by date range (Issue #29)
+
+Standalone mock GET route handler under `contrib/routes/` filtering transactions by optional date range parameters (`from`, `to`).
+
+## Query Parameters
+
+- **from**: Optional ISO 8601 date string (e.g. `2026-07-01`)
+- **to**: Optional ISO 8601 date string (e.g. `2026-07-15`)
+
+## Run
+
+```sh
+node route.mjs
+```
+
+## Example
+
+```
+GET /transactions-by-date?from=2026-07-01&to=2026-07-15
+```

--- a/contrib/routes/issue-29-transactions-by-date/route.mjs
+++ b/contrib/routes/issue-29-transactions-by-date/route.mjs
@@ -1,0 +1,58 @@
+import http from "node:http";
+import url from "node:url";
+
+/**
+ * Mock GET Route: Transactions Filtered by Date (Issue #29)
+ * Returns sample transactions filtered by optional 'from' and 'to' date parameters.
+ */
+export const SAMPLE_TRANSACTIONS = [
+  { id: "tx-101", amount: "50.00", asset: "XLM", createdAt: "2026-07-01T10:00:00Z" },
+  { id: "tx-102", amount: "120.50", asset: "USDC", createdAt: "2026-07-05T14:30:00Z" },
+  { id: "tx-103", amount: "15.00", asset: "XLM", createdAt: "2026-07-10T09:15:00Z" },
+  { id: "tx-104", amount: "200.00", asset: "EURC", createdAt: "2026-07-15T18:45:00Z" },
+  { id: "tx-105", amount: "1000.00", asset: "XLM", createdAt: "2026-07-20T11:20:00Z" },
+  { id: "tx-106", amount: "75.25", asset: "USDC", createdAt: "2026-07-25T16:10:00Z" },
+  { id: "tx-107", amount: "30.00", asset: "XLM", createdAt: "2026-07-28T08:00:00Z" },
+];
+
+export function filterTransactionsByDate(transactions, fromDate, toDate) {
+  return transactions.filter(tx => {
+    const txTime = new Date(tx.createdAt).getTime();
+    if (fromDate && txTime < new Date(fromDate).getTime()) return false;
+    if (toDate && txTime > new Date(toDate).getTime()) return false;
+    return true;
+  });
+}
+
+export function handleTransactionsByDateRequest(req, res) {
+  if (req.method === "GET") {
+    const parsedUrl = url.parse(req.url, true);
+    const { from, to } = parsedUrl.query;
+    
+    const filtered = filterTransactionsByDate(SAMPLE_TRANSACTIONS, from, to);
+    
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      status: "success",
+      count: filtered.length,
+      from: from || null,
+      to: to || null,
+      transactions: filtered
+    }));
+    return;
+  }
+
+  res.writeHead(405, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Method not allowed. Use GET." }));
+}
+
+const PORT = process.env.PORT || 4029;
+if (process.argv[1] && process.argv[1].endsWith("route.mjs")) {
+  const server = http.createServer((req, res) => {
+    handleTransactionsByDateRequest(req, res);
+  });
+
+  server.listen(PORT, () => {
+    console.log(`transactions-by-date mock listening on http://localhost:${PORT}/transactions-by-date`);
+  });
+}

--- a/contrib/routes/issue-31-fee-estimates/README.md
+++ b/contrib/routes/issue-31-fee-estimates/README.md
@@ -1,0 +1,21 @@
+# Mock route: network fee estimates (Issue #31)
+
+Standalone mock GET route handler returning priority tier network fee estimates (`low`, `medium`, `high`) in stroops.
+
+## Fee Values (Stroops)
+
+- **low**: `100` stroops
+- **medium**: `500` stroops
+- **high**: `1000` stroops
+
+## Run
+
+```sh
+node route.mjs
+```
+
+## Example
+
+```
+GET /fee-estimates
+```

--- a/contrib/routes/issue-31-fee-estimates/route.mjs
+++ b/contrib/routes/issue-31-fee-estimates/route.mjs
@@ -1,0 +1,42 @@
+import http from "node:http";
+
+/**
+ * Mock GET Route: Fee Estimates (Issue #31)
+ * Returns network fee estimates for low, medium, and high priority tiers in stroops.
+ */
+export const FEE_ESTIMATES = {
+  low: 100,      // Base minimum fee (100 stroops = 0.00001 XLM)
+  medium: 500,    // Standard network fee
+  high: 1000,    // High priority fee
+};
+
+export function handleFeeEstimatesRequest(req, res) {
+  if (req.method === "GET") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      status: "success",
+      unit: "stroops",
+      fees: FEE_ESTIMATES
+    }));
+    return;
+  }
+
+  res.writeHead(405, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Method not allowed. Use GET." }));
+}
+
+const PORT = process.env.PORT || 4031;
+if (process.argv[1] && process.argv[1].endsWith("route.mjs")) {
+  const server = http.createServer((req, res) => {
+    if (req.url === "/fee-estimates" || req.url === "/") {
+      handleFeeEstimatesRequest(req, res);
+    } else {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+    }
+  });
+
+  server.listen(PORT, () => {
+    console.log(`fee-estimates mock listening on http://localhost:${PORT}/fee-estimates`);
+  });
+}

--- a/contrib/routes/issue-32-address-validate/README.md
+++ b/contrib/routes/issue-32-address-validate/README.md
@@ -1,0 +1,22 @@
+# Mock route: address validate (Issue #32)
+
+Standalone mock POST route handler validating Stellar public key address format.
+
+## Rules
+
+- Must be a string
+- Must start with `G`
+- Length must be 56 characters
+
+## Run
+
+```sh
+node route.mjs
+```
+
+## Example
+
+```
+POST /address-validate
+{ "address": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFXYCZLXF3WGC6W263L2B" }
+```

--- a/contrib/routes/issue-32-address-validate/route.mjs
+++ b/contrib/routes/issue-32-address-validate/route.mjs
@@ -1,0 +1,62 @@
+import http from "node:http";
+
+/**
+ * Mock POST Route: Address Validation (Issue #32)
+ * Validates Stellar public key address format (starts with 'G' and 56 chars long).
+ */
+export function validateStellarAddress(address) {
+  if (typeof address !== "string") {
+    return { valid: false, reason: "Address must be a string" };
+  }
+
+  if (address.length !== 56) {
+    return { valid: false, reason: `Invalid address length (expected 56 characters, got ${address.length})` };
+  }
+
+  if (!address.startsWith("G")) {
+    return { valid: false, reason: "Public key address must start with 'G'" };
+  }
+
+  return { valid: true };
+}
+
+export function handleAddressValidateRequest(req, res, bodyData) {
+  if (req.method === "POST") {
+    try {
+      const payload = JSON.parse(bodyData || "{}");
+      const result = validateStellarAddress(payload.address);
+      
+      res.writeHead(result.valid ? 200 : 400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        ...result,
+        address: payload.address || null
+      }));
+      return;
+    } catch (err) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ valid: false, reason: "Invalid JSON payload" }));
+      return;
+    }
+  }
+
+  res.writeHead(405, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Method not allowed. Use POST." }));
+}
+
+const PORT = process.env.PORT || 4032;
+if (process.argv[1] && process.argv[1].endsWith("route.mjs")) {
+  const server = http.createServer((req, res) => {
+    if (req.url === "/address-validate" || req.url === "/") {
+      let body = "";
+      req.on("data", chunk => { body += chunk; });
+      req.on("end", () => { handleAddressValidateRequest(req, res, body); });
+    } else {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+    }
+  });
+
+  server.listen(PORT, () => {
+    console.log(`address-validate mock listening on http://localhost:${PORT}/address-validate`);
+  });
+}

--- a/contrib/routes/issue-73-allowed-assets/README.md
+++ b/contrib/routes/issue-73-allowed-assets/README.md
@@ -1,0 +1,28 @@
+# Mock route / validator: allowed assets configuration (Issue #73)
+
+Standalone mock route module under `contrib/routes/` validating the `allowedAssets` array configuration structure.
+
+## Asset Types
+
+Supported asset types:
+- `native` (XLM)
+- `credit_alphanum4` (e.g. USDC)
+- `credit_alphanum12` (e.g. STELLARLUMEN)
+
+## Run
+
+```sh
+node route.mjs
+```
+
+## Example
+
+```
+POST /allowed-assets
+{
+  "allowedAssets": [
+    { "code": "XLM", "type": "native" },
+    { "code": "USDC", "type": "credit_alphanum4", "issuer": "GA5ZSE..." }
+  ]
+}
+```

--- a/contrib/routes/issue-73-allowed-assets/route.mjs
+++ b/contrib/routes/issue-73-allowed-assets/route.mjs
@@ -1,0 +1,63 @@
+import http from "node:http";
+
+/**
+ * Mock Route / Validator Module: Allowed Assets Validation (Issue #73)
+ * Validates allowedAssets array configuration for wallet policies.
+ */
+export const ALLOWED_ASSET_TYPES = ["native", "credit_alphanum4", "credit_alphanum12"];
+
+export function validateAllowedAssetsConfig(allowedAssets) {
+  if (!Array.isArray(allowedAssets)) {
+    return { valid: false, reason: "'allowedAssets' must be an array" };
+  }
+
+  for (const asset of allowedAssets) {
+    if (!asset || typeof asset !== "object") {
+      return { valid: false, reason: "Each asset entry must be an object" };
+    }
+    if (!asset.code || typeof asset.code !== "string") {
+      return { valid: false, reason: "Asset missing valid 'code' property" };
+    }
+    if (!ALLOWED_ASSET_TYPES.includes(asset.type)) {
+      return { valid: false, reason: `Invalid asset type '${asset.type}'. Expected one of: ${ALLOWED_ASSET_TYPES.join(", ")}` };
+    }
+  }
+
+  return { valid: true };
+}
+
+export function handleAllowedAssetsRequest(req, res, bodyData) {
+  if (req.method === "POST") {
+    try {
+      const payload = JSON.parse(bodyData || "{}");
+      const result = validateAllowedAssetsConfig(payload.allowedAssets);
+      
+      res.writeHead(result.valid ? 200 : 400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        ...result,
+        count: Array.isArray(payload.allowedAssets) ? payload.allowedAssets.length : 0
+      }));
+      return;
+    } catch (err) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ valid: false, reason: "Invalid JSON payload" }));
+      return;
+    }
+  }
+
+  res.writeHead(405, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Method not allowed. Use POST." }));
+}
+
+const PORT = process.env.PORT || 4073;
+if (process.argv[1] && process.argv[1].endsWith("route.mjs")) {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", chunk => { body += chunk; });
+    req.on("end", () => { handleAllowedAssetsRequest(req, res, body); });
+  });
+
+  server.listen(PORT, () => {
+    console.log(`allowed-assets mock listening on http://localhost:${PORT}/allowed-assets`);
+  });
+}


### PR DESCRIPTION
Closes #31
Closes #32
Closes #29
Closes #73

## Description for the 4 Fixes

1. **Issue #31**: Added mock GET route returning network fee estimates (low, medium, high in stroops) under contrib/routes/issue-31-fee-estimates/.
2. **Issue #32**: Added mock POST route validating Stellar public key address format (starts with 'G', 56 chars long) under contrib/routes/issue-32-address-validate/.
3. **Issue #29**: Added mock GET route for filtering sample transactions by date range (rom and 	o query parameters) under contrib/routes/issue-29-transactions-by-date/.
4. **Issue #73**: Added mock POST validator route for checking llowedAssets configuration array schema under contrib/routes/issue-73-allowed-assets/.