### PR TITLE
feat(contrib): implement mock route modules for webhook, rate limiting, agent key minting, and policy attach builds 

### DIFF
--- a/contrib/routes/agent-key-mint/README.md
+++ b/contrib/routes/agent-key-mint/README.md
@@ -1,0 +1,63 @@
+# Agent Session Key Mint
+
+## Purpose
+
+This mock route simulates minting a scoped agent session key with deterministic
+identifiers and timestamps. It does not perform cryptography or call any
+external system.
+
+## Endpoints
+
+### `POST /session-keys/mint`
+
+<br />
+
+Creates a mock session key.
+
+Example request:
+
+```json
+{
+  "expirySeconds": 90,
+  "budget": 250
+}
+```
+
+Example response (`201`):
+
+```json
+{
+  "keyId": "mock-session-key-0001",
+  "expiresAt": "2026-07-29T14:31:30.000Z",
+  "budget": 250,
+  "createdAt": "2026-07-29T14:30:00.000Z"
+}
+```
+
+Example validation error (`400`):
+
+```json
+{
+  "error": {
+    "message": "expirySeconds must be greater than 0"
+  }
+}
+```
+
+## Validation Rules
+
+- `expirySeconds` is required and must be greater than `0`.
+- `budget` is required and must be greater than `0`.
+
+## How To Run The Test
+
+```bash
+node --test contrib/routes/agent-key-mint/route.test.js
+```
+
+## Expected Behavior
+
+- Each successful request returns a deterministic mock key id.
+- `expiresAt` is computed as `createdAt + expirySeconds`.
+- Invalid payloads return descriptive `400` errors.
+

--- a/contrib/routes/agent-key-mint/route.js
+++ b/contrib/routes/agent-key-mint/route.js
@@ -1,0 +1,93 @@
+function createAgentKeyMintRoute(options = {}) {
+  const now = options.now ?? (() => new Date());
+  let nextKeyNumber = 1;
+
+  function mintKey(body = {}) {
+    const expirySecondsResult = validatePositiveNumber(body.expirySeconds, "expirySeconds");
+    if (!expirySecondsResult.ok) {
+      return expirySecondsResult.response;
+    }
+
+    const budgetResult = validatePositiveNumber(body.budget, "budget");
+    if (!budgetResult.ok) {
+      return budgetResult.response;
+    }
+
+    
+    const createdAtDate = toDate(now());
+    const createdAt = createdAtDate.toISOString();
+    const expiresAt = new Date(
+      createdAtDate.getTime() + expirySecondsResult.value * 1000,
+    ).toISOString();
+    const keyId = `mock-session-key-${String(nextKeyNumber).padStart(4, "0")}`;
+
+    nextKeyNumber += 1;
+
+    return jsonResponse(201, {
+      keyId,
+      expiresAt,
+      budget: budgetResult.value,
+      createdAt,
+    });
+  }
+
+  function handleRequest(request = {}) {
+    const method = normalizeMethod(request.method);
+    const path = request.path ?? "";
+
+    if (method === "POST" && path === "/session-keys/mint") {
+      return mintKey(request.body);
+    }
+
+    return errorResponse(404, "route not found");
+  }
+
+  return {
+    handleRequest,
+    mintKey,
+  };
+}
+
+function validatePositiveNumber(value, fieldName) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return {
+      ok: false,
+      response: errorResponse(400, `${fieldName} must be greater than 0`),
+    };
+  }
+
+  return {
+    ok: true,
+    value,
+  };
+}
+
+function normalizeMethod(method) {
+  return typeof method === "string" ? method.toUpperCase() : "";
+}
+
+function toDate(value) {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      "content-type": "application/json",
+    },
+    body,
+  };
+}
+
+function errorResponse(statusCode, message) {
+  return jsonResponse(statusCode, {
+    error: {
+      message,
+    },
+  });
+}
+
+module.exports = {
+  createAgentKeyMintRoute,
+};

--- a/contrib/routes/agent-key-mint/route.test.js
+++ b/contrib/routes/agent-key-mint/route.test.js
@@ -1,0 +1,56 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createAgentKeyMintRoute } = require("./route");
+
+test("agent key mint route returns deterministic mock session keys", () => {
+  const route = createAgentKeyMintRoute({
+    now: () => new Date("2026-07-29T14:30:00.000Z"),
+  });
+
+  
+  const response = route.handleRequest({
+    method: "POST",
+    path: "/session-keys/mint",
+    body: {
+      expirySeconds: 90,
+      budget: 250,
+    },
+  });
+
+  assert.equal(response.statusCode, 201);
+  assert.deepEqual(response.body, {
+    keyId: "mock-session-key-0001",
+    expiresAt: "2026-07-29T14:31:30.000Z",
+    budget: 250,
+    createdAt: "2026-07-29T14:30:00.000Z",
+  });
+});
+
+test("agent key mint route rejects invalid payloads", () => {
+  const route = createAgentKeyMintRoute();
+
+  const expiryResponse = route.handleRequest({
+    method: "POST",
+    path: "/session-keys/mint",
+    body: {
+      expirySeconds: 0,
+      budget: 10,
+    },
+  });
+
+  assert.equal(expiryResponse.statusCode, 400);
+  assert.equal(expiryResponse.body.error.message, "expirySeconds must be greater than 0");
+
+  const budgetResponse = route.handleRequest({
+    method: "POST",
+    path: "/session-keys/mint",
+    body: {
+      expirySeconds: 60,
+      budget: -1,
+    },
+  });
+
+  assert.equal(budgetResponse.statusCode, 400);
+  assert.equal(budgetResponse.body.error.message, "budget must be greater than 0");
+});

--- a/contrib/routes/policy-attach-build/README.md
+++ b/contrib/routes/policy-attach-build/README.md
@@ -1,0 +1,63 @@
+# Policy Attach Transaction Builder
+
+## Purpose
+
+This mock route simulates building an unsigned transaction payload for attaching
+a policy. The response is placeholder data only and never touches real wallet,
+blockchain, or policy infrastructure.
+
+## Endpoints
+
+### `POST /policy-attachments/build`
+
+Builds a deterministic fake unsigned transaction envelope.
+
+Example request:
+
+```json
+{
+  "policyId": "policy-123",
+  "accountId": "account-789"
+}
+```
+
+Example response (`200`):
+
+```json
+{
+  "unsignedEnvelope": "unsigned-policy-policy-123-account-789-1785339900000",
+  "expiry": "2026-07-29T15:50:00.000Z",
+  "policyId": "policy-123",
+  "accountId": "account-789"
+}
+```
+
+Example validation error (`400`):
+
+```json
+{
+  "error": {
+    "message": "policyId is required"
+  }
+}
+```
+
+## Validation Rules
+
+- `policyId` is required and must be a non-empty string.
+- `accountId` is required and must be a non-empty string.
+
+## How To Run The Test
+
+```bash
+node --test contrib/routes/policy-attach-build/route.test.js
+```
+
+## Expected Behavior
+
+- The route returns a deterministic fake envelope string.
+- The response always includes `expiry`, `policyId`, and `accountId`.
+- Invalid payloads return descriptive `400` responses.
+
+  <br />
+

--- a/contrib/routes/policy-attach-build/route.js
+++ b/contrib/routes/policy-attach-build/route.js
@@ -1,0 +1,93 @@
+function createPolicyAttachBuildRoute(options = {}) {
+  const now = options.now ?? (() => new Date());
+  const expiryWindowSeconds = options.expiryWindowSeconds ?? 300;
+
+  function buildUnsignedTransaction(body = {}) {
+    const policyIdResult = validateRequiredString(body.policyId, "policyId");
+    if (!policyIdResult.ok) {
+      return policyIdResult.response;
+    }
+
+    const accountIdResult = validateRequiredString(body.accountId, "accountId");
+    if (!accountIdResult.ok) {
+      return accountIdResult.response;
+    }
+
+    
+    const createdAtDate = toDate(now());
+    const timestamp = createdAtDate.getTime();
+    const policyId = policyIdResult.value;
+    const accountId = accountIdResult.value;
+
+    return jsonResponse(200, {
+      unsignedEnvelope: `unsigned-policy-${toEnvelopeToken(policyId)}-${toEnvelopeToken(accountId)}-${timestamp}`,
+      expiry: new Date(createdAtDate.getTime() + expiryWindowSeconds * 1000).toISOString(),
+      policyId,
+      accountId,
+    });
+  }
+
+  function handleRequest(request = {}) {
+    const method = normalizeMethod(request.method);
+    const path = request.path ?? "";
+
+    if (method === "POST" && path === "/policy-attachments/build") {
+      return buildUnsignedTransaction(request.body);
+    }
+
+    return errorResponse(404, "route not found");
+  }
+
+  return {
+    handleRequest,
+    buildUnsignedTransaction,
+  };
+}
+
+function validateRequiredString(value, fieldName) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return {
+      ok: false,
+      response: errorResponse(400, `${fieldName} is required`),
+    };
+  }
+
+  return {
+    ok: true,
+    value: value.trim(),
+  };
+}
+
+function toEnvelopeToken(value) {
+  return value.trim().replace(/\s+/g, "-");
+}
+
+function normalizeMethod(method) {
+  return typeof method === "string" ? method.toUpperCase() : "";
+}
+
+function toDate(value) {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      "content-type": "application/json",
+    },
+    body,
+  };
+}
+
+function errorResponse(statusCode, message) {
+  return jsonResponse(statusCode, {
+    error: {
+      message,
+    },
+  });
+}
+
+module.exports = {
+  createPolicyAttachBuildRoute,
+};

--- a/contrib/routes/policy-attach-build/route.test.js
+++ b/contrib/routes/policy-attach-build/route.test.js
@@ -1,0 +1,58 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createPolicyAttachBuildRoute } = require("./route");
+
+test("policy attach build route returns a deterministic unsigned envelope", () => {
+  const route = createPolicyAttachBuildRoute({
+    now: () => new Date("2026-07-29T15:45:00.000Z"),
+  });
+
+  
+  const response = route.handleRequest({
+    method: "POST",
+    path: "/policy-attachments/build",
+    body: {
+      policyId: "policy-123",
+      accountId: "account-789",
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(
+    response.body.unsignedEnvelope,
+    "unsigned-policy-policy-123-account-789-1785339900000",
+  );
+  assert.equal(response.body.policyId, "policy-123");
+  assert.equal(response.body.accountId, "account-789");
+  assert.equal(response.body.expiry, "2026-07-29T15:50:00.000Z");
+  assert.notEqual(response.body.unsignedEnvelope.length, 0);
+});
+
+test("policy attach build route validates required fields", () => {
+  const route = createPolicyAttachBuildRoute();
+
+  const missingPolicyResponse = route.handleRequest({
+    method: "POST",
+    path: "/policy-attachments/build",
+    body: {
+      policyId: "   ",
+      accountId: "account-789",
+    },
+  });
+
+  assert.equal(missingPolicyResponse.statusCode, 400);
+  assert.equal(missingPolicyResponse.body.error.message, "policyId is required");
+
+  const missingAccountResponse = route.handleRequest({
+    method: "POST",
+    path: "/policy-attachments/build",
+    body: {
+      policyId: "policy-123",
+      accountId: "",
+    },
+  });
+
+  assert.equal(missingAccountResponse.statusCode, 400);
+  assert.equal(missingAccountResponse.body.error.message, "accountId is required");
+});

--- a/contrib/routes/rate-limit-config/README.md
+++ b/contrib/routes/rate-limit-config/README.md
@@ -1,0 +1,89 @@
+# Rate Limit Configuration
+
+## Purpose
+
+This mock route simulates configuring rate limits for named endpoints using only
+in-memory state. It is fully isolated inside
+`contrib/routes/rate-limit-config/`.
+
+## Endpoints
+
+### `PUT /rate-limits`
+
+Stores a custom rate limit for an endpoint.
+
+Example request:
+
+```json
+{
+  "endpointName": "listPolicies",
+  "limit": 25
+}
+```
+
+Example response (`200`):
+
+```json
+{
+  "endpoint": "listPolicies",
+  "limit": 25,
+  "updatedAt": "2026-07-29T13:00:00.000Z"
+}
+```
+
+### `GET /rate-limits/:endpointName`
+
+<br />
+
+Returns the current configuration for the endpoint. If the endpoint has not
+been configured yet, the route returns a deterministic default limit of `100`.
+
+Example default response (`200`):
+
+```json
+{
+  "endpoint": "listPolicies",
+  "limit": 100,
+  "source": "default"
+}
+```
+
+Example custom response (`200`):
+
+```json
+{
+  "endpoint": "listPolicies",
+  "limit": 25,
+  "source": "custom",
+  "updatedAt": "2026-07-29T13:00:00.000Z"
+}
+```
+
+Example validation error (`400`):
+
+```json
+{
+  "error": {
+    "message": "limit must be a positive integer"
+  }
+}
+```
+
+## Validation Rules
+
+- `endpointName` is required and must be a non-empty string.
+- `limit` is required and must be a positive integer.
+- `0`, negative numbers, decimals, and strings are rejected.
+
+## How To Run The Test
+
+```bash
+node --test contrib/routes/rate-limit-config/route.test.js
+```
+
+## Expected Behavior
+
+- Unknown endpoints return the deterministic default configuration.
+- Configured endpoints return the last custom value stored in memory.
+- Invalid payloads return descriptive `400` responses.
+

--- a/contrib/routes/rate-limit-config/route.js
+++ b/contrib/routes/rate-limit-config/route.js
@@ -1,0 +1,140 @@
+const DEFAULT_LIMIT = 100;
+
+function createRateLimitConfigRoute(options = {}) {
+  const now = options.now ?? (() => new Date());
+  const defaultLimit = options.defaultLimit ?? DEFAULT_LIMIT;
+  const configurations = new Map();
+
+  
+  function setRateLimit(body = {}) {
+    const endpointNameResult = validateEndpointName(body.endpointName);
+    if (!endpointNameResult.ok) {
+      return endpointNameResult.response;
+    }
+
+    const limitResult = validatePositiveInteger(body.limit, "limit");
+    if (!limitResult.ok) {
+      return limitResult.response;
+    }
+
+    const updatedAt = toIsoTimestamp(now());
+    const endpoint = endpointNameResult.value;
+    const configuration = {
+      endpoint,
+      limit: limitResult.value,
+      updatedAt,
+    };
+
+    configurations.set(endpoint, configuration);
+
+    return jsonResponse(200, configuration);
+  }
+
+  function getRateLimit(endpointName) {
+    const endpointNameResult = validateEndpointName(endpointName);
+    if (!endpointNameResult.ok) {
+      return endpointNameResult.response;
+    }
+
+    const endpoint = endpointNameResult.value;
+    const configuration = configurations.get(endpoint);
+
+    if (!configuration) {
+      return jsonResponse(200, {
+        endpoint,
+        limit: defaultLimit,
+        source: "default",
+      });
+    }
+
+    return jsonResponse(200, {
+      endpoint: configuration.endpoint,
+      limit: configuration.limit,
+      source: "custom",
+      updatedAt: configuration.updatedAt,
+    });
+  }
+
+  function handleRequest(request = {}) {
+    const method = normalizeMethod(request.method);
+    const path = request.path ?? "";
+
+    if (method === "PUT" && path === "/rate-limits") {
+      return setRateLimit(request.body);
+    }
+
+    if (method === "GET" && path.startsWith("/rate-limits/")) {
+      return getRateLimit(path.slice("/rate-limits/".length));
+    }
+
+    return errorResponse(404, "route not found");
+  }
+
+  return {
+    handleRequest,
+    setRateLimit,
+    getRateLimit,
+  };
+}
+
+function validateEndpointName(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return {
+      ok: false,
+      response: errorResponse(400, "endpointName is required"),
+    };
+  }
+
+  return {
+    ok: true,
+    value: value.trim(),
+  };
+}
+
+function validatePositiveInteger(value, fieldName) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return {
+      ok: false,
+      response: errorResponse(400, `${fieldName} must be a positive integer`),
+    };
+  }
+
+  return {
+    ok: true,
+    value,
+  };
+}
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      "content-type": "application/json",
+    },
+    body,
+  };
+}
+
+function errorResponse(statusCode, message) {
+  return jsonResponse(statusCode, {
+    error: {
+      message,
+    },
+  });
+}
+
+function normalizeMethod(method) {
+  return typeof method === "string" ? method.toUpperCase() : "";
+}
+
+function toIsoTimestamp(value) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return new Date(value).toISOString();
+}
+
+module.exports = {
+  createRateLimitConfigRoute,
+};

--- a/contrib/routes/rate-limit-config/route.test.js
+++ b/contrib/routes/rate-limit-config/route.test.js
@@ -1,0 +1,113 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createRateLimitConfigRoute } = require("./route");
+
+test("rate limit route returns the deterministic default configuration", () => {
+  const route = createRateLimitConfigRoute();
+
+  const response = route.handleRequest({
+    method: "GET",
+    path: "/rate-limits/listPolicies",
+  });
+
+  
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, {
+    endpoint: "listPolicies",
+    limit: 100,
+    source: "default",
+  });
+});
+
+test("rate limit route stores and returns custom configuration", () => {
+  const route = createRateLimitConfigRoute({
+    now: () => new Date("2026-07-29T13:00:00.000Z"),
+  });
+
+  const updateResponse = route.handleRequest({
+    method: "PUT",
+    path: "/rate-limits",
+    body: {
+      endpointName: "listPolicies",
+      limit: 25,
+    },
+  });
+
+  assert.equal(updateResponse.statusCode, 200);
+  assert.deepEqual(updateResponse.body, {
+    endpoint: "listPolicies",
+    limit: 25,
+    updatedAt: "2026-07-29T13:00:00.000Z",
+  });
+
+  const readResponse = route.handleRequest({
+    method: "GET",
+    path: "/rate-limits/listPolicies",
+  });
+
+  assert.equal(readResponse.statusCode, 200);
+  assert.deepEqual(readResponse.body, {
+    endpoint: "listPolicies",
+    limit: 25,
+    source: "custom",
+    updatedAt: "2026-07-29T13:00:00.000Z",
+  });
+});
+
+test("rate limit route rejects invalid input", () => {
+  const route = createRateLimitConfigRoute();
+
+  const cases = [
+    {
+      name: "missing endpointName",
+      request: {
+        method: "PUT",
+        path: "/rate-limits",
+        body: { limit: 10 },
+      },
+      expectedMessage: "endpointName is required",
+    },
+    {
+      name: "zero limit",
+      request: {
+        method: "PUT",
+        path: "/rate-limits",
+        body: { endpointName: "listPolicies", limit: 0 },
+      },
+      expectedMessage: "limit must be a positive integer",
+    },
+    {
+      name: "decimal limit",
+      request: {
+        method: "PUT",
+        path: "/rate-limits",
+        body: { endpointName: "listPolicies", limit: 2.5 },
+      },
+      expectedMessage: "limit must be a positive integer",
+    },
+    {
+      name: "string limit",
+      request: {
+        method: "PUT",
+        path: "/rate-limits",
+        body: { endpointName: "listPolicies", limit: "20" },
+      },
+      expectedMessage: "limit must be a positive integer",
+    },
+    {
+      name: "missing endpoint in get",
+      request: {
+        method: "GET",
+        path: "/rate-limits/   ",
+      },
+      expectedMessage: "endpointName is required",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const response = route.handleRequest(testCase.request);
+    assert.equal(response.statusCode, 400, testCase.name);
+    assert.equal(response.body.error.message, testCase.expectedMessage, testCase.name);
+  }
+});

--- a/contrib/routes/webhook-retry-queue/README.md
+++ b/contrib/routes/webhook-retry-queue/README.md
@@ -1,0 +1,83 @@
+# Webhook Retry Queue
+
+## Purpose
+
+This mock route simulates a webhook delivery queue that advances through a
+deterministic retry lifecycle in memory. It does not send real webhooks or
+touch any code outside `contrib/routes/webhook-retry-queue/`.
+
+## Endpoints
+
+### `POST /deliveries`
+
+Creates a new webhook delivery entry.
+
+Example request:
+
+```json
+{}
+```
+
+Example response (`201`):
+
+```json
+{
+  "deliveryId": "delivery-0001",
+  "status": "pending",
+  "retryCount": 0,
+  "createdAt": "2026-07-29T12:00:00.000Z"
+}
+```
+
+### `GET /deliveries/:deliveryId`
+
+Returns the current delivery status and automatically advances the lifecycle on
+each lookup until a terminal state is reached.
+
+Lifecycle progression:
+
+`pending -> retrying (1) -> retrying (2) -> retrying (3) -> delivered`
+
+Example response (`200`):
+
+```json
+{
+  "deliveryId": "delivery-0001",
+  "status": "retrying",
+  "retryCount": 2,
+  "maxRetries": 3,
+  "updatedAt": "2026-07-29T12:00:02.000Z"
+}
+```
+
+Example error (`404`):
+
+```json
+{
+  "error": {
+    "message": "delivery missing-delivery was not found"
+  }
+}
+```
+
+## Validation Rules
+
+- `deliveryId` must be present in the path for status lookups.
+- Unknown deliveries return `404`.
+- Unsupported method/path combinations return `404`.
+
+## How To Run The Test
+
+<br />
+
+```bash
+node --test contrib/routes/webhook-retry-queue/route.test.js
+```
+
+## Expected Behavior
+
+- Enqueue starts every delivery in `pending` with `retryCount: 0`.
+- Status polling advances the delivery deterministically.
+- Once the delivery reaches `delivered`, later lookups keep returning the same
+  terminal state.
+

--- a/contrib/routes/webhook-retry-queue/route.js
+++ b/contrib/routes/webhook-retry-queue/route.js
@@ -1,0 +1,138 @@
+const DEFAULT_MAX_RETRIES = 3;
+ 
+
+function createWebhookRetryQueueRoute(options = {}) {
+  const now = options.now ?? (() => new Date());
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const deliveries = new Map();
+  let nextDeliveryNumber = 1;
+
+  function enqueueDelivery() {
+    const timestamp = toIsoTimestamp(now());
+    const deliveryId = `delivery-${String(nextDeliveryNumber).padStart(4, "0")}`;
+
+    nextDeliveryNumber += 1;
+
+    const delivery = {
+      deliveryId,
+      status: "pending",
+      retryCount: 0,
+      maxRetries,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    deliveries.set(deliveryId, delivery);
+
+    return jsonResponse(201, {
+      deliveryId: delivery.deliveryId,
+      status: delivery.status,
+      retryCount: delivery.retryCount,
+      createdAt: delivery.createdAt,
+    });
+  }
+
+  function getDeliveryStatus(deliveryId) {
+    if (!isNonEmptyString(deliveryId)) {
+      return errorResponse(400, "deliveryId is required");
+    }
+
+    const normalizedDeliveryId = deliveryId.trim();
+    const delivery = deliveries.get(normalizedDeliveryId);
+
+    if (!delivery) {
+      return errorResponse(404, `delivery ${normalizedDeliveryId} was not found`);
+    }
+
+    advanceDeliveryLifecycle(delivery, now);
+
+    return jsonResponse(200, {
+      deliveryId: delivery.deliveryId,
+      status: delivery.status,
+      retryCount: delivery.retryCount,
+      maxRetries: delivery.maxRetries,
+      updatedAt: delivery.updatedAt,
+    });
+  }
+
+  function handleRequest(request = {}) {
+    const method = normalizeMethod(request.method);
+    const path = request.path ?? "";
+
+    if (method === "POST" && path === "/deliveries") {
+      return enqueueDelivery();
+    }
+
+    if (method === "GET" && path.startsWith("/deliveries/")) {
+      return getDeliveryStatus(path.slice("/deliveries/".length));
+    }
+
+    return errorResponse(404, "route not found");
+  }
+
+  return {
+    handleRequest,
+    enqueueDelivery,
+    getDeliveryStatus,
+  };
+}
+
+function advanceDeliveryLifecycle(delivery, now) {
+  if (delivery.status === "delivered" || delivery.status === "failed") {
+    return delivery;
+  }
+
+  delivery.updatedAt = toIsoTimestamp(now());
+
+  if (delivery.status === "pending") {
+    delivery.status = "retrying";
+    delivery.retryCount = 1;
+    return delivery;
+  }
+
+  if (delivery.retryCount < delivery.maxRetries) {
+    delivery.retryCount += 1;
+    return delivery;
+  }
+
+  delivery.status = "delivered";
+  return delivery;
+}
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      "content-type": "application/json",
+    },
+    body,
+  };
+}
+
+function errorResponse(statusCode, message) {
+  return jsonResponse(statusCode, {
+    error: {
+      message,
+    },
+  });
+}
+
+function normalizeMethod(method) {
+  return typeof method === "string" ? method.toUpperCase() : "";
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function toIsoTimestamp(value) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return new Date(value).toISOString();
+}
+
+module.exports = {
+  createWebhookRetryQueueRoute,
+};

--- a/contrib/routes/webhook-retry-queue/route.test.js
+++ b/contrib/routes/webhook-retry-queue/route.test.js
@@ -1,0 +1,74 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createWebhookRetryQueueRoute } = require("./route");
+
+function createSequentialClock(isoTimestamps) {
+  let index = 0;
+
+  return () => {
+    const value = isoTimestamps[Math.min(index, isoTimestamps.length - 1)];
+    index += 1;
+    return new Date(value);
+  };
+}
+
+
+test("webhook retry queue advances deterministically to a terminal state", () => {
+  const route = createWebhookRetryQueueRoute({
+    now: createSequentialClock([
+      "2026-07-29T12:00:00.000Z",
+      "2026-07-29T12:00:01.000Z",
+      "2026-07-29T12:00:02.000Z",
+      "2026-07-29T12:00:03.000Z",
+      "2026-07-29T12:00:04.000Z",
+    ]),
+  });
+
+  const enqueueResponse = route.handleRequest({
+    method: "POST",
+    path: "/deliveries",
+  });
+
+  assert.equal(enqueueResponse.statusCode, 201);
+  assert.deepEqual(enqueueResponse.body, {
+    deliveryId: "delivery-0001",
+    status: "pending",
+    retryCount: 0,
+    createdAt: "2026-07-29T12:00:00.000Z",
+  });
+
+  const progression = [
+    route.handleRequest({ method: "GET", path: "/deliveries/delivery-0001" }).body,
+    route.handleRequest({ method: "GET", path: "/deliveries/delivery-0001" }).body,
+    route.handleRequest({ method: "GET", path: "/deliveries/delivery-0001" }).body,
+    route.handleRequest({ method: "GET", path: "/deliveries/delivery-0001" }).body,
+  ];
+
+  assert.deepEqual(
+    progression.map((item) => ({
+      status: item.status,
+      retryCount: item.retryCount,
+    })),
+    [
+      { status: "retrying", retryCount: 1 },
+      { status: "retrying", retryCount: 2 },
+      { status: "retrying", retryCount: 3 },
+      { status: "delivered", retryCount: 3 },
+    ],
+  );
+
+  assert.equal(progression.at(-1).maxRetries, 3);
+  assert.equal(progression.at(-1).updatedAt, "2026-07-29T12:00:04.000Z");
+});
+
+test("webhook retry queue returns not found for unknown deliveries", () => {
+  const route = createWebhookRetryQueueRoute();
+  const response = route.handleRequest({
+    method: "GET",
+    path: "/deliveries/missing-delivery",
+  });
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(response.body.error.message, "delivery missing-delivery was not found");
+});


### PR DESCRIPTION

## Summary

This PR adds four self-contained mock route modules under `contrib/routes/` to simulate common backend workflows without affecting production code. Each module includes request validation, deterministic mock behavior, documentation, and a sample script or test demonstrating its functionality.

## Changes

- Added a mock webhook delivery retry queue with enqueue and status endpoints that simulate retry progression to a terminal state.
- Added a mock rate limit configuration module with endpoints to set validated limits and retrieve custom or default configurations.
- Added a mock agent session key mint module that generates scoped session keys with computed expiry timestamps and budget metadata.
- Added a mock policy attach transaction builder that returns deterministic unsigned transaction envelope payloads with expiry information.
- Included README documentation for each module with usage examples and implementation details.
- Added sample scripts/tests covering lifecycle progression, validation, default behavior, expiry calculations, and generated payload assertions.

## Notes

- All work is fully contained within the `contrib/` directory.
- No production code or files outside `contrib/` were modified.
- The implementations are deterministic, self-contained, and intended for demonstration and testing purposes only.


Closes #86 
Closes #87 
Closes #88 
Closes #90 