### PR TITLE
Add three route suites: batch queue, verification cache, and fee spon…

### DIFF
--- a/contrib/routes/batch-queue-suite/README.md
+++ b/contrib/routes/batch-queue-suite/README.md
@@ -1,0 +1,53 @@
+# Batch Queue Suite
+
+A self-contained route handler simulating a batched submission queue with retry logic.
+
+## Endpoints
+
+### POST /enqueue-batch
+
+Accepts a batch of mock transactions and processes them in order. A configurable fraction of items fail on the first attempt and succeed on retry.
+
+**Request Body:**
+```json
+{
+  "transactions": [
+    { "id": "tx1", "data": "..." },
+    { "id": "tx2", "data": "..." }
+  ],
+  "failureRate": 0.3,
+  "maxRetries": 3
+}
+```
+
+**Response:**
+```json
+{
+  "batchId": "batch-123",
+  "totalCount": 2,
+  "pending": 2
+}
+```
+
+### GET /batch-status/:batchId
+
+Returns the status of each item in the batch, including per-item state (pending, retrying, succeeded, or failed after retries exhausted).
+
+**Response:**
+```json
+{
+  "batchId": "batch-123",
+  "items": [
+    { "id": "tx1", "state": "succeeded", "attempts": 1 },
+    { "id": "tx2", "state": "retrying", "attempts": 2 }
+  ]
+}
+```
+
+## Running the Test
+
+```bash
+node test.ts
+```
+
+This test demonstrates a batch that fully succeeds after retries.

--- a/contrib/routes/batch-queue-suite/index.ts
+++ b/contrib/routes/batch-queue-suite/index.ts
@@ -1,0 +1,131 @@
+import Fastify, { FastifyRequest, FastifyReply } from "fastify";
+
+const app = Fastify({ logger: false });
+
+// In-memory storage
+const batches = new Map<string, Batch>();
+let batchCounter = 0;
+
+interface Transaction {
+  id: string;
+  data: string;
+}
+
+interface BatchItem {
+  id: string;
+  data: string;
+  state: "pending" | "retrying" | "succeeded" | "failed";
+  attempts: number;
+  shouldFail: boolean;
+}
+
+interface Batch {
+  id: string;
+  items: BatchItem[];
+  maxRetries: number;
+  createdAt: number;
+}
+
+interface EnqueueRequest {
+  transactions: Transaction[];
+  failureRate?: number;
+  maxRetries?: number;
+}
+
+// POST /enqueue-batch
+app.post("/enqueue-batch", async (request: FastifyRequest, reply: FastifyReply) => {
+  const body = request.body as EnqueueRequest;
+  const { transactions, failureRate = 0.3, maxRetries = 3 } = body;
+
+  if (!Array.isArray(transactions) || transactions.length === 0) {
+    return reply.status(400).send({ error: "transactions must be a non-empty array" });
+  }
+
+  batchCounter++;
+  const batchId = `batch-${batchCounter}`;
+
+  const items: BatchItem[] = transactions.map((tx) => ({
+    id: tx.id,
+    data: tx.data,
+    state: "pending" as const,
+    attempts: 0,
+    shouldFail: Math.random() < failureRate,
+  }));
+
+  const batch: Batch = {
+    id: batchId,
+    items,
+    maxRetries,
+    createdAt: Date.now(),
+  };
+
+  batches.set(batchId, batch);
+
+  // Start processing the batch
+  processBatch(batch);
+
+  return {
+    batchId,
+    totalCount: items.length,
+    pending: items.length,
+  };
+});
+
+// GET /batch-status/:batchId
+app.get("/batch-status/:batchId", async (request: FastifyRequest, reply: FastifyReply) => {
+  const { batchId } = request.params as { batchId: string };
+
+  const batch = batches.get(batchId);
+  if (!batch) {
+    return reply.status(404).send({ error: "Batch not found" });
+  }
+
+  return {
+    batchId,
+    items: batch.items.map((item) => ({
+      id: item.id,
+      state: item.state,
+      attempts: item.attempts,
+    })),
+  };
+});
+
+async function processBatch(batch: Batch): Promise<void> {
+  for (const item of batch.items) {
+    await processItem(batch, item);
+  }
+}
+
+async function processItem(batch: Batch, item: BatchItem): Promise<void> {
+  if (item.state === "succeeded" || item.state === "failed") {
+    return;
+  }
+
+  item.attempts++;
+  item.state = "retrying";
+
+  // Simulate processing delay
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  if (item.shouldFail && item.attempts === 1) {
+    // First attempt fails
+    item.state = "retrying";
+    // Retry after a short delay
+    setTimeout(() => processItem(batch, item), 50);
+  } else if (item.attempts > batch.maxRetries) {
+    // Retries exhausted
+    item.state = "failed";
+  } else {
+    // Success
+    item.state = "succeeded";
+  }
+}
+
+// Start server if run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number(process.env.PORT) || 3001;
+  await app.listen({ port, host: "0.0.0.0" });
+  console.log(`Batch queue suite running on port ${port}`);
+}
+
+export { app };

--- a/contrib/routes/batch-queue-suite/package.json
+++ b/contrib/routes/batch-queue-suite/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "batch-queue-suite",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test.ts"
+  },
+  "dependencies": {
+    "fastify": "^5.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/contrib/routes/batch-queue-suite/test.ts
+++ b/contrib/routes/batch-queue-suite/test.ts
@@ -1,0 +1,80 @@
+import { app } from "./index";
+
+async function testBatchWithRetries(): Promise<void> {
+  console.log("Testing batch queue with retries...\n");
+
+  // Start server in background
+  const port = 3001;
+  const server = await app.listen({ port, host: "127.0.0.1" });
+
+  try {
+    // Enqueue a batch with 5 transactions
+    const enqueueResponse = await fetch(`http://127.0.0.1:${port}/enqueue-batch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        transactions: [
+          { id: "tx1", data: "transaction 1" },
+          { id: "tx2", data: "transaction 2" },
+          { id: "tx3", data: "transaction 3" },
+          { id: "tx4", data: "transaction 4" },
+          { id: "tx5", data: "transaction 5" },
+        ],
+        failureRate: 0.4, // 40% will fail on first attempt
+        maxRetries: 3,
+      }),
+    });
+
+    const enqueueData = (await enqueueResponse.json()) as { batchId: string; totalCount: number; pending: number };
+    console.log("Enqueued batch:", enqueueData);
+    console.log(`Batch ID: ${enqueueData.batchId}\n`);
+
+    // Poll for status until all items are done
+    let allDone = false;
+    let attempts = 0;
+    const maxAttempts = 20;
+
+    while (!allDone && attempts < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const statusResponse = await fetch(`http://127.0.0.1:${port}/batch-status/${enqueueData.batchId}`);
+      const statusData = (await statusResponse.json()) as {
+        batchId: string;
+        items: Array<{ id: string; state: string; attempts: number }>;
+      };
+
+      console.log(`Status check ${attempts + 1}:`);
+      statusData.items.forEach((item) => {
+        console.log(`  ${item.id}: ${item.state} (attempts: ${item.attempts})`);
+      });
+
+      allDone = statusData.items.every((item) => item.state === "succeeded" || item.state === "failed");
+      attempts++;
+    }
+
+    console.log("\nFinal status:");
+    const finalResponse = await fetch(`http://127.0.0.1:${port}/batch-status/${enqueueData.batchId}`);
+    const finalData = (await finalResponse.json()) as {
+      batchId: string;
+      items: Array<{ id: string; state: string; attempts: number }>;
+    };
+
+    finalData.items.forEach((item) => {
+      console.log(`  ${item.id}: ${item.state} (attempts: ${item.attempts})`);
+    });
+
+    const succeeded = finalData.items.filter((i) => i.state === "succeeded").length;
+    const failed = finalData.items.filter((i) => i.state === "failed").length;
+    console.log(`\nSummary: ${succeeded} succeeded, ${failed} failed`);
+
+    if (allDone) {
+      console.log("✓ Test passed: All items completed");
+    } else {
+      console.log("✗ Test failed: Items did not complete in time");
+    }
+  } finally {
+    await app.close();
+  }
+}
+
+testBatchWithRetries().catch(console.error);

--- a/contrib/routes/batch-queue-suite/tsconfig.json
+++ b/contrib/routes/batch-queue-suite/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/contrib/routes/fee-sponsorship-suite/README.md
+++ b/contrib/routes/fee-sponsorship-suite/README.md
@@ -1,0 +1,58 @@
+# Fee Sponsorship Suite
+
+A self-contained route handler simulating fee sponsorship across multiple mock submissions.
+
+## Endpoints
+
+### POST /submit
+
+Submits a transaction with fee sponsorship. Each submission deducts a fee amount from the in-memory sponsor balance. Rejects with a clear error once the sponsor balance would go negative.
+
+**Request Body:**
+```json
+{
+  "transactionId": "tx1",
+  "fee": 100
+}
+```
+
+**Response (success):**
+```json
+{
+  "transactionId": "tx1",
+  "feeDeducted": 100,
+  "remainingBalance": 900,
+  "status": "accepted"
+}
+```
+
+**Response (insufficient balance):**
+```json
+{
+  "error": "Insufficient sponsor balance",
+  "transactionId": "tx1",
+  "requiredFee": 100,
+  "currentBalance": 50
+}
+```
+
+### GET /sponsor-balance
+
+Returns the current sponsor account balance.
+
+**Response:**
+```json
+{
+  "balance": 900,
+  "initialBalance": 1000,
+  "totalFeesDeducted": 100
+}
+```
+
+## Running the Test
+
+```bash
+node test.ts
+```
+
+This test demonstrates several successful submissions and one rejected once the budget runs out.

--- a/contrib/routes/fee-sponsorship-suite/index.ts
+++ b/contrib/routes/fee-sponsorship-suite/index.ts
@@ -1,0 +1,70 @@
+import Fastify, { FastifyRequest, FastifyReply } from "fastify";
+
+const app = Fastify({ logger: false });
+
+// In-memory sponsor state
+const INITIAL_BALANCE = 1000;
+let sponsorBalance = INITIAL_BALANCE;
+let totalFeesDeducted = 0;
+
+interface SubmitRequest {
+  transactionId: string;
+  fee?: number;
+}
+
+// POST /submit
+app.post("/submit", async (request: FastifyRequest, reply: FastifyReply) => {
+  const body = request.body as SubmitRequest;
+  const { transactionId, fee = 50 } = body;
+
+  if (!transactionId) {
+    return reply.status(400).send({ error: "transactionId is required" });
+  }
+
+  if (typeof fee !== "number" || fee <= 0) {
+    return reply.status(400).send({ error: "fee must be a positive number" });
+  }
+
+  if (sponsorBalance < fee) {
+    return reply.status(402).send({
+      error: "Insufficient sponsor balance",
+      transactionId,
+      requiredFee: fee,
+      currentBalance: sponsorBalance,
+    });
+  }
+
+  sponsorBalance -= fee;
+  totalFeesDeducted += fee;
+
+  return {
+    transactionId,
+    feeDeducted: fee,
+    remainingBalance: sponsorBalance,
+    status: "accepted",
+  };
+});
+
+// GET /sponsor-balance
+app.get("/sponsor-balance", async () => {
+  return {
+    balance: sponsorBalance,
+    initialBalance: INITIAL_BALANCE,
+    totalFeesDeducted,
+  };
+});
+
+// Reset function for testing
+export function __resetSponsorForTest(): void {
+  sponsorBalance = INITIAL_BALANCE;
+  totalFeesDeducted = 0;
+}
+
+// Start server if run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number(process.env.PORT) || 3003;
+  await app.listen({ port, host: "0.0.0.0" });
+  console.log(`Fee sponsorship suite running on port ${port}`);
+}
+
+export { app };

--- a/contrib/routes/fee-sponsorship-suite/package.json
+++ b/contrib/routes/fee-sponsorship-suite/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fee-sponsorship-suite",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test.ts"
+  },
+  "dependencies": {
+    "fastify": "^5.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/contrib/routes/fee-sponsorship-suite/test.ts
+++ b/contrib/routes/fee-sponsorship-suite/test.ts
@@ -1,0 +1,151 @@
+import { app, __resetSponsorForTest } from "./index";
+
+async function testFeeSponsorship(): Promise<void> {
+  console.log("Testing fee sponsorship...\n");
+
+  __resetSponsorForTest();
+
+  // Start server in background
+  const port = 3003;
+  await app.listen({ port, host: "127.0.0.1" });
+
+  try {
+    // Check initial balance
+    console.log("Initial sponsor balance:");
+    const balanceResponse1 = await fetch(`http://127.0.0.1:${port}/sponsor-balance`);
+    const balance1 = (await balanceResponse1.json()) as {
+      balance: number;
+      initialBalance: number;
+      totalFeesDeducted: number;
+    };
+    console.log(`  Balance: ${balance1.balance}`);
+    console.log(`  Initial: ${balance1.initialBalance}`);
+    console.log(`  Total Fees Deducted: ${balance1.totalFeesDeducted}\n`);
+
+    // Submit first transaction
+    console.log("Submitting transaction 1 (fee: 200):");
+    const submit1 = await fetch(`http://127.0.0.1:${port}/submit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ transactionId: "tx1", fee: 200 }),
+    });
+    const result1 = (await submit1.json()) as {
+      transactionId: string;
+      feeDeducted: number;
+      remainingBalance: number;
+      status: string;
+    };
+    console.log(`  Status: ${result1.status}`);
+    console.log(`  Fee Deducted: ${result1.feeDeducted}`);
+    console.log(`  Remaining Balance: ${result1.remainingBalance}\n`);
+
+    if (result1.status !== "accepted") {
+      console.log("✗ Test failed: First submission should be accepted");
+      return;
+    }
+
+    // Submit second transaction
+    console.log("Submitting transaction 2 (fee: 300):");
+    const submit2 = await fetch(`http://127.0.0.1:${port}/submit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ transactionId: "tx2", fee: 300 }),
+    });
+    const result2 = (await submit2.json()) as {
+      transactionId: string;
+      feeDeducted: number;
+      remainingBalance: number;
+      status: string;
+    };
+    console.log(`  Status: ${result2.status}`);
+    console.log(`  Fee Deducted: ${result2.feeDeducted}`);
+    console.log(`  Remaining Balance: ${result2.remainingBalance}\n`);
+
+    if (result2.status !== "accepted") {
+      console.log("✗ Test failed: Second submission should be accepted");
+      return;
+    }
+
+    // Submit third transaction
+    console.log("Submitting transaction 3 (fee: 400):");
+    const submit3 = await fetch(`http://127.0.0.1:${port}/submit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ transactionId: "tx3", fee: 400 }),
+    });
+    const result3 = (await submit3.json()) as {
+      transactionId: string;
+      feeDeducted: number;
+      remainingBalance: number;
+      status: string;
+    };
+    console.log(`  Status: ${result3.status}`);
+    console.log(`  Fee Deducted: ${result3.feeDeducted}`);
+    console.log(`  Remaining Balance: ${result3.remainingBalance}\n`);
+
+    if (result3.status !== "accepted") {
+      console.log("✗ Test failed: Third submission should be accepted");
+      return;
+    }
+
+    // Check balance after successful submissions
+    console.log("Balance after 3 successful submissions:");
+    const balanceResponse2 = await fetch(`http://127.0.0.1:${port}/sponsor-balance`);
+    const balance2 = (await balanceResponse2.json()) as {
+      balance: number;
+      initialBalance: number;
+      totalFeesDeducted: number;
+    };
+    console.log(`  Balance: ${balance2.balance}`);
+    console.log(`  Total Fees Deducted: ${balance2.totalFeesDeducted}\n`);
+
+    if (balance2.balance !== 100) {
+      console.log("✗ Test failed: Expected balance of 100 after 900 in fees");
+      return;
+    }
+
+    // Attempt submission that should fail due to insufficient balance
+    console.log("Submitting transaction 4 (fee: 200) - should fail:");
+    const submit4 = await fetch(`http://127.0.0.1:${port}/submit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ transactionId: "tx4", fee: 200 }),
+    });
+    const result4 = (await submit4.json()) as {
+      error: string;
+      transactionId: string;
+      requiredFee: number;
+      currentBalance: number;
+    };
+    console.log(`  Error: ${result4.error}`);
+    console.log(`  Required Fee: ${result4.requiredFee}`);
+    console.log(`  Current Balance: ${result4.currentBalance}\n`);
+
+    if (!result4.error || result4.error !== "Insufficient sponsor balance") {
+      console.log("✗ Test failed: Fourth submission should be rejected");
+      return;
+    }
+
+    // Verify balance hasn't changed after failed submission
+    console.log("Balance after failed submission:");
+    const balanceResponse3 = await fetch(`http://127.0.0.1:${port}/sponsor-balance`);
+    const balance3 = (await balanceResponse3.json()) as {
+      balance: number;
+      initialBalance: number;
+      totalFeesDeducted: number;
+    };
+    console.log(`  Balance: ${balance3.balance}`);
+    console.log(`  Total Fees Deducted: ${balance3.totalFeesDeducted}\n`);
+
+    if (balance3.balance !== 100) {
+      console.log("✗ Test failed: Balance should not change after failed submission");
+      return;
+    }
+
+    console.log("✓ All tests passed!");
+  } finally {
+    await app.close();
+  }
+}
+
+testFeeSponsorship().catch(console.error);

--- a/contrib/routes/fee-sponsorship-suite/tsconfig.json
+++ b/contrib/routes/fee-sponsorship-suite/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/contrib/routes/verification-cache-suite/README.md
+++ b/contrib/routes/verification-cache-suite/README.md
@@ -1,0 +1,45 @@
+# Verification Cache Suite
+
+A self-contained route handler simulating a contract verification registry cache lookup.
+
+## Endpoints
+
+### GET /lookup?id=<contractId>
+
+Looks up a contract verification result, caching it after the first lookup and serving subsequent lookups from cache with a hit flag.
+
+**Query Parameters:**
+- `id`: Contract identifier
+
+**Response:**
+```json
+{
+  "id": "0x123...",
+  "verified": true,
+  "sourceCode": "...",
+  "cacheHit": false
+}
+```
+
+On the first lookup, `cacheHit` is `false`. On subsequent lookups for the same id, `cacheHit` is `true`.
+
+### GET /cache-stats
+
+Reports total lookups and total cache hits.
+
+**Response:**
+```json
+{
+  "totalLookups": 10,
+  "totalCacheHits": 7,
+  "hitRate": 0.7
+}
+```
+
+## Running the Test
+
+```bash
+node test.ts
+```
+
+This test demonstrates a first miss, a second hit, and the resulting cache stats.

--- a/contrib/routes/verification-cache-suite/index.ts
+++ b/contrib/routes/verification-cache-suite/index.ts
@@ -1,0 +1,77 @@
+import Fastify, { FastifyRequest, FastifyReply } from "fastify";
+
+const app = Fastify({ logger: false });
+
+// In-memory cache and stats
+const cache = new Map<string, VerificationResult>();
+let totalLookups = 0;
+let totalCacheHits = 0;
+
+interface VerificationResult {
+  id: string;
+  verified: boolean;
+  sourceCode: string;
+  compilerVersion: string;
+}
+
+// GET /lookup
+app.get("/lookup", async (request: FastifyRequest, reply: FastifyReply) => {
+  const { id } = request.query as { id: string };
+
+  if (!id) {
+    return reply.status(400).send({ error: "id query parameter is required" });
+  }
+
+  totalLookups++;
+
+  const cached = cache.get(id);
+  if (cached) {
+    totalCacheHits++;
+    return {
+      ...cached,
+      cacheHit: true,
+    };
+  }
+
+  // Simulate verification lookup (mock data)
+  const result: VerificationResult = {
+    id,
+    verified: true,
+    sourceCode: `// Source code for ${id}\npragma solidity ^0.8.0;\ncontract Mock { }`,
+    compilerVersion: "0.8.20",
+  };
+
+  cache.set(id, result);
+
+  return {
+    ...result,
+    cacheHit: false,
+  };
+});
+
+// GET /cache-stats
+app.get("/cache-stats", async () => {
+  const hitRate = totalLookups > 0 ? totalCacheHits / totalLookups : 0;
+
+  return {
+    totalLookups,
+    totalCacheHits,
+    hitRate,
+  };
+});
+
+// Reset function for testing
+export function __resetCacheForTest(): void {
+  cache.clear();
+  totalLookups = 0;
+  totalCacheHits = 0;
+}
+
+// Start server if run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number(process.env.PORT) || 3002;
+  await app.listen({ port, host: "0.0.0.0" });
+  console.log(`Verification cache suite running on port ${port}`);
+}
+
+export { app };

--- a/contrib/routes/verification-cache-suite/package.json
+++ b/contrib/routes/verification-cache-suite/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "verification-cache-suite",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test.ts"
+  },
+  "dependencies": {
+    "fastify": "^5.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/contrib/routes/verification-cache-suite/test.ts
+++ b/contrib/routes/verification-cache-suite/test.ts
@@ -1,0 +1,104 @@
+import { app, __resetCacheForTest } from "./index";
+
+async function testVerificationCache(): Promise<void> {
+  console.log("Testing verification cache...\n");
+
+  __resetCacheForTest();
+
+  // Start server in background
+  const port = 3002;
+  await app.listen({ port, host: "127.0.0.1" });
+
+  try {
+    const contractId = "0x1234567890abcdef";
+
+    // First lookup - should be a cache miss
+    console.log("First lookup (should be cache miss):");
+    const response1 = await fetch(`http://127.0.0.1:${port}/lookup?id=${contractId}`);
+    const data1 = (await response1.json()) as {
+      id: string;
+      verified: boolean;
+      sourceCode: string;
+      cacheHit: boolean;
+    };
+    console.log(`  ID: ${data1.id}`);
+    console.log(`  Verified: ${data1.verified}`);
+    console.log(`  Cache Hit: ${data1.cacheHit}`);
+
+    if (data1.cacheHit !== false) {
+      console.log("✗ Test failed: First lookup should have cacheHit=false");
+      return;
+    }
+    console.log("✓ First lookup correctly reports cache miss\n");
+
+    // Second lookup - should be a cache hit
+    console.log("Second lookup (should be cache hit):");
+    const response2 = await fetch(`http://127.0.0.1:${port}/lookup?id=${contractId}`);
+    const data2 = (await response2.json()) as {
+      id: string;
+      verified: boolean;
+      sourceCode: string;
+      cacheHit: boolean;
+    };
+    console.log(`  ID: ${data2.id}`);
+    console.log(`  Verified: ${data2.verified}`);
+    console.log(`  Cache Hit: ${data2.cacheHit}`);
+
+    if (data2.cacheHit !== true) {
+      console.log("✗ Test failed: Second lookup should have cacheHit=true");
+      return;
+    }
+    console.log("✓ Second lookup correctly reports cache hit\n");
+
+    // Third lookup - another cache hit
+    console.log("Third lookup (should be cache hit):");
+    const response3 = await fetch(`http://127.0.0.1:${port}/lookup?id=${contractId}`);
+    const data3 = (await response3.json()) as {
+      id: string;
+      verified: boolean;
+      sourceCode: string;
+      cacheHit: boolean;
+    };
+    console.log(`  ID: ${data3.id}`);
+    console.log(`  Verified: ${data3.verified}`);
+    console.log(`  Cache Hit: ${data3.cacheHit}`);
+
+    if (data3.cacheHit !== true) {
+      console.log("✗ Test failed: Third lookup should have cacheHit=true");
+      return;
+    }
+    console.log("✓ Third lookup correctly reports cache hit\n");
+
+    // Check cache stats
+    console.log("Cache stats:");
+    const statsResponse = await fetch(`http://127.0.0.1:${port}/cache-stats`);
+    const stats = (await statsResponse.json()) as {
+      totalLookups: number;
+      totalCacheHits: number;
+      hitRate: number;
+    };
+    console.log(`  Total Lookups: ${stats.totalLookups}`);
+    console.log(`  Total Cache Hits: ${stats.totalCacheHits}`);
+    console.log(`  Hit Rate: ${stats.hitRate.toFixed(2)}`);
+
+    if (stats.totalLookups !== 3) {
+      console.log("✗ Test failed: Expected 3 total lookups");
+      return;
+    }
+    if (stats.totalCacheHits !== 2) {
+      console.log("✗ Test failed: Expected 2 total cache hits");
+      return;
+    }
+    if (Math.abs(stats.hitRate - 2/3) > 0.01) {
+      console.log("✗ Test failed: Hit rate should be 0.67");
+      return;
+    }
+    console.log("✓ Cache stats are correct\n");
+
+    console.log("✓ All tests passed!");
+  } finally {
+    await app.close();
+  }
+}
+
+testVerificationCache().catch(console.error);

--- a/contrib/routes/verification-cache-suite/tsconfig.json
+++ b/contrib/routes/verification-cache-suite/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
…sorship

- Issue #103: Batch queue suite with enqueue-batch and batch-status endpoints
  - Processes mock transactions in order with configurable retry logic
  - Reports per-item state (pending, retrying, succeeded, failed)
  - Includes test demonstrating batch that fully succeeds after retries

- Issue #110: Verification cache suite with lookup and cache-stats endpoints
  - Caches contract verification results after first lookup
  - Reports cache hit/miss status and cache statistics
  - Includes test covering first miss, second hit, and resulting stats

- Issue #106: Fee sponsorship suite with submit and sponsor-balance endpoints
  - Tracks sponsor account fee budget across submissions
  - Rejects submissions when sponsor balance would go negative
  - Includes test covering successful submissions and budget exhaustion

All suites are self-contained under contrib/routes/ with README, implementation, tests, and configuration files.

Closes #103, #110, #106