### PR TITLE
Funding-path re-audit fixes: scope V2 credentials (RA-1), spend-budget atomicity (RA-2), persistence fail-closed (RA-4), fixture-defect pattern (RA-9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
         run: pnpm test
         env:
           TEST_DATABASE_URL: postgres://vela:vela@localhost:5433/vela
+          # RA-2: the DB-backed integration tests (incl. the spend-budget
+          # concurrency guarantee) must ACTUALLY RUN in CI. With this set, the
+          # integration suites FAIL rather than silently skip if the Postgres
+          # service ever goes missing, so the atomicity guarantee cannot quietly
+          # stop being exercised.
+          CI_REQUIRE_DB: "1"
 
       - name: Build
         run: pnpm build

--- a/apps/docs/overview.md
+++ b/apps/docs/overview.md
@@ -18,7 +18,7 @@ key-pair account.
 | **Smart account**               | Web            | Each wallet is a passkey-controlled Soroban smart-wallet contract (a C-address).                   |
 | **Send & track payments**       | Web            | Build → review → passkey-sign → submit → track to finality, with fees sponsored.                   |
 | **Account policies**            | Web            | Author policies from templates (spending limit, multisig, allowlist), review, and deploy on-chain. |
-| **Configurable spending limit** | Web + contract | Deploy a per-account Soroban policy that enforces a user-chosen fixed-window (tumbling) spend cap.          |
+| **Configurable spending limit** | Web + contract | Deploy a per-account Soroban policy that enforces a user-chosen fixed-window (tumbling) spend cap. |
 | **Account cleanup & merge**     | Web            | A guided planner that inspects a classic account, plans cleanup, and merges it — never one-click.  |
 | **dApp connection & signing**   | Extension      | Pair the extension as a device signer; approve dApp connections and transactions per-origin.       |
 | **Trust signals in signing**    | Extension      | The signing prompt decodes the transaction and flags value transfers subject to account policies.  |

--- a/apps/extension/lib/tx-signer.test.ts
+++ b/apps/extension/lib/tx-signer.test.ts
@@ -40,18 +40,42 @@ vi.mock("passkey-kit", () => {
   return { PasskeyKit };
 });
 
+// The credential shape to build. passkey-kit@0.14 signs V2 (upgrades V1 in place
+// at auth-payload.js:67), so V2 is the REAL shape reaching the signer; the filter
+// must match all address-bound variants (RA-1), not just the V1 string.
+type CredKind = "v1" | "v2" | "delegates";
+
+function walletAddressCreds(): xdr.SorobanAddressCredentials {
+  return new xdr.SorobanAddressCredentials({
+    address: Address.fromString(WALLET).toScAddress(),
+    nonce: xdr.Int64.fromString("0"),
+    signatureExpirationLedger: 0,
+    signature: xdr.ScVal.scvVoid(),
+  });
+}
+
+function walletCredentials(kind: CredKind): xdr.SorobanCredentials {
+  switch (kind) {
+    case "v1":
+      return xdr.SorobanCredentials.sorobanCredentialsAddress(walletAddressCreds());
+    case "v2":
+      return xdr.SorobanCredentials.sorobanCredentialsAddressV2(walletAddressCreds());
+    case "delegates":
+      return xdr.SorobanCredentials.sorobanCredentialsAddressWithDelegates(
+        new xdr.SorobanAddressCredentialsWithDelegates({
+          addressCredentials: walletAddressCreds(),
+          delegates: [],
+        }),
+      );
+  }
+}
+
 // Build a single-op invokeHostFunction whose one auth entry is address-bound to
-// WALLET, so the signer's filter matches it.
-function buildTxWithWalletAuth(): string {
+// WALLET, so the signer's filter matches it. Defaults to V2 — the real shape the
+// kit produces — so the test exercises production traffic, not a legacy V1 shape.
+function buildTxWithWalletAuth(kind: CredKind = "v2"): string {
   const authEntry = new xdr.SorobanAuthorizationEntry({
-    credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
-      new xdr.SorobanAddressCredentials({
-        address: Address.fromString(WALLET).toScAddress(),
-        nonce: xdr.Int64.fromString("0"),
-        signatureExpirationLedger: 0,
-        signature: xdr.ScVal.scvVoid(),
-      }),
-    ),
+    credentials: walletCredentials(kind),
     rootInvocation: new xdr.SorobanAuthorizedInvocation({
       function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
         new xdr.InvokeContractArgs({
@@ -152,4 +176,23 @@ describe("signTransactionXdr (L4 expiration binding)", () => {
     // Nothing was signed.
     expect(signAuthEntryCalls).toHaveLength(0);
   });
+
+  // RA-1: the wallet's real auth entries are V2 (or with-delegates), not V1. The
+  // signer must sign each address-bound variant bound to the paired wallet — a
+  // V1-only filter would skip them and throw "no auth entries for the wallet".
+  it.each(["v1", "v2", "delegates"] as const)(
+    "signs the wallet's %s address-bound auth entry",
+    async (kind) => {
+      const { signTransactionXdr } = await import("./tx-signer");
+      const signedXdr = await signTransactionXdr({
+        xdr: buildTxWithWalletAuth(kind),
+        wallet,
+        deviceKeyPair,
+        deviceRawPublicKey,
+        getTrustedLatestLedger: async () => 1_000_000,
+      });
+      expect(typeof signedXdr).toBe("string");
+      expect(signAuthEntryCalls).toHaveLength(1);
+    },
+  );
 });

--- a/apps/extension/lib/tx-signer.ts
+++ b/apps/extension/lib/tx-signer.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "buffer";
+import type { xdr } from "@stellar/stellar-sdk";
 import type { Signer } from "passkey-kit";
 import { signWithDeviceKey } from "./device-key";
 import {
@@ -60,7 +61,7 @@ export async function signTransactionXdr(input: {
   const { wallet } = input;
   const networkPassphrase = NETWORK_PASSPHRASES[wallet.network];
 
-  const [{ PasskeyKit }, { Address, TransactionBuilder }] = await Promise.all([
+  const [{ PasskeyKit }, { Address, TransactionBuilder, xdr }] = await Promise.all([
     import("passkey-kit"),
     import("@stellar/stellar-sdk"),
   ]);
@@ -91,6 +92,25 @@ export async function signTransactionXdr(input: {
     throw new Error("Fee-bump transactions cannot be signed by the extension");
   }
 
+  // The SorobanAddressCredentials across every address-bound variant, or
+  // undefined for source-account. passkey-kit@0.14 signs V2 (upgrades V1 in
+  // place, auth-payload.js:67), so a V1-only match (RA-1) skipped the wallet's
+  // real entries and signed nothing. All three arms wrap the same struct.
+  const addrCreds = (
+    creds: ReturnType<xdr.SorobanAuthorizationEntry["credentials"]>,
+  ): xdr.SorobanAddressCredentials | undefined => {
+    switch (creds.switch().name) {
+      case "sorobanCredentialsAddress":
+        return creds.address();
+      case "sorobanCredentialsAddressV2":
+        return creds.addressV2();
+      case "sorobanCredentialsAddressWithDelegates":
+        return creds.addressWithDelegates().addressCredentials();
+      default:
+        return undefined; // sorobanCredentialsSourceAccount — not a wallet subject
+    }
+  };
+
   const signer = createDeviceSigner(input.deviceKeyPair, input.deviceRawPublicKey);
   let signedAny = false;
 
@@ -98,11 +118,9 @@ export async function signTransactionXdr(input: {
     if (operation.type !== "invokeHostFunction" || !operation.auth) continue;
     for (let i = 0; i < operation.auth.length; i++) {
       const entry = operation.auth[i]!;
-      if (entry.credentials().switch().name !== "sorobanCredentialsAddress") continue;
-      const entryAddress = Address.fromScAddress(
-        entry.credentials().address().address(),
-      ).toString();
-      if (entryAddress !== wallet.address) continue;
+      const creds = addrCreds(entry.credentials());
+      if (!creds) continue;
+      if (Address.fromScAddress(creds.address()).toString() !== wallet.address) continue;
       // Explicit expiration ⇒ the kit does NOT call getLatestLedger on the
       // caller's rpcUrl (L4).
       operation.auth[i] = await kit.signAuthEntry(entry, signer, { expiration });

--- a/apps/web/app/cleanup/page.test.tsx
+++ b/apps/web/app/cleanup/page.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Cleanup from "./page";
@@ -58,14 +59,15 @@ const mergeStep = {
   hash: "b".repeat(64),
 };
 
-async function inspectWith(plan: typeof blockedPlan) {
+async function inspectWith(plan: typeof blockedPlan, { strict = false } = {}) {
   planMock.mockResolvedValue({ plan });
   window.localStorage.setItem("vellar.session", JSON.stringify(SESSION));
-  render(
+  const tree = (
     <WalletProvider>
       <Cleanup />
-    </WalletProvider>,
+    </WalletProvider>
   );
+  render(strict ? <StrictMode>{tree}</StrictMode> : tree);
   // AppShell restores the session asynchronously; wait for the form.
   fireEvent.change(await screen.findByLabelText(/old account/i), { target: { value: G1 } });
   fireEvent.change(screen.getByLabelText(/destination/i), { target: { value: G2 } });
@@ -103,6 +105,26 @@ describe("Cleanup wizard", () => {
     watchMock.mockResolvedValue(true); // every watched tx confirms immediately
 
     await inspectWith(blockedPlan);
+    fireEvent.click(screen.getByRole("button", { name: /start cleanup/i }));
+
+    await waitFor(() => expect(mergeMock).toHaveBeenCalledWith(G1, G2));
+    expect(await screen.findByText(/account closed/i)).toBeDefined();
+  });
+
+  // Regression: the unmount cleanup latches cancelledRef, and StrictMode mounts
+  // → unmounts → remounts. If the remount doesn't un-latch it, every watch()
+  // sees cancelled=true, returns before advancing, and the wizard stalls on the
+  // step card forever. Unlike the other cases this mock HONOURS the cancelled
+  // callback, exactly as the real watchTransaction does — that is what makes the
+  // latch observable here.
+  it("auto-advances to done after a StrictMode remount", async () => {
+    executeMock.mockResolvedValue({ steps: [cleanupStep], plan: blockedPlan });
+    mergeMock.mockResolvedValue({ step: mergeStep });
+    watchMock.mockImplementation(
+      async (_hash: string, options: { cancelled?: () => boolean }) => !options.cancelled?.(), // cancelled → never seen, mirroring the real watcher
+    );
+
+    await inspectWith(blockedPlan, { strict: true });
     fireEvent.click(screen.getByRole("button", { name: /start cleanup/i }));
 
     await waitFor(() => expect(mergeMock).toHaveBeenCalledWith(G1, G2));

--- a/apps/web/app/cleanup/page.tsx
+++ b/apps/web/app/cleanup/page.tsx
@@ -33,12 +33,16 @@ export default function Cleanup() {
   const [error, setError] = useState<string | null>(null);
   const cancelledRef = useRef(false);
 
-  useEffect(
-    () => () => {
+  // The unmount cleanup LATCHES cancelledRef, so every (re)mount must un-latch
+  // it. React StrictMode mounts → unmounts → remounts, so without the reset the
+  // remounted wizard is born cancelled: watch() bails out on its first check and
+  // the flow stalls on "Waiting for this transaction…" forever.
+  useEffect(() => {
+    cancelledRef.current = false;
+    return () => {
       cancelledRef.current = true;
-    },
-    [],
-  );
+    };
+  }, []);
 
   async function run(action: () => Promise<void>) {
     setBusy(true);

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -650,11 +650,28 @@ concurrency test that would catch it (`pg-budget.test.ts:112-127`) is `describe.
 and does not run in ordinary CI, so the atomicity guarantee is **unverified** and would fail against
 real Postgres.
 
-> **Status (RA-2): OPEN — hard mainnet blocker.** Serialize the check+insert (recommend a unique
-> per-`(line,network,window)` counter row updated with `… ON CONFLICT DO UPDATE … WHERE new_total <=
-max`, or `pg_advisory_xact_lock(line,network)` wrapping check+insert in one tx, or SERIALIZABLE +
-> retry). Then **un-skip** the concurrency test and stand up Postgres in CI so the guarantee is
-> actually exercised — a guarantee that only holds when a local env var is set is not a guarantee.
+> **Status (RA-2): CLOSED.** `pg-budget.ts` now runs the check+insert inside a **transaction**
+> guarded by `pg_advisory_xact_lock(hashtext('<line>:<network>'))` **taken before the aggregate
+> read**, so same-`(line,network)` callers serialize (lock auto-released at commit) and different
+> keys never block each other. Chosen over a unique counter row (would force a tumbling window,
+> re-introducing M3's boundary leak in our own ledger) and over SERIALIZABLE+retry (retry loops +
+> aborts on the funding hot path).
+>
+> **A second defect surfaced and was fixed:** the existing concurrency test was **decorative**. It
+> both (a) skipped locally behind `skipIf(!TEST_DATABASE_URL)` and (b) fired `Promise.all` over a
+> single drizzle pool, which serializes on the pool and never actually raced — so it passed even
+> against the broken single-statement code. Proven with real parallel connections (12 own-connection
+> consumers, ceiling 1): the old single statement inserted **10 rows** (overshoot); the advisory-lock
+> version inserts exactly **1**. The test is rewritten to use N independent single-connection pools
+> so it truly races — it now **fails against the pre-fix code and passes with the lock** (verified
+> against Postgres 16 via `infra/docker`). Unit tests (`budget.test.ts`, no DB) additionally pin that
+> the lock statement is issued **first**, inside a transaction, keyed on `hashtext(line:network)`.
+>
+> **CI now enforces the guarantee runs:** the workflow already provisions Postgres and passes
+> `TEST_DATABASE_URL`; it also sets `CI_REQUIRE_DB=1`, under which the DB integration suites **fail
+> rather than silently skip** if the DB ever goes missing — so "the guarantee only holds when a local
+> env var is set" can no longer be true in CI. The false "ONE atomic statement" claim in `budget.ts`
+> is corrected.
 
 ### RA-3 — M1 (session enumeration + revocation) is still OPEN; the doc's own status is stale 🟡 Medium `[my code]`
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -771,12 +771,24 @@ XDR-decoding assertion added in remediation for the same pattern (does the fixtu
 Three instances of the pattern (scope.test.ts + L1 + FIX-1's absence). Only FIX 2 builds its fixture
 the way the kit actually produces the value.
 
-> **Status (RA-9): OPEN — fixed alongside RA-1.** Rule going forward: any test that asserts on a
-> decoded passkey-kit XDR shape must construct its fixture from the **real kit signing/deploy path**
-> (or through the passkey-kit-sdk `Signer` spec), so a kit shape-change breaks the test rather than
-> hiding behind it. This pass: build RA-1's scope/tx-signer fixtures kit-derived; add a
-> `needsSponsorRebuild` test feeding real V2 + `sourceAccount` entries; encode L1's `buildAddPolicyXdr`
-> through the `Signer` spec's 5-element Policy tuple.
+> **Status (RA-9): CLOSED.** All three instances of the pattern closed:
+>
+> - **RA-1 (scope + tx-signer):** fixtures default to **V2** and parametrize v1/v2/delegates — a
+>   V1-only regression fails (see RA-1).
+> - **FIX-1 `needsSponsorRebuild`:** now has a test (`sponsor.test.ts`) — the predicate is exercised
+>   with real V2/V1/delegates address credentials (→ route to sponsor), source-account and mixed
+>   address+source (→ false), plus multi-op / empty-auth / non-invoke / unparseable guards. A
+>   regression to a positive V1-only check now fails.
+> - **L1 `buildAddPolicyXdr`:** rebuilt to the kit's **real 5-element** `Signer::Policy` tuple
+>   `[Symbol('Policy'), Address, SignerExpiration::None, SignerLimits::None, SignerStorage::Persistent]`
+>   (matching `passkey-kit` `buildPolicySigner` + the `passkey-kit-sdk` `Signer` UDT), replacing the
+>   hand-built 3-element vec. A new assertion pins the tuple **arity** so a kit encoding drift is
+>   visible; the decode path still finds the policy address in the realistic shape.
+>
+> `passkey-kit-sdk` is only a transitive dep here, so the fixtures reproduce the kit's on-the-wire
+> shape element-for-element rather than importing the `Spec` directly; each is tied to the kit source
+> lines it mirrors. Rule going forward: any test asserting on a decoded passkey-kit XDR shape must be
+> built from (or pinned against) the real kit shape, never hand-fit to the parser.
 
 ### Re-audit bottom line
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -750,6 +750,29 @@ dashboard settings. Classify each as closed-by-doc / deferred / config-only, nev
 
 > **Status (RA-8): informational.** No code change; ensures the closure ledger stays honest.
 
+### RA-9 — Fixture-defect pattern: XDR-decoding tests built to match the code, not the kit ℹ️ Info → drives RA-1 `[my code]`
+
+RA-1 is a **test-fixture failure as much as a code failure** — `scope.test.ts` built **V1**
+credential fixtures, so the suite validated the V1-only bug instead of catching it. Auditing every
+XDR-decoding assertion added in remediation for the same pattern (does the fixture match what
+`passkey-kit@0.14.0` really produces, or what the implementation happens to parse?):
+
+| Remediation | Fixture site | Verdict | Kit-shape change that slips past |
+| --- | --- | --- | --- |
+| **FIX 2** derivation gate | `derivation.test.ts:17` (pinned deployer, verified against the kit) + live `deriveWalletContractId` | **KIT-DERIVED (robust)** | none kit-shaped; a real seed/deployer drift breaks the pinned-pubkey assertion loudly |
+| **FIX 1** `needsSponsorRebuild` | **no fixture at all** — `sponsor.test.ts` covers only `enforceFeeCap` / `consumeSponsorBudget` | **UNTESTED** | any change to the credential-type filter — nothing asserts on V2, the `sourceAccount` exclusion, or the one-op/invokeHostFunction/has-auth guards. (The filter is a _negative_ `!== sorobanCredentialsSourceAccount` check, so it accepts V2 correctly _today_ — safe by luck, not by test.) |
+| **L1** attach-tx decode | `verify-attach.test.ts:34-38` `buildAddPolicyXdr` | **CODE-SHAPED (same defect class as `scope.test.ts`)** | the helper builds a **3-element** `[Symbol('Policy'), Address, Void]` vec, but the kit's real `Signer::Policy` is a **5-element** tuple `[Symbol('Policy'), Address, Vec[Void], Vec[Void], Vec[Symbol('Persistent')]]`. It passes only because `collectAddresses` scans for the address _anywhere_ in the args and the function name is correct. A kit change to where the address is embedded breaks production while the test stays green. |
+
+Three instances of the pattern (scope.test.ts + L1 + FIX-1's absence). Only FIX 2 builds its fixture
+the way the kit actually produces the value.
+
+> **Status (RA-9): OPEN — fixed alongside RA-1.** Rule going forward: any test that asserts on a
+> decoded passkey-kit XDR shape must construct its fixture from the **real kit signing/deploy path**
+> (or through the passkey-kit-sdk `Signer` spec), so a kit shape-change breaks the test rather than
+> hiding behind it. This pass: build RA-1's scope/tx-signer fixtures kit-derived; add a
+> `needsSponsorRebuild` test feeding real V2 + `sourceAccount` entries; encode L1's `buildAddPolicyXdr`
+> through the `Signer` spec's 5-element Policy tuple.
+
 ### Re-audit bottom line
 
 - **Closed by passing test (verified by reading assertions):** C1/H1/V2, V1 derivation gate, H2, H3,

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -581,3 +581,183 @@ are testnet-only.
 **Dropped from blocking:** M4 (availability-only per V3; gate `verified_only` out of the mainnet
 builder + add detach UI when that path is enabled).
 **Still gated on dashboard (V6):** final severity of L2 (port exposure) and M9 (autoDeploy).
+
+---
+
+## Re-audit of the patched tree (RA) — findings introduced or missed by the remediation
+
+Method: after #228 + #230 merged, the patched tree was re-audited **read-only**, treating all
+remediation code as untrusted new surface. Nine parallel hunts (SSRF guard, derivation gate,
+route-scoping, spend budget, escape hatches, FIX-12 paths, policy-attach invariant, closure-by-test,
+standard sweep); every candidate then adversarially re-verified against the actually-installed code
+(the verifier defaulted to _refuting_). Nine findings survived verification. The two Highs sit on the
+**funding path** — the exact controls the mainnet gate depends on.
+
+### RA-1 — Route scope gate matches only the **V1** credential string; passkey-kit 0.14 signs **V2** 🔴 High `[my code]`
+
+`services/wallet-service/src/scope.ts:43`; same defect in `apps/extension/lib/tx-signer.ts:101`.
+
+`extractAddressAuthSubjects` filters auth entries with `entry.credentials().switch().name !==
+"sorobanCredentialsAddress"` — an exact match on **V1** only. But the production signer
+`passkey-kit@0.14.0` **never emits V1 for a signed wallet op**: `kit/tx-ops.js:45` calls
+`toAddressBoundCredentials`, which `kit/auth-payload.js:65-67` upgrades every entry **in place** to
+`sorobanCredentialsAddressV2`, and `tx-ops.js:46-48` throws unless the payload is V2/with-delegates
+("there is deliberately NO V1 signing path"). `@stellar/stellar-sdk@16.0.1` `curr_generated.js:1726-1731`
+confirms the enum has V1(1)/V2(2)/with-delegates(3). Two failures:
+
+- **(b) fail-closed BREAK (live on testnet today):** a normal single-op V2-signed wallet tx yields
+  `subjects === []` → `assertScopedToKnownWallets` throws `ScopeError('no_wallet_subject')` →
+  **HTTP 403 on every legitimate `/wallet/submit`** in the production posture (the gate is live
+  whenever `deps.networkPassphrase` is set — `server.ts:203-207`, wired from server config at
+  `index.ts:100-111`). Every post-deploy wallet operation is rejected the moment the gate is enabled.
+- **(a) scope BYPASS:** a mixed tx with one V1 entry bound to a known wallet + one V2 entry bound to
+  an attacker contract yields `subjects === [known]` (V2 skipped at line 43), passes the gate, and
+  `needsSponsorRebuild` routes it to the funded sponsor rebuild `{func, auth:[A,B]}` — the V2 leg
+  rides past the C1/H1/V2 scope control.
+
+The suite is green only because `scope.test.ts` builds solely V1 / source-account fixtures — the V2
+path is never exercised (see the fixture-defect note in RA notes). The identical V1-only filter in
+`tx-signer.ts:101` means the extension signer would skip the real V2 entries and sign nothing.
+
+> **Status (RA-1): OPEN — hard mainnet blocker AND live testnet break.** Fix must match
+> `sorobanCredentialsAddressV2` and `sorobanCredentialsAddressWithDelegates`, extract the address
+> from each variant, in **both** `scope.ts` and `tx-signer.ts`; add a mixed-V1+V2 bypass test; and
+> derive fixtures from passkey-kit's actual signing path so a future credential-shape change breaks
+> the test rather than hiding behind it.
+
+### RA-2 — Spend-budget conditional INSERT is not atomic under READ COMMITTED 🔴 High `[my code]`
+
+`packages/service-kit/src/pg-budget.ts:41`.
+
+`tryConsume` runs check-and-record as a single `WITH agg AS (SELECT SUM(count)/SUM(stroops) FROM
+spend_ledger WHERE line/network/at>windowStart) INSERT … SELECT … WHERE agg.sum + N <= max`
+statement. The aggregate CTE takes **no row locks** (no `FOR UPDATE`), the INSERT writes a fresh
+`randomUUID` row against only a **non-unique** `(line,network,at)` index, and `db/client.ts:19` is a
+bare `pg.Pool` with **no isolation override** (default READ COMMITTED; no SERIALIZABLE / `FOR UPDATE`
+/ advisory lock anywhere in the repo). N concurrent requests each snapshot the same committed sum,
+all pass the `WHERE`, all commit → the ceiling degrades from a hard cap to **ceiling + pool
+concurrency**.
+
+`budget.ts:2-4` documents this cap as the **sole** binding funding-path control (the gateway per-IP
+limit does not bind — no `trustProxy`). So the overshoot is a direct drain of real sponsor XLM past
+the FIX-3 ceiling: fire 8 concurrent `/wallet/submit` (or `/wallet/create` / `/policies/deploy` —
+all share `createPgSpendBudget`) against a maxCount=1 boundary → up to 8 sponsored txs land. The
+concurrency test that would catch it (`pg-budget.test.ts:112-127`) is `describe.skipIf(!TEST_DATABASE_URL)`
+and does not run in ordinary CI, so the atomicity guarantee is **unverified** and would fail against
+real Postgres.
+
+> **Status (RA-2): OPEN — hard mainnet blocker.** Serialize the check+insert (recommend a unique
+> per-`(line,network,window)` counter row updated with `… ON CONFLICT DO UPDATE … WHERE new_total <=
+> max`, or `pg_advisory_xact_lock(line,network)` wrapping check+insert in one tx, or SERIALIZABLE +
+> retry). Then **un-skip** the concurrency test and stand up Postgres in CI so the guarantee is
+> actually exercised — a guarantee that only holds when a local env var is set is not a guarantee.
+
+### RA-3 — M1 (session enumeration + revocation) is still OPEN; the doc's own status is stale 🟡 Medium `[my code]`
+
+`services/wallet-service/src/server.ts:254-274`.
+
+`GET /wallet/sessions` (`:254-261`) and `DELETE /wallet/session/:id` (`:263-274`) read only
+query/params and enforce **no** ownership or bearer credential. An unauthenticated attacker who
+learns a victim's public C-address (it is on-chain) can enumerate every active session id + metadata
+(`GET …?contractId=<victim>`), then `DELETE` each → log the victim out of all devices. M1 has **no**
+"Status: CLOSED" block and still sits on the pre-exposure checklist (Remediation order item 6), yet
+its Fix ("authorize read/revoke with the caller's own opaque session id as a bearer capability") was
+never implemented. Impact is bounded — sessions gate **no** on-chain authority (authorization is
+on-chain via `__check_auth`; web connected-state derives from SDK localStorage) — so this is device-
+management DoS + session-graph disclosure, **not** an authz bypass.
+
+> **Status (RA-3): OPEN.** "Open finding with doc text implying otherwise" is the worst of both.
+> Implement the bearer-capability ownership guard on both routes and add a 401/403 test for a
+> non-owning caller; keep the impact note accurate (no on-chain authority).
+
+### RA-4 — `ALLOW_INMEMORY` fail-closed boot guard is **inert** on the deploy targets 🟡 Medium `[my code]`
+
+`packages/service-kit/src/persistence.ts:29,41,56`.
+
+`isProduction` is a strict `nodeEnv === "production"` and gates both fail-closed branches. The
+deployed process (`@vellar/all-in-one`) starts via `tsx … src/index.ts` with **no `NODE_ENV`**, and
+**no committed config** (`render.yaml` envVars, `railway.json`, `.env.example`) sets it — confirmed
+by repo-wide grep; neither platform injects it by default. So at runtime `isProduction(undefined) ===
+false`: when `DATABASE_URL` is set but unreachable, the guard falls through to `allow-inmemory` and
+`/health` reports ok. This **silently undoes FIX 7 (M6) on the actual deploy target** — and
+`render.yaml:8` warns the free Postgres **expires at 30 days**, exactly the DB-gone failure mode
+where audit log, sessions, and the FIX-3 spend budgets would reset to volatile in-memory while
+health monitoring says healthy. Downgraded High→Medium only because both manifests are testnet-only.
+
+> **Status (RA-4): OPEN — fix in this pass.** Set `NODE_ENV=production` in the deploy config so the
+> FIX-7 guard is live, or key the guard off a signal actually present at runtime. This is worse than
+> a normal Medium because it re-opens a finding already marked closed.
+
+### RA-5 — Cleanup builder pays the full asset balance **before** cancelling offers (ignores selling liabilities) 🟡 Medium `[my code]`
+
+`services/lifecycle-service/src/builder.ts:59` (+ `horizon.ts` never parses `selling_liabilities`).
+
+`collectCleanupOps` emits every non-native payment at `amount = balance.balance` (the **full**
+trustline balance) and its trustline removal, and only **afterward** the offer cancels — so payments
+always precede cancels in the op list. For an account holding an asset it also has an open offer
+selling (100 USDC held, 40 USDC on offer), the payment of 100 hits the 40 locked as a selling
+liability → `op_underfunded` → whole tx `txFAILED`. Guided cleanup can never complete for a common
+real account state, and the wizard surfaces a raw `op_underfunded`. No fund loss (txs are unsigned)
+and the `/lifecycle/merge` preflight re-inspects live state (409 while blockers remain), so no
+irreversible merge on partial cleanup — a liveness/correctness bug, not a safety one. Untested.
+
+> **Status (RA-5): OPEN.** Cancel offers before payments (or subtract `selling_liabilities` from the
+> paid amount); parse `selling_liabilities` in `horizon.ts`; add a balance-plus-same-asset-offer test.
+
+### RA-6 — V3 detach invariant is pinned only at the pure helper; the attach/detach wiring is untested 🟡 Medium `[my code]`
+
+`apps/web/lib/connector-factory.ts:123`.
+
+V3's refutation of permanent fund lock holds **only** because the policy attaches as a standalone
+`SignerLimits(None)` signer, triggering the wallet's `is_sole_self_removal` exception on detach. That
+fund-lock-critical shape lives entirely in the pure helper `policyAttachArgs`; `policy-signer.test.ts`
+asserts only the helper in isolation, `policy.test.ts` drives detach through a `vi.fn` fake (never the
+real `kit.remove(SignerKey.Policy(...))`), and the L1 backend verifier deliberately does **not** check
+the `SignerLimits` shape. So a plausible future edit — making `verified_only` a co-signer inside
+another key's `SignerLimits` map, as the verified-recipient doc-comment contemplates — would ship
+**green** and re-introduce the V3 permanent-fund-lock (a reject-everything policy could then block its
+own removal). No live bypass today; a test-coverage gap on a fund-lock-critical invariant.
+
+> **Status (RA-6): OPEN.** Add an integration test that drives the real `connector-factory` attach
+> and asserts the emitted signer is standalone `SignerLimits(None)`, and a detach test through the
+> real `kit.remove` path — so the shape breaks a test if a refactor changes it.
+
+### RA-7 — `isBlockedAddress` misses hex-form IPv4-mapped + NAT64 IPv6 ℹ️ Info `[my code]`
+
+`services/worker-service/src/repo-url-guard.ts:64`.
+
+As a pure unit, `isBlockedAddress` returns `false` for `::ffff:7f00:1` (127.0.0.1), `::ffff:a9fe:a9fe`
+(169.254.169.254), and `64:ff9b::a9fe:a9fe` (NAT64) — the line-64 regex catches only the dotted
+`::ffff:d.d.d.d` form. **Downgraded to Info** (from a claimed Low): no reachable failure today —
+`new URL` keeps IPv6 literals bracketed, so `isIP` returns 0, the literal branch is skipped, and
+`dns.lookup` of the bracketed string throws ENOTFOUND (fail-closed); the only production resolver
+emits IPv4-mapped answers in the dotted form the regex does catch. Latent defense-in-depth: it
+defends only a hypothetical future refactor that strips brackets before the literal check.
+
+> **Status (RA-7): OPEN (latent).** Canonicalize IPv6 to bytes and range-check embedded IPv4-mapped
+> + NAT64 rather than string-prefix matching. Low urgency; no live path.
+
+### RA-8 — Audit hygiene: M3 / M4 / M5(deferral) / M8 / M9 are **not** code-fixed closures ℹ️ Info
+
+Reporting risk, not a runtime defect. A reviewer tallying "closed by passing test" must not count
+these: **M3** leak behavior is unchanged — the tests pin the _documented_ 2× tumbling-window property
+(`spending-limit/src/test.rs:276` passes ~2× across a boundary); **M4** is product-gated + the V3
+recovery path, no mainnet registry; **M5** is a boot-refusal guard only (`attestor-guard.ts`), **not**
+a threshold attestor — a single `ATTESTOR_SECRET_KEY` compromise still forges provenance the moment
+`ALLOW_SINGLE_KEY_ATTESTOR` is set; **M8** is a lockfile/override pin, no test; **M9** committed
+`autoDeploy:false` + the `pnpm audit` gate, but branch-protection / Railway toggles remain manual
+dashboard settings. Classify each as closed-by-doc / deferred / config-only, never closed-by-test.
+
+> **Status (RA-8): informational.** No code change; ensures the closure ledger stays honest.
+
+### Re-audit bottom line
+
+- **Closed by passing test (verified by reading assertions):** C1/H1/V2, V1 derivation gate, H2, H3,
+  M2, M6-readiness, M7, L1, L3, L4, L5, L6/L6b.
+- **Closed by doc/config/deferral (NOT code-fixed):** M3, M4, M5, M8, M9 (see RA-8).
+- **Open / partial:** RA-1, RA-2 (funding-path Highs), RA-3 (M1), RA-4, RA-5, RA-6, RA-7.
+- **Mainnet: NO-GO** until RA-1, RA-2, M1 are fixed+tested, plus the deferred prerequisites (M5
+  multisig attestor, V3 detach UI) and the two V6 dashboard facts (L2 port firewalling, M9
+  autoDeploy/branch-protection) are confirmed. Every verdict remains conditional on the **unaudited**
+  `vellar-sdk` / `passkey-kit` (passkey ceremony, session store, address derivation this repo
+  enforces against — and the V1→V2 credential upgrade that drives RA-1 lives in that unread kit).

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -619,11 +619,15 @@ The suite is green only because `scope.test.ts` builds solely V1 / source-accoun
 path is never exercised (see the fixture-defect note in RA notes). The identical V1-only filter in
 `tx-signer.ts:101` means the extension signer would skip the real V2 entries and sign nothing.
 
-> **Status (RA-1): OPEN — hard mainnet blocker AND live testnet break.** Fix must match
-> `sorobanCredentialsAddressV2` and `sorobanCredentialsAddressWithDelegates`, extract the address
-> from each variant, in **both** `scope.ts` and `tx-signer.ts`; add a mixed-V1+V2 bypass test; and
-> derive fixtures from passkey-kit's actual signing path so a future credential-shape change breaks
-> the test rather than hiding behind it.
+> **Status (RA-1): CLOSED.** `scope.ts` and `tx-signer.ts` now resolve the `SorobanAddressCredentials`
+> across **all three** address-bound arms (`sorobanCredentialsAddress` V1, `sorobanCredentialsAddressV2`,
+> `sorobanCredentialsAddressWithDelegates` → `.addressCredentials()`) and read `.address()` uniformly;
+> source-account is skipped. Fixtures are now kit-shaped: the test builders default to **V2** (the real
+> signer output — `toAddressBoundCredentials` upgrades V1 in place) and parametrize over v1/v2/delegates,
+> so a V1-only regression fails immediately. `scope.test.ts` adds the mixed V1(known)+V2(attacker) bypass
+> case at both the extract and `assertScopedToKnownWallets` levels (the attacker V2 leg is now surfaced
+> and rejected); `tx-signer.test.ts` asserts each variant is signed. 13 scope tests + 62 extension tests
+> pass; both packages typecheck.
 
 ### RA-2 — Spend-budget conditional INSERT is not atomic under READ COMMITTED 🔴 High `[my code]`
 
@@ -648,7 +652,7 @@ real Postgres.
 
 > **Status (RA-2): OPEN — hard mainnet blocker.** Serialize the check+insert (recommend a unique
 > per-`(line,network,window)` counter row updated with `… ON CONFLICT DO UPDATE … WHERE new_total <=
-> max`, or `pg_advisory_xact_lock(line,network)` wrapping check+insert in one tx, or SERIALIZABLE +
+max`, or `pg_advisory_xact_lock(line,network)` wrapping check+insert in one tx, or SERIALIZABLE +
 > retry). Then **un-skip** the concurrency test and stand up Postgres in CI so the guarantee is
 > actually exercised — a guarantee that only holds when a local env var is set is not a guarantee.
 
@@ -735,7 +739,8 @@ emits IPv4-mapped answers in the dotted form the regex does catch. Latent defens
 defends only a hypothetical future refactor that strips brackets before the literal check.
 
 > **Status (RA-7): OPEN (latent).** Canonicalize IPv6 to bytes and range-check embedded IPv4-mapped
-> + NAT64 rather than string-prefix matching. Low urgency; no live path.
+>
+> - NAT64 rather than string-prefix matching. Low urgency; no live path.
 
 ### RA-8 — Audit hygiene: M3 / M4 / M5(deferral) / M8 / M9 are **not** code-fixed closures ℹ️ Info
 
@@ -757,11 +762,11 @@ credential fixtures, so the suite validated the V1-only bug instead of catching 
 XDR-decoding assertion added in remediation for the same pattern (does the fixture match what
 `passkey-kit@0.14.0` really produces, or what the implementation happens to parse?):
 
-| Remediation | Fixture site | Verdict | Kit-shape change that slips past |
-| --- | --- | --- | --- |
-| **FIX 2** derivation gate | `derivation.test.ts:17` (pinned deployer, verified against the kit) + live `deriveWalletContractId` | **KIT-DERIVED (robust)** | none kit-shaped; a real seed/deployer drift breaks the pinned-pubkey assertion loudly |
-| **FIX 1** `needsSponsorRebuild` | **no fixture at all** — `sponsor.test.ts` covers only `enforceFeeCap` / `consumeSponsorBudget` | **UNTESTED** | any change to the credential-type filter — nothing asserts on V2, the `sourceAccount` exclusion, or the one-op/invokeHostFunction/has-auth guards. (The filter is a _negative_ `!== sorobanCredentialsSourceAccount` check, so it accepts V2 correctly _today_ — safe by luck, not by test.) |
-| **L1** attach-tx decode | `verify-attach.test.ts:34-38` `buildAddPolicyXdr` | **CODE-SHAPED (same defect class as `scope.test.ts`)** | the helper builds a **3-element** `[Symbol('Policy'), Address, Void]` vec, but the kit's real `Signer::Policy` is a **5-element** tuple `[Symbol('Policy'), Address, Vec[Void], Vec[Void], Vec[Symbol('Persistent')]]`. It passes only because `collectAddresses` scans for the address _anywhere_ in the args and the function name is correct. A kit change to where the address is embedded breaks production while the test stays green. |
+| Remediation                     | Fixture site                                                                                        | Verdict                                                | Kit-shape change that slips past                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FIX 2** derivation gate       | `derivation.test.ts:17` (pinned deployer, verified against the kit) + live `deriveWalletContractId` | **KIT-DERIVED (robust)**                               | none kit-shaped; a real seed/deployer drift breaks the pinned-pubkey assertion loudly                                                                                                                                                                                                                                                                                                                                                        |
+| **FIX 1** `needsSponsorRebuild` | **no fixture at all** — `sponsor.test.ts` covers only `enforceFeeCap` / `consumeSponsorBudget`      | **UNTESTED**                                           | any change to the credential-type filter — nothing asserts on V2, the `sourceAccount` exclusion, or the one-op/invokeHostFunction/has-auth guards. (The filter is a _negative_ `!== sorobanCredentialsSourceAccount` check, so it accepts V2 correctly _today_ — safe by luck, not by test.)                                                                                                                                                 |
+| **L1** attach-tx decode         | `verify-attach.test.ts:34-38` `buildAddPolicyXdr`                                                   | **CODE-SHAPED (same defect class as `scope.test.ts`)** | the helper builds a **3-element** `[Symbol('Policy'), Address, Void]` vec, but the kit's real `Signer::Policy` is a **5-element** tuple `[Symbol('Policy'), Address, Vec[Void], Vec[Void], Vec[Symbol('Persistent')]]`. It passes only because `collectAddresses` scans for the address _anywhere_ in the args and the function name is correct. A kit change to where the address is embedded breaks production while the test stays green. |
 
 Three instances of the pattern (scope.test.ts + L1 + FIX-1's absence). Only FIX 2 builds its fixture
 the way the kit actually produces the value.

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -705,9 +705,60 @@ false`: when `DATABASE_URL` is set but unreachable, the guard falls through to `
 where audit log, sessions, and the FIX-3 spend budgets would reset to volatile in-memory while
 health monitoring says healthy. Downgraded High→Medium only because both manifests are testnet-only.
 
-> **Status (RA-4): OPEN — fix in this pass.** Set `NODE_ENV=production` in the deploy config so the
-> FIX-7 guard is live, or key the guard off a signal actually present at runtime. This is worse than
-> a normal Medium because it re-opens a finding already marked closed.
+> **Status (RA-4): CLOSED — by inverting the default, not by patching the manifest.** Setting
+> `NODE_ENV=production` in the deploy config would work only until the next target that forgets it —
+> a missing env var still meaning "less safe" is the bug. Instead the polarity is inverted: in
+> `packages/service-kit/src/persistence.ts`, in-memory is now the branch that requires an **explicit**
+> signal, and **absence fails closed**:
+>
+> - `resolvePersistencePolicy` degrades to in-memory only on an **explicitly ephemeral** env
+>   (`NODE_ENV === "development" | "test"`) or the operator opt-in `ALLOW_INMEMORY=1`. An **unset**
+>   `NODE_ENV` — the deploy-target reality — no longer degrades; with no usable durable DB it returns
+>   `fail` and the service `process.exit(1)`s. The wallet- and policy-service call sites feed
+>   `process.env.NODE_ENV` straight in, so they inherit the fix.
+> - Local dev keeps working because the `dev` scripts now set `NODE_ENV=development` explicitly
+>   (7 services), and Vitest sets `NODE_ENV=test`; the deployed `start` scripts stay unset, so they
+>   fail closed unless a DB is wired (which `render.yaml`/`railway.json` do) or `ALLOW_INMEMORY=1` is
+>   set. The signal is now the presence of an explicit dev marker, never the absence of a prod one.
+> - A regression test pins the exact deploy-target case (`nodeEnv: undefined` + no/unreachable DB →
+>   `fail`) that had no coverage before.
+>
+> **Repo-wide inertness sweep (per the RA-4 directive "if this one was wrong, others likely are").**
+> 19 environment-signal checks audited; 7 were the same "unset ⇒ less-safe" shape. Dispositions:
+>
+> - **Fixed here (same NODE_ENV persistence class):** `persistence.ts` (the anchor) + its wallet/
+>   policy call sites (auto-fixed). **`verification-service/index.ts` was the worst case** — it had
+>   **no `resolvePersistencePolicy` and no NODE_ENV backstop at all**, always silently falling back to
+>   an in-memory store on unset/unreachable DB; it now uses the same fail-closed policy.
+> - **New latent finding, filed as RA-10 (separate mechanism, not fixed here):** `attestor-guard.ts:16`
+>   keys the mainnet single-key guard on an **exact passphrase match**, so an unset
+>   `STELLAR_NETWORK_PASSPHRASE` defaults to testnet and **silently bypasses** the M5 guard if a worker
+>   is pointed at mainnet without setting the passphrase. Requires the attestor to be enabled; tracked
+>   for the M5 work.
+> - **Already-documented conditional guards (not new):** the sponsor/relayer scoping
+>   (`wallet-service/server.ts:109`, wired only when the relayer is configured) and the L1
+>   attach-verify (`policy-service/server.ts:97`, wired only when RPC is available) are "absent config
+>   ⇒ skip guard" in shape, but both are intended — the guarded funding/deploy path is itself inert
+>   without that config. The `VERIFY_BUILD_IMAGE` stub switch is loud + already documented. No change.
+> - **Confirmed CORRECT (fail-closed) — do not touch:** the extension's `import.meta.env.COMMAND`
+>   (unset ⇒ `build`/strict), `WXT_PUBLIC_ALLOW_ANY_PAIR_ORIGIN`, `ALLOW_SINGLE_KEY_ATTESTOR`, worker
+>   `DATABASE_URL`, and the gateway CORS/rate-limit/body-cap defaults. The extension is the reference
+>   for the right shape: absence yields the safe branch.
+
+### RA-10 — `attestor-guard` mainnet check is bypassed by an unset passphrase ℹ️ Info → tracked with M5 `[my code]`
+
+`services/worker-service/src/attestor-guard.ts:16`. `attestorNetwork` returns `"mainnet"` only on an
+**exact** `MAINNET_PASSPHRASE` match; an unset `STELLAR_NETWORK_PASSPHRASE` defaults to the testnet
+passphrase (`config.ts:53`), so a worker pointed at a mainnet RPC/registry while forgetting the
+passphrase mis-classifies as testnet and the single-key-on-mainnet refusal (M5) **silently does not
+run**. Surfaced by the RA-4 inertness sweep. Same class as RA-4 (unset ⇒ less-safe) but a different
+signal (network passphrase, not `NODE_ENV`), and it only bites when the attestor is enabled
+(`ATTESTOR_SECRET_KEY` + `ATTESTATION_REGISTRY_ID` set).
+
+> **Status (RA-10): OPEN — tracked with M5.** M5 (attestor-as-multisig) is already a deferred mainnet
+> prerequisite; fold this in there. Fix direction: derive the attestor's network from the same
+> explicit signal the rest of the mainnet posture uses and fail closed when the passphrase is unset
+> but a mainnet registry/RPC is configured, rather than defaulting the classification to testnet.
 
 ### RA-5 — Cleanup builder pays the full asset balance **before** cancelling offers (ignores selling liabilities) 🟡 Medium `[my code]`
 

--- a/packages/service-kit/src/budget.test.ts
+++ b/packages/service-kit/src/budget.test.ts
@@ -5,6 +5,7 @@ import {
   withinCeiling,
   type BudgetLimits,
 } from "./budget";
+import { createPgSpendBudget, type BudgetDb } from "./pg-budget";
 
 describe("withinCeiling (pure ceiling logic)", () => {
   const limits: BudgetLimits = { maxStroops: 500_000_000n, maxCount: 500 };
@@ -68,5 +69,78 @@ describe("budgetLimitsFromEnv", () => {
       {},
     );
     expect(limits).toEqual({ maxCount: 30 });
+  });
+});
+
+// RA-2: the check-and-record must be serialized against concurrent same-key
+// callers, or N parallel requests each read the same committed sum and all pass
+// (ceiling overshoot). The mechanism is pg_advisory_xact_lock inside a
+// transaction, taken BEFORE the aggregate read. These unit tests prove the
+// ORDER and structure without a real DB; pg-budget.test.ts proves the actual
+// concurrency guarantee against Postgres.
+describe("createPgSpendBudget serialization (RA-2)", () => {
+  /** Flatten a drizzle `sql` object to its literal SQL text (chunk values). */
+  function sqlText(q: unknown): string {
+    const chunks = (q as { queryChunks?: Array<{ value?: string[] } | null> }).queryChunks ?? [];
+    return chunks
+      .map((c) => (c && Array.isArray(c.value) ? c.value.join("") : ""))
+      .join(" ")
+      .toLowerCase();
+  }
+
+  /** A mock BudgetDb that records, in order, every statement run inside the
+   * transaction, and returns an insert row so the consume reads as ok. */
+  function recordingDb() {
+    const order: string[] = [];
+    const db: BudgetDb = {
+      async execute() {
+        throw new Error("consume must run inside a transaction, not a bare execute");
+      },
+      async transaction(fn) {
+        const tx = {
+          async execute(q: unknown) {
+            order.push(sqlText(q));
+            // The final check-insert statement RETURNs a row id when it inserts.
+            return { rows: [{ id: "row-1" }] };
+          },
+        };
+        return fn(tx as never);
+      },
+    };
+    return { db, order };
+  }
+
+  it("takes the advisory lock BEFORE the aggregate read, inside one transaction", async () => {
+    const { db, order } = recordingDb();
+    const budget = createPgSpendBudget(db, {
+      windowMs: 3_600_000,
+      limits: {
+        sponsor: { maxStroops: 1n, maxCount: 1 },
+        deploy: { maxCount: 1 },
+        create: { maxCount: 1 },
+      },
+    });
+
+    await budget.tryConsume({ line: "sponsor", network: "testnet", stroops: 0n });
+
+    // First statement in the tx acquires the per-(line,network) advisory lock…
+    expect(order[0]).toContain("pg_advisory_xact_lock");
+    // …and only AFTER it do we aggregate the window and insert.
+    const lockIdx = order.findIndex((s) => s.includes("pg_advisory_xact_lock"));
+    const aggIdx = order.findIndex((s) => s.includes("spend_ledger") && s.includes("sum"));
+    expect(lockIdx).toBeGreaterThanOrEqual(0);
+    expect(aggIdx).toBeGreaterThan(lockIdx);
+  });
+
+  it("keys the advisory lock on (line, network) so different keys don't serialize", async () => {
+    const { db, order } = recordingDb();
+    const budget = createPgSpendBudget(db, {
+      windowMs: 3_600_000,
+      limits: { sponsor: { maxCount: 1 }, deploy: { maxCount: 1 }, create: { maxCount: 1 } },
+    });
+    await budget.tryConsume({ line: "deploy", network: "mainnet", stroops: 0n });
+    const lockStmt = order.find((s) => s.includes("pg_advisory_xact_lock"))!;
+    // The lock argument derives from line+network (hashed), not a constant.
+    expect(lockStmt).toContain("hashtext");
   });
 });

--- a/packages/service-kit/src/budget.ts
+++ b/packages/service-kit/src/budget.ts
@@ -8,9 +8,11 @@
 //    never a request body's network field (V5).
 //  - FAIL CLOSED: if the ledger cannot be accounted (no DB / DB down), refuse —
 //    never sponsor unmetered. createUnavailableBudget is that refusing stub.
-//  - Check + record are ONE atomic statement in the Postgres impl (see
-//    pg-budget), so two concurrent requests cannot both pass before either
-//    records.
+//  - Check + record are serialized against concurrent same-(line,network)
+//    callers in the Postgres impl (a per-key pg_advisory_xact_lock taken before
+//    the aggregate read; see pg-budget, RA-2), so two concurrent requests cannot
+//    both pass before either records. A single conditional-INSERT is NOT enough
+//    under READ COMMITTED.
 
 export type BudgetLine = "sponsor" | "deploy" | "create";
 export type BudgetNetwork = "testnet" | "mainnet";

--- a/packages/service-kit/src/persistence.test.ts
+++ b/packages/service-kit/src/persistence.test.ts
@@ -1,9 +1,37 @@
 import { describe, expect, it } from "vitest";
 import { resolvePersistencePolicy } from "./persistence";
 
-describe("resolvePersistencePolicy (M6 fail-closed boot)", () => {
-  it("dev without DATABASE_URL: allows in-memory (convenience)", () => {
+describe("resolvePersistencePolicy (M6/FIX 7 fail-closed boot; RA-4 inversion)", () => {
+  // RA-4: the default is now FAIL-CLOSED. In-memory is the LESS-safe branch, so
+  // it requires an EXPLICIT signal — either ALLOW_INMEMORY=1 (operator opt-in)
+  // or an explicitly non-production NODE_ENV (development/test). An UNSET signal
+  // — the actual deploy-target state — must fail closed, not degrade.
+
+  it("NODE_ENV UNSET without DATABASE_URL: refuses to boot (the deploy-target reality)", () => {
+    // This is the RA-4 defect: on Render/Railway NODE_ENV is unset, so the old
+    // isProduction===false silently degraded. It must now fail closed.
+    const r = resolvePersistencePolicy({ databaseUrl: undefined, nodeEnv: undefined });
+    expect(r.action).toBe("fail");
+    if (r.action === "fail") expect(r.reason).toMatch(/DATABASE_URL/);
+  });
+
+  it("NODE_ENV UNSET with DATABASE_URL unreachable: refuses to boot (no silent degrade)", () => {
+    const r = resolvePersistencePolicy({
+      databaseUrl: "postgres://x",
+      nodeEnv: undefined,
+      connected: false,
+    });
+    expect(r.action).toBe("fail");
+    if (r.action === "fail") expect(r.reason).toMatch(/unreachable|could not connect/i);
+  });
+
+  it("dev (NODE_ENV=development) without DATABASE_URL: allows in-memory (explicit dev signal)", () => {
     const r = resolvePersistencePolicy({ databaseUrl: undefined, nodeEnv: "development" });
+    expect(r).toEqual({ action: "allow-inmemory" });
+  });
+
+  it("test (NODE_ENV=test, e.g. Vitest) without DATABASE_URL: allows in-memory", () => {
+    const r = resolvePersistencePolicy({ databaseUrl: undefined, nodeEnv: "test" });
     expect(r).toEqual({ action: "allow-inmemory" });
   });
 
@@ -23,22 +51,35 @@ describe("resolvePersistencePolicy (M6 fail-closed boot)", () => {
     if (r.action === "fail") expect(r.reason).toMatch(/unreachable|could not connect/i);
   });
 
-  it("production WITH DATABASE_URL and connected: proceeds on Postgres", () => {
-    const r = resolvePersistencePolicy({
-      databaseUrl: "postgres://x",
-      nodeEnv: "production",
-      connected: true,
-    });
-    expect(r).toEqual({ action: "use-postgres" });
+  it("WITH DATABASE_URL and connected: proceeds on Postgres (any env)", () => {
+    expect(
+      resolvePersistencePolicy({
+        databaseUrl: "postgres://x",
+        nodeEnv: "production",
+        connected: true,
+      }),
+    ).toEqual({ action: "use-postgres" });
+    expect(
+      resolvePersistencePolicy({
+        databaseUrl: "postgres://x",
+        nodeEnv: undefined,
+        connected: true,
+      }),
+    ).toEqual({ action: "use-postgres" });
   });
 
-  it("ALLOW_INMEMORY=1 overrides the production guard (explicit operator opt-in)", () => {
-    const r = resolvePersistencePolicy({
-      databaseUrl: undefined,
-      nodeEnv: "production",
-      allowInmemory: true,
-    });
-    expect(r).toEqual({ action: "allow-inmemory" });
+  it("ALLOW_INMEMORY=1 overrides the guard in ANY env (explicit operator opt-in)", () => {
+    expect(
+      resolvePersistencePolicy({
+        databaseUrl: undefined,
+        nodeEnv: "production",
+        allowInmemory: true,
+      }),
+    ).toEqual({ action: "allow-inmemory" });
+    // Even with NODE_ENV unset, the explicit opt-in is honored.
+    expect(
+      resolvePersistencePolicy({ databaseUrl: undefined, nodeEnv: undefined, allowInmemory: true }),
+    ).toEqual({ action: "allow-inmemory" });
   });
 
   it("dev WITH DATABASE_URL unreachable: degrades to in-memory (unchanged dev DX)", () => {

--- a/packages/service-kit/src/persistence.ts
+++ b/packages/service-kit/src/persistence.ts
@@ -1,4 +1,4 @@
-// Persistence boot policy (security-audit.md M6 / FIX 7).
+// Persistence boot policy (security-audit.md M6 / FIX 7; inverted per RA-4).
 //
 // The old behavior silently degraded to in-memory repositories whenever
 // DATABASE_URL was unset OR Postgres was unreachable, and /health still
@@ -6,27 +6,41 @@
 // volatile state (audit log, session list, and — since FIX 1/FIX 3 — the
 // funding-path scoping and spend budgets all depend on durable state).
 //
-// This makes the decision explicit and FAIL-CLOSED in production: a prod
-// instance either runs on Postgres or refuses to boot, unless the operator
-// explicitly opts into in-memory with ALLOW_INMEMORY=1.
+// FIX 7 gated fail-closed on `NODE_ENV === "production"`. RA-4: NOTHING sets
+// NODE_ENV=production on the deploy targets (@vellar/all-in-one runs via
+// `tsx src/index.ts`; no render.yaml/railway.json/.env sets it), so that guard
+// was inert and the instance silently degraded — fail-OPEN by default. A missing
+// env var meant "not production" meant "less safe."
+//
+// INVERTED: the default is FAIL-CLOSED. In-memory is the less-safe branch, so it
+// requires an EXPLICIT signal — either ALLOW_INMEMORY=1 (operator opt-in) or an
+// explicitly non-production NODE_ENV (`development`/`test`). An UNSET NODE_ENV —
+// the deploy-target reality — no longer degrades; it refuses to boot without a
+// durable DB. Local dev keeps working (tsx watch/Next set development; Vitest
+// sets test; or set ALLOW_INMEMORY=1).
 
 export interface PersistenceInputs {
   /** process.env.DATABASE_URL (undefined when unset). */
   databaseUrl: string | undefined;
-  /** process.env.NODE_ENV. */
+  /** process.env.NODE_ENV. UNSET is treated as a deployed environment (fail
+   * closed) — NOT as dev. */
   nodeEnv: string | undefined;
   /** Whether a connection attempt succeeded. Omit when no attempt was made
    * (i.e. databaseUrl is unset). */
   connected?: boolean;
   /** process.env.ALLOW_INMEMORY === "1" — explicit operator opt-in to run
-   * stateless even in production. */
+   * stateless (e.g. an ephemeral demo), honored in ANY environment. */
   allowInmemory?: boolean;
 }
 
 export type PersistenceDecision =
   { action: "use-postgres" } | { action: "allow-inmemory" } | { action: "fail"; reason: string };
 
-const isProduction = (nodeEnv: string | undefined) => nodeEnv === "production";
+/** In-memory is permitted ONLY on an explicitly non-production environment.
+ * Crucially, an UNSET NODE_ENV is NOT ephemeral — it fails closed. This is the
+ * RA-4 inversion: absence means "assume deployed," not "assume dev." */
+const isExplicitlyEphemeral = (nodeEnv: string | undefined) =>
+  nodeEnv === "development" || nodeEnv === "test";
 
 /** Decide how a service should handle its persistence at boot. Pure so the
  * fail-closed logic is unit-tested without spinning a real DB. */
@@ -34,32 +48,29 @@ export function resolvePersistencePolicy(inputs: PersistenceInputs): Persistence
   const { databaseUrl, nodeEnv, connected, allowInmemory } = inputs;
 
   // Explicit opt-in always wins: an operator who sets ALLOW_INMEMORY=1 has
-  // accepted volatile state (e.g. an ephemeral demo).
+  // accepted volatile state, in any environment.
   if (allowInmemory) return { action: "allow-inmemory" };
 
+  // A durable, connected DB is always fine.
+  if (databaseUrl && connected) return { action: "use-postgres" };
+
+  // No usable durable store. Degrade ONLY on an explicitly ephemeral env;
+  // otherwise (incl. NODE_ENV unset — the deploy-target reality) fail closed.
+  if (isExplicitlyEphemeral(nodeEnv)) return { action: "allow-inmemory" };
+
   if (!databaseUrl) {
-    if (isProduction(nodeEnv)) {
-      return {
-        action: "fail",
-        reason:
-          "DATABASE_URL is not set in production. Refusing to run on in-memory storage " +
-          "(set DATABASE_URL, or ALLOW_INMEMORY=1 to explicitly accept volatile state).",
-      };
-    }
-    return { action: "allow-inmemory" };
-  }
-
-  // DATABASE_URL is set. If the connection succeeded, use it.
-  if (connected) return { action: "use-postgres" };
-
-  // Set but unreachable.
-  if (isProduction(nodeEnv)) {
     return {
       action: "fail",
       reason:
-        "DATABASE_URL is set but Postgres is unreachable in production. Refusing to degrade " +
-        "to in-memory storage (fail-closed). Fix the database or set ALLOW_INMEMORY=1.",
+        "DATABASE_URL is not set and this is not an explicitly ephemeral environment " +
+        "(NODE_ENV is not development/test). Refusing to run on volatile in-memory storage. " +
+        "Set DATABASE_URL, or ALLOW_INMEMORY=1 to explicitly accept volatile state.",
     };
   }
-  return { action: "allow-inmemory" };
+  return {
+    action: "fail",
+    reason:
+      "DATABASE_URL is set but Postgres is unreachable (could not connect). Refusing to degrade " +
+      "to in-memory storage (fail-closed). Fix the database or set ALLOW_INMEMORY=1.",
+  };
 }

--- a/packages/service-kit/src/pg-budget.ts
+++ b/packages/service-kit/src/pg-budget.ts
@@ -3,21 +3,29 @@ import { sql } from "drizzle-orm";
 import type { BudgetLimits, ConsumeRequest, ConsumeResult, SpendBudget } from "./budget";
 
 // Postgres-backed rolling-window spend budget (security-audit.md H1/M2/FIX 3).
-// Shared by every funding-path service (wallet + policy) so the atomic
-// conditional-INSERT lives in ONE place. Each service owns its own spend_ledger
-// migration; this only needs a drizzle-style executor.
+// Shared by every funding-path service (wallet + policy) so the serialized
+// check-and-record lives in ONE place. Each service owns its own spend_ledger
+// migration; this only needs a drizzle-style executor with transactions.
 //
-// The check and the record are a SINGLE atomic statement: a CTE aggregates the
-// window for (line, network), and the INSERT ... SELECT emits a row only when
-// adding this call stays within BOTH ceilings. Two concurrent requests cannot
-// both pass before either records (verified by a real-Postgres concurrency
-// test). Keyed off the network the CALLER passes (server config, never a
-// request body — V5). Throws on a DB error; callers treat a throw as "refuse"
-// (fail closed).
+// RA-2: a single conditional-INSERT is NOT enough. Under READ COMMITTED (the
+// pool default), the aggregate CTE reads a committed snapshot that cannot see
+// other in-flight uncommitted inserts, so N concurrent same-key requests each
+// read the same sum, all pass the WHERE, and all commit — overshooting the
+// ceiling by the pool-concurrency factor. So the check+insert runs inside a
+// TRANSACTION guarded by pg_advisory_xact_lock keyed on (line, network), taken
+// BEFORE the aggregate read: same-key callers serialize on the lock (auto-
+// released at commit); different keys never block each other. Keyed off the
+// network the CALLER passes (server config, never a request body — V5). Throws
+// on a DB error; callers treat a throw as "refuse" (fail closed).
 
-/** Minimal structural view of a drizzle db — just what the budget needs. */
+/** Minimal structural view of a drizzle db — the budget needs a transaction so
+ * the advisory lock and the check-insert share one connection/transaction. */
+export interface BudgetTx {
+  execute(query: ReturnType<typeof sql>): Promise<unknown>;
+}
 export interface BudgetDb {
   execute(query: ReturnType<typeof sql>): Promise<unknown>;
+  transaction<T>(fn: (tx: BudgetTx) => Promise<T>): Promise<T>;
 }
 
 export interface PgBudgetConfig {
@@ -38,24 +46,33 @@ export function createPgSpendBudget(db: BudgetDb, config: PgBudgetConfig): Spend
       const at = now();
       const maxStroops = limits.maxStroops ?? null; // null => count-only line
 
-      const result = await db.execute(sql`
-        WITH agg AS (
-          SELECT
-            COALESCE(SUM(stroops), 0)::numeric AS sum_stroops,
-            COALESCE(SUM(count), 0)::int      AS sum_count
-          FROM spend_ledger
-          WHERE line = ${req.line}
-            AND network = ${req.network}
-            AND at > ${windowStart}
-        )
-        INSERT INTO spend_ledger (id, line, network, stroops, count, at)
-        SELECT ${id}, ${req.line}, ${req.network}, ${req.stroops.toString()}::bigint, ${addCount}, ${at}
-        FROM agg
-        WHERE agg.sum_count + ${addCount} <= ${limits.maxCount}
-          AND (${maxStroops}::numeric IS NULL
-               OR agg.sum_stroops + ${req.stroops.toString()}::numeric <= ${maxStroops}::numeric)
-        RETURNING id
-      `);
+      const result = await db.transaction(async (tx) => {
+        // Serialize same-(line,network) callers BEFORE the aggregate read.
+        // hashtext(line||network) → a stable int4 lock key; the xact-scoped lock
+        // releases automatically at commit/rollback. Different keys use
+        // different lock ids and never block each other.
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${`${req.line}:${req.network}`}))`,
+        );
+        return tx.execute(sql`
+          WITH agg AS (
+            SELECT
+              COALESCE(SUM(stroops), 0)::numeric AS sum_stroops,
+              COALESCE(SUM(count), 0)::int      AS sum_count
+            FROM spend_ledger
+            WHERE line = ${req.line}
+              AND network = ${req.network}
+              AND at > ${windowStart}
+          )
+          INSERT INTO spend_ledger (id, line, network, stroops, count, at)
+          SELECT ${id}, ${req.line}, ${req.network}, ${req.stroops.toString()}::bigint, ${addCount}, ${at}
+          FROM agg
+          WHERE agg.sum_count + ${addCount} <= ${limits.maxCount}
+            AND (${maxStroops}::numeric IS NULL
+                 OR agg.sum_stroops + ${req.stroops.toString()}::numeric <= ${maxStroops}::numeric)
+          RETURNING id
+        `);
+      });
 
       const rows = (result as { rows?: unknown[] }).rows;
       const inserted = Array.isArray(rows) ? rows : Array.isArray(result) ? result : [];

--- a/services/all-in-one/package.json
+++ b/services/all-in-one/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "tsx --env-file-if-exists=../../.env src/index.ts",
-    "dev": "tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -5,7 +5,7 @@
   "description": "Unified API entrypoint: auth/session middleware, rate limiting, request tracing, client routing",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
     "start": "tsx --env-file-if-exists=../../.env src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/services/lifecycle-service/package.json
+++ b/services/lifecycle-service/package.json
@@ -5,7 +5,7 @@
   "description": "Account inspection, blocker detection, cleanup planning, merge validation",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
     "start": "tsx --env-file-if-exists=../../.env src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/services/policy-service/package.json
+++ b/services/policy-service/package.json
@@ -5,7 +5,7 @@
   "description": "Policy schema validation, template registry, simulation and deployment orchestration",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
     "start": "tsx --env-file-if-exists=../../.env src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/services/policy-service/src/verify-attach.test.ts
+++ b/services/policy-service/src/verify-attach.test.ts
@@ -22,20 +22,39 @@ const POLICY = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
 const OTHER_WALLET = "CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT";
 const OTHER_POLICY = "CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67";
 
-/** Build an add_signer(Policy) tx XDR, as kit.addPolicy produces: an
- * invokeContract on the WALLET calling add_signer with a Signer::Policy enum
- * (a vec: [symbol('Policy'), address(policy), void]). */
+/**
+ * Build an `add_signer(Policy)` tx XDR the way `kit.addPolicy` REALLY produces
+ * it. passkey-kit's `buildPolicySigner` (wallet-ops.js:73-83) emits the native
+ * `Signer::Policy` = `{tag:"Policy", values:[policy, expiration, limits, store]}`,
+ * which the contract spec (`passkey-kit-sdk` `Signer` UDT:
+ * `values:[string, SignerExpiration, SignerLimits, SignerStorage]`) encodes as a
+ * **5-element** vec, NOT the 3-element `[Symbol, Address, Void]` the earlier
+ * fixture hand-built to match the parser (RA-9). For the standalone attach the
+ * kit passes: expiration `None`, limits `None`, storage `Persistent`.
+ *
+ * A `passkey-kit-sdk` `Spec.funcArgsToScVals` would be strictly better, but that
+ * package is only a transitive dep here; this reproduces the same on-the-wire
+ * shape element-for-element so a tuple-arity/position drift breaks the test.
+ */
+function buildPolicySignerScVal(policy: string): xdr.ScVal {
+  return xdr.ScVal.scvVec([
+    xdr.ScVal.scvSymbol("Policy"),
+    nativeToScVal(Address.fromString(policy), { type: "address" }), // policy address
+    xdr.ScVal.scvVoid(), // SignerExpiration::None (Option<u64> absent)
+    xdr.ScVal.scvVoid(), // SignerLimits::None
+    xdr.ScVal.scvVec([xdr.ScVal.scvSymbol("Persistent")]), // SignerStorage::Persistent
+  ]);
+}
+
 function buildAddPolicyXdr(opts: {
   wallet: string;
   policy: string;
   fn?: string;
   passphrase?: string;
+  /** Override the signer arg entirely (to test a shape the scan must still handle). */
+  signerScVal?: xdr.ScVal;
 }): string {
-  const signer = xdr.ScVal.scvVec([
-    xdr.ScVal.scvSymbol("Policy"),
-    nativeToScVal(Address.fromString(opts.policy), { type: "address" }),
-    xdr.ScVal.scvVoid(),
-  ]);
+  const signer = opts.signerScVal ?? buildPolicySignerScVal(opts.policy);
   const func = xdr.HostFunction.hostFunctionTypeInvokeContract(
     new xdr.InvokeContractArgs({
       contractAddress: Address.fromString(opts.wallet).toScAddress(),
@@ -68,6 +87,17 @@ describe("verifyAttachTx (L1 full attach verification)", () => {
     await expect(
       verifyAttachTx(successLookup(xdrStr), { txHash: "h", ...target }),
     ).resolves.toBeUndefined();
+  });
+
+  it("uses the real 5-element Signer::Policy tuple, not a hand-shaped 3-element vec (RA-9)", () => {
+    // Pin the fixture arity so this test is exercising the kit's actual shape.
+    // If the kit's Signer::Policy encoding changes arity, this assertion — and
+    // therefore the decode path under test — moves with it instead of silently
+    // passing on a stale hand-built shape.
+    const signer = buildPolicySignerScVal(POLICY);
+    expect(signer.switch().name).toBe("scvVec");
+    expect(signer.vec()?.length).toBe(5);
+    expect(signer.vec()![0]!.sym().toString()).toBe("Policy");
   });
 
   it("rejects (mismatch) a valid tx that attached a DIFFERENT policy", async () => {

--- a/services/verification-service/package.json
+++ b/services/verification-service/package.json
@@ -5,7 +5,7 @@
   "description": "Verification submissions, source bundle metadata, artifact comparison, status APIs",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
     "start": "tsx --env-file-if-exists=../../.env src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/services/verification-service/src/index.ts
+++ b/services/verification-service/src/index.ts
@@ -1,4 +1,10 @@
-import { hostFromEnv, portFromEnv, startService, tryConnectDb } from "@vellar/service-kit";
+import {
+  hostFromEnv,
+  portFromEnv,
+  resolvePersistencePolicy,
+  startService,
+  tryConnectDb,
+} from "@vellar/service-kit";
 import { configFromEnv } from "./config";
 import { buildServer, type VerificationServiceDeps } from "./server";
 
@@ -7,8 +13,7 @@ import { buildServer, type VerificationServiceDeps } from "./server";
 // §11; technical-doc.md §5.5/§7.6). It never runs builds itself — worker-service
 // does that in an isolated process (§8.4) and updates records via the shared
 // Postgres. When DATABASE_URL is set, a submitted record is a queued job the
-// worker polls; without it, records live in memory and are never built (a loud
-// warning is logged) — the submit/read API still works for local dev.
+// worker polls; without it, records live in memory and are never built.
 
 const config = configFromEnv();
 const deps: VerificationServiceDeps = {
@@ -19,6 +24,7 @@ const deps: VerificationServiceDeps = {
 };
 
 let closeDb: (() => Promise<void>) | undefined;
+let dbConnected = false;
 if (config.databaseUrl) {
   const databaseUrl = config.databaseUrl;
   const { connectDb } = await import("./db/client");
@@ -34,7 +40,25 @@ if (config.databaseUrl) {
     // worker-service polls for status="submitted" rows and claims them.
     deps.queue = createPgBuildJobQueue();
     closeDb = handle.close;
+    dbConnected = true;
   }
+}
+
+// RA-4: fail closed BEFORE serving. This service previously ALWAYS fell back to
+// an in-memory store when DATABASE_URL was unset or unreachable, with no
+// NODE_ENV backstop at all — the worst case of the M6/FIX-7 inertness class. Now
+// the same fail-closed policy as wallet/policy-service applies: on a deploy
+// target (NODE_ENV not development/test) a missing/unreachable DB refuses to
+// boot rather than silently serving a store whose submissions are never built.
+const policy = resolvePersistencePolicy({
+  databaseUrl: config.databaseUrl,
+  nodeEnv: process.env.NODE_ENV,
+  connected: config.databaseUrl ? dbConnected : undefined,
+  allowInmemory: process.env.ALLOW_INMEMORY === "1",
+});
+if (policy.action === "fail") {
+  console.error(`[verification-service] ${policy.reason}`);
+  process.exit(1);
 }
 
 const app = buildServer(deps);
@@ -42,9 +66,11 @@ if (closeDb) {
   app.addHook("onClose", async () => closeDb?.());
   app.log.info("Postgres connected, migrations applied");
 }
-if (!config.databaseUrl) {
+if (!dbConnected) {
   app.log.warn(
-    "DATABASE_URL not set — using an in-memory verification store; submissions will NOT be built or survive a restart.",
+    "DATABASE_URL not set/unreachable — using an in-memory verification store; submissions will " +
+      "NOT be built or survive a restart. (Explicitly permitted here via NODE_ENV=development/test " +
+      "or ALLOW_INMEMORY=1; a production boot without a durable DB refuses to start.)",
   );
 }
 

--- a/services/wallet-service/package.json
+++ b/services/wallet-service/package.json
@@ -5,7 +5,7 @@
   "description": "Wallet metadata, account preferences, session/device records, audit logs",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
     "start": "tsx --env-file-if-exists=../../.env src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/services/wallet-service/src/db/pg-budget.test.ts
+++ b/services/wallet-service/src/db/pg-budget.test.ts
@@ -1,13 +1,26 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { drizzle } from "drizzle-orm/node-postgres";
 import { sql } from "drizzle-orm";
+import pg from "pg";
 import { createPgSpendBudget, type PgBudgetConfig } from "@vellar/service-kit";
 import { connectDb, type DbHandle } from "./client";
 
-// Integration tests against a real Postgres. Skipped unless TEST_DATABASE_URL
-// is set (CI provisions one; locally: docker compose up + TEST_DATABASE_URL).
-// The atomic conditional-INSERT that gives the concurrency guarantee can only
-// be verified against a real DB, not a mock.
+// Integration tests against a real Postgres. Skipped LOCALLY unless
+// TEST_DATABASE_URL is set (docker compose up + TEST_DATABASE_URL). The
+// serialized check-and-record (RA-2 advisory lock) can only be verified against
+// a real DB, not a mock — so "skips locally" must never become "silently skips
+// in CI": when CI_REQUIRE_DB=1 (set in the CI workflow) but no DB is
+// configured, the suite FAILS instead of skipping, so the guarantee cannot
+// vanish by a dropped env var. (This is why RA-2 shipped: the concurrency test
+// was effectively decorative — skipped locally, and its Promise.all-over-one-
+// pool shape never raced even when it ran.)
 const DATABASE_URL = process.env.TEST_DATABASE_URL;
+if (!DATABASE_URL && process.env.CI_REQUIRE_DB === "1") {
+  throw new Error(
+    "CI_REQUIRE_DB=1 but TEST_DATABASE_URL is unset — the pg-budget concurrency " +
+      "guarantee (RA-2) would silently skip. Provision Postgres in CI or unset CI_REQUIRE_DB.",
+  );
+}
 
 describe.skipIf(!DATABASE_URL)("createPgSpendBudget (atomic rolling-window budget)", () => {
   let handle: DbHandle;
@@ -109,20 +122,64 @@ describe.skipIf(!DATABASE_URL)("createPgSpendBudget (atomic rolling-window budge
     ).toBe(true);
   });
 
-  it("CONCURRENCY: with room for exactly one more, only one of N parallel consumes succeeds", async () => {
-    // Ceiling = 1 call. Fire 8 concurrent consumes; the atomic conditional
-    // INSERT must let exactly one land.
-    const budget = createPgSpendBudget(db, {
-      ...baseConfig,
-      limits: { ...baseConfig.limits, sponsor: { maxStroops: 500_000_000n, maxCount: 1 } },
+  it("CONCURRENCY: with room for exactly one more, only one of N truly-parallel consumes succeeds", async () => {
+    // RA-2: this MUST use independent connections. Firing Promise.all over a
+    // single drizzle pool serializes on the pool and never exercises real
+    // concurrency — the decorative shape that let RA-2 ship. Each consumer here
+    // gets its OWN single-connection pool, so N tryConsumes truly race. Against
+    // the old single-statement version this overshoots (all read the same
+    // committed sum); the advisory lock (taken before the read) holds it to 1.
+    const N = 12;
+    const pools: pg.Pool[] = [];
+    const budgets = Array.from({ length: N }, () => {
+      const pool = new pg.Pool({ connectionString: DATABASE_URL as string, max: 1 });
+      pools.push(pool);
+      return createPgSpendBudget(drizzle(pool), {
+        ...baseConfig,
+        limits: { ...baseConfig.limits, sponsor: { maxStroops: 500_000_000n, maxCount: 1 } },
+      });
     });
-    const results = await Promise.all(
-      Array.from({ length: 8 }, () =>
-        budget.tryConsume({ line: "sponsor", network: "testnet", stroops: 1_000n }),
-      ),
-    );
-    const okCount = results.filter((r) => r.ok).length;
-    expect(okCount).toBe(1);
-    expect(await ledgerRowCount()).toBe(1);
+    try {
+      const results = await Promise.all(
+        budgets.map((b) => b.tryConsume({ line: "sponsor", network: "testnet", stroops: 1_000n })),
+      );
+      const okCount = results.filter((r) => r.ok).length;
+      expect(okCount).toBe(1);
+      expect(await ledgerRowCount()).toBe(1);
+    } finally {
+      await Promise.all(pools.map((p) => p.end()));
+    }
+  });
+
+  it("CONCURRENCY: different (line, network) keys do NOT serialize against each other", async () => {
+    // The advisory lock is per-key: a sponsor:testnet consume and a
+    // deploy:mainnet consume race freely and both land at their own ceilings.
+    const mkBudget = () => {
+      const pool = new pg.Pool({ connectionString: DATABASE_URL as string, max: 1 });
+      return {
+        pool,
+        budget: createPgSpendBudget(drizzle(pool), {
+          ...baseConfig,
+          limits: {
+            ...baseConfig.limits,
+            sponsor: { maxStroops: 500_000_000n, maxCount: 1 },
+            deploy: { maxStroops: 200_000_000n, maxCount: 1 },
+          },
+        }),
+      };
+    };
+    const a = mkBudget();
+    const b = mkBudget();
+    try {
+      const [r1, r2] = await Promise.all([
+        a.budget.tryConsume({ line: "sponsor", network: "testnet", stroops: 1_000n }),
+        b.budget.tryConsume({ line: "deploy", network: "mainnet", stroops: 1_000n }),
+      ]);
+      expect(r1.ok).toBe(true);
+      expect(r2.ok).toBe(true);
+      expect(await ledgerRowCount()).toBe(2);
+    } finally {
+      await Promise.all([a.pool.end(), b.pool.end()]);
+    }
   });
 });

--- a/services/wallet-service/src/db/pg-repository.test.ts
+++ b/services/wallet-service/src/db/pg-repository.test.ts
@@ -10,9 +10,16 @@ import {
 } from "./pg-repository";
 import { activityLogs, wallets, walletSessions } from "./schema";
 
-// Integration tests against a real Postgres. Skipped unless TEST_DATABASE_URL
-// is set (CI provides a service container; locally: infra/docker compose).
+// Integration tests against a real Postgres. Skipped LOCALLY unless
+// TEST_DATABASE_URL is set (CI provides a service container; locally:
+// infra/docker compose). CI sets CI_REQUIRE_DB=1 so these FAIL rather than
+// silently skip if the DB service ever goes missing (RA-2).
 const DATABASE_URL = process.env.TEST_DATABASE_URL;
+if (!DATABASE_URL && process.env.CI_REQUIRE_DB === "1") {
+  throw new Error(
+    "CI_REQUIRE_DB=1 but TEST_DATABASE_URL is unset — DB integration tests would silently skip.",
+  );
+}
 
 describe.skipIf(!DATABASE_URL)("pg repositories", () => {
   let handle: DbHandle;

--- a/services/wallet-service/src/scope.test.ts
+++ b/services/wallet-service/src/scope.test.ts
@@ -15,27 +15,67 @@ const PASSPHRASE = "Test SDF Network ; September 2015";
 const KNOWN_WALLET = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
 const OTHER_CONTRACT = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
 
-/** Builds a signed-shaped single-op invokeHostFunction tx whose auth entries
- * carry address credentials bound to the given contract subjects. */
-function buildInvokeTx(subjects: string[], opts?: { sourceAccountCreds?: boolean }): string {
+/** Which auth-credential shape to build. The production signer
+ * (passkey-kit@0.14.0) never emits V1 for a signed wallet op: it upgrades every
+ * entry IN PLACE to `sorobanCredentialsAddressV2` (auth-payload.js:65-67), and
+ * throws unless the payload is V2/with-delegates. So V2 is the REAL production
+ * shape; V1 is a legacy/attacker-constructable shape. Fixtures cover all three
+ * address-bound variants plus source-account, so a kit shape-change (or a
+ * regression to a V1-only filter) breaks a test rather than hiding. */
+type CredKind = "v1" | "v2" | "delegates" | "source";
+
+/** The SorobanAddressCredentials struct all three address-bound variants wrap. */
+function addressCreds(subject: string): xdr.SorobanAddressCredentials {
+  return new xdr.SorobanAddressCredentials({
+    address: Address.fromString(subject).toScAddress(),
+    nonce: xdr.Int64.fromString("0"),
+    signatureExpirationLedger: 0,
+    signature: xdr.ScVal.scvVoid(),
+  });
+}
+
+/** Build a credentials union for `subject` in the requested variant. V2 mirrors
+ * exactly what the kit's `toAddressBoundCredentials` produces:
+ * `sorobanCredentialsAddressV2(<same SorobanAddressCredentials>)`. */
+function credentialsFor(subject: string, kind: CredKind): xdr.SorobanCredentials {
+  switch (kind) {
+    case "source":
+      return xdr.SorobanCredentials.sorobanCredentialsSourceAccount();
+    case "v1":
+      return xdr.SorobanCredentials.sorobanCredentialsAddress(addressCreds(subject));
+    case "v2":
+      return xdr.SorobanCredentials.sorobanCredentialsAddressV2(addressCreds(subject));
+    case "delegates":
+      return xdr.SorobanCredentials.sorobanCredentialsAddressWithDelegates(
+        new xdr.SorobanAddressCredentialsWithDelegates({
+          addressCredentials: addressCreds(subject),
+          delegates: [],
+        }),
+      );
+  }
+}
+
+/** Builds a single-op invokeHostFunction tx whose auth entries carry the given
+ * (subject, credential-kind) pairs. `subjects` as string[] defaults every entry
+ * to V2 — the real production shape — so tests read as "what the kit produces"
+ * unless a kind is stated explicitly. */
+function buildInvokeTx(
+  subjects: Array<string | { subject: string; kind: CredKind }>,
+  opts?: { sourceAccountCreds?: boolean },
+): string {
   const source = Keypair.random();
   const account = new Account(source.publicKey(), "0");
-  const primary = Address.fromString(subjects[0] ?? OTHER_CONTRACT);
+  const entries = subjects.map((s) =>
+    typeof s === "string"
+      ? { subject: s, kind: (opts?.sourceAccountCreds ? "source" : "v2") as CredKind }
+      : s,
+  );
+  const primary = Address.fromString(entries[0]?.subject ?? OTHER_CONTRACT);
 
-  const auth = subjects.map((subject) => {
+  const auth = entries.map(({ subject, kind }) => {
     const addr = Address.fromString(subject);
-    const credentials = opts?.sourceAccountCreds
-      ? xdr.SorobanCredentials.sorobanCredentialsSourceAccount()
-      : xdr.SorobanCredentials.sorobanCredentialsAddress(
-          new xdr.SorobanAddressCredentials({
-            address: addr.toScAddress(),
-            nonce: xdr.Int64.fromString("0"),
-            signatureExpirationLedger: 0,
-            signature: xdr.ScVal.scvVoid(),
-          }),
-        );
     return new xdr.SorobanAuthorizationEntry({
-      credentials,
+      credentials: credentialsFor(subject, kind),
       rootInvocation: new xdr.SorobanAuthorizedInvocation({
         function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
           new xdr.InvokeContractArgs({
@@ -68,14 +108,36 @@ function buildInvokeTx(subjects: string[], opts?: { sourceAccountCreds?: boolean
 }
 
 describe("extractAddressAuthSubjects", () => {
-  it("returns every address-credential subject in the tx", () => {
+  it("returns every address-credential subject in the tx (V2 — the real signer shape)", () => {
     const xdrStr = buildInvokeTx([KNOWN_WALLET, OTHER_CONTRACT]);
     const subjects = extractAddressAuthSubjects(xdrStr, PASSPHRASE);
     expect(subjects).toEqual([KNOWN_WALLET, OTHER_CONTRACT]);
   });
 
+  // RA-1: passkey-kit@0.14 signs V2, not V1. Each address-bound variant must be
+  // recognized, or the gate returns [] for real traffic (fail-closed break) and
+  // skips attacker V2 legs in a mixed tx (scope evasion).
+  it.each(["v1", "v2", "delegates"] as const)(
+    "extracts the subject from a %s address-bound credential",
+    (kind) => {
+      const xdrStr = buildInvokeTx([{ subject: KNOWN_WALLET, kind }]);
+      expect(extractAddressAuthSubjects(xdrStr, PASSPHRASE)).toEqual([KNOWN_WALLET]);
+    },
+  );
+
+  it("extracts BOTH subjects from a mixed V1 + V2 transaction (no leg skipped)", () => {
+    // The RA-1 bypass: one V1 entry bound to a known wallet + one V2 entry bound
+    // to an attacker contract. If V2 is skipped, the attacker leg rides past the
+    // gate. Both subjects must surface.
+    const xdrStr = buildInvokeTx([
+      { subject: KNOWN_WALLET, kind: "v1" },
+      { subject: OTHER_CONTRACT, kind: "v2" },
+    ]);
+    expect(extractAddressAuthSubjects(xdrStr, PASSPHRASE)).toEqual([KNOWN_WALLET, OTHER_CONTRACT]);
+  });
+
   it("ignores source-account credentials (a deploy carries no address subject)", () => {
-    const xdrStr = buildInvokeTx([KNOWN_WALLET], { sourceAccountCreds: true });
+    const xdrStr = buildInvokeTx([{ subject: KNOWN_WALLET, kind: "source" }]);
     expect(extractAddressAuthSubjects(xdrStr, PASSPHRASE)).toEqual([]);
   });
 
@@ -108,10 +170,28 @@ describe("assertScopedToKnownWallets", () => {
     );
   });
 
+  it("rejects the RA-1 bypass: a known-wallet V1 leg + an attacker-contract V2 leg", async () => {
+    // Both legs must be scoped. The V2 attacker leg must NOT ride past the gate.
+    const xdrStr = buildInvokeTx([
+      { subject: KNOWN_WALLET, kind: "v1" },
+      { subject: OTHER_CONTRACT, kind: "v2" },
+    ]);
+    await expect(assertScopedToKnownWallets(xdrStr, PASSPHRASE, knownOnly)).rejects.toBeInstanceOf(
+      ScopeError,
+    );
+  });
+
+  it("passes a real V2-signed single-op wallet tx (must not fail-closed on legit traffic)", async () => {
+    const xdrStr = buildInvokeTx([{ subject: KNOWN_WALLET, kind: "v2" }]);
+    await expect(
+      assertScopedToKnownWallets(xdrStr, PASSPHRASE, knownOnly),
+    ).resolves.toBeUndefined();
+  });
+
   it("rejects a tx with NO address-credential subject at all (nothing to attribute the spend to)", async () => {
     // A source-account-auth invoke has no address subject; the relayer/sponsor
     // must not fund a tx we cannot attribute to a known wallet.
-    const xdrStr = buildInvokeTx([KNOWN_WALLET], { sourceAccountCreds: true });
+    const xdrStr = buildInvokeTx([{ subject: KNOWN_WALLET, kind: "source" }]);
     await expect(assertScopedToKnownWallets(xdrStr, PASSPHRASE, knownOnly)).rejects.toBeInstanceOf(
       ScopeError,
     );

--- a/services/wallet-service/src/scope.ts
+++ b/services/wallet-service/src/scope.ts
@@ -1,4 +1,4 @@
-import { Address, TransactionBuilder } from "@stellar/stellar-sdk";
+import { Address, TransactionBuilder, xdr } from "@stellar/stellar-sdk";
 
 // Route-level funding-path scoping (security-audit.md C1 + H1 + V2).
 //
@@ -24,6 +24,33 @@ export class ScopeError extends Error {
   }
 }
 
+/**
+ * The `SorobanAddressCredentials` for an auth entry, across ALL address-bound
+ * credential variants — or undefined for source-account credentials.
+ *
+ * The production signer (`passkey-kit@0.14.0`) never emits V1: it upgrades every
+ * signed entry IN PLACE to `sorobanCredentialsAddressV2` (auth-payload.js:65-67)
+ * and refuses to sign a non-address-bound payload. Matching only the V1 string
+ * (the RA-1 defect) therefore returned [] for real traffic — a fail-closed break
+ * — and skipped attacker V2 legs in a mixed tx. All three address-bound arms
+ * (`address` V1, `addressV2`, `addressWithDelegates`) wrap the same
+ * `SorobanAddressCredentials`, so the subject address is read uniformly.
+ */
+function addressCredentials(
+  creds: xdr.SorobanCredentials,
+): xdr.SorobanAddressCredentials | undefined {
+  switch (creds.switch().name) {
+    case "sorobanCredentialsAddress":
+      return creds.address();
+    case "sorobanCredentialsAddressV2":
+      return creds.addressV2();
+    case "sorobanCredentialsAddressWithDelegates":
+      return creds.addressWithDelegates().addressCredentials();
+    default:
+      return undefined; // sorobanCredentialsSourceAccount — no address subject
+  }
+}
+
 /** Every address-credential auth subject (smart-account C-address) in a single
  * signed transaction. Returns [] for an unparseable xdr or a tx with no
  * address-credential auth entries. */
@@ -40,8 +67,9 @@ export function extractAddressAuthSubjects(signedXdr: string, networkPassphrase:
   for (const op of tx.operations) {
     if (op.type !== "invokeHostFunction" || !op.auth) continue;
     for (const entry of op.auth) {
-      if (entry.credentials().switch().name !== "sorobanCredentialsAddress") continue;
-      subjects.push(Address.fromScAddress(entry.credentials().address().address()).toString());
+      const addrCreds = addressCredentials(entry.credentials());
+      if (!addrCreds) continue; // source-account: no subject to attribute
+      subjects.push(Address.fromScAddress(addrCreds.address()).toString());
     }
   }
   return subjects;

--- a/services/wallet-service/src/sponsor.test.ts
+++ b/services/wallet-service/src/sponsor.test.ts
@@ -1,6 +1,93 @@
+import {
+  Account,
+  Address,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+  xdr,
+} from "@stellar/stellar-sdk";
 import { describe, expect, it } from "vitest";
-import { consumeSponsorBudget, enforceFeeCap, SPONSOR_DEFAULT_MAX_FEE_STROOPS } from "./sponsor";
+import {
+  consumeSponsorBudget,
+  enforceFeeCap,
+  needsSponsorRebuild,
+  SPONSOR_DEFAULT_MAX_FEE_STROOPS,
+} from "./sponsor";
 import { SubmissionError } from "./relayer";
+
+const PASSPHRASE = "Test SDF Network ; September 2015";
+const WALLET = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+// RA-9/FIX-1: needsSponsorRebuild had NO test. Its filter is a NEGATIVE match
+// (accept unless sorobanCredentialsSourceAccount), so it correctly accepts the
+// V2 credentials passkey-kit@0.14 actually emits — but that was safe by luck,
+// not by test. These fixtures build the REAL V2 shape (plus V1/delegates/
+// source-account) so a regression to a positive V1-only check fails here.
+type CredKind = "v1" | "v2" | "delegates" | "source";
+
+function addrCreds(subject: string): xdr.SorobanAddressCredentials {
+  return new xdr.SorobanAddressCredentials({
+    address: Address.fromString(subject).toScAddress(),
+    nonce: xdr.Int64.fromString("0"),
+    signatureExpirationLedger: 0,
+    signature: xdr.ScVal.scvVoid(),
+  });
+}
+
+function credentialsFor(subject: string, kind: CredKind): xdr.SorobanCredentials {
+  switch (kind) {
+    case "source":
+      return xdr.SorobanCredentials.sorobanCredentialsSourceAccount();
+    case "v1":
+      return xdr.SorobanCredentials.sorobanCredentialsAddress(addrCreds(subject));
+    case "v2":
+      return xdr.SorobanCredentials.sorobanCredentialsAddressV2(addrCreds(subject));
+    case "delegates":
+      return xdr.SorobanCredentials.sorobanCredentialsAddressWithDelegates(
+        new xdr.SorobanAddressCredentialsWithDelegates({
+          addressCredentials: addrCreds(subject),
+          delegates: [],
+        }),
+      );
+  }
+}
+
+function invokeOp(authKinds: CredKind[]): xdr.Operation {
+  const auth = authKinds.map(
+    (kind) =>
+      new xdr.SorobanAuthorizationEntry({
+        credentials: credentialsFor(WALLET, kind),
+        rootInvocation: new xdr.SorobanAuthorizedInvocation({
+          function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+            new xdr.InvokeContractArgs({
+              contractAddress: Address.fromString(WALLET).toScAddress(),
+              functionName: "transfer",
+              args: [],
+            }),
+          ),
+          subInvocations: [],
+        }),
+      }),
+  );
+  return Operation.invokeHostFunction({
+    func: xdr.HostFunction.hostFunctionTypeInvokeContract(
+      new xdr.InvokeContractArgs({
+        contractAddress: Address.fromString(WALLET).toScAddress(),
+        functionName: "transfer",
+        args: [],
+      }),
+    ),
+    auth,
+  });
+}
+
+/** Build a signed-shaped tx from operations, so needsSponsorRebuild parses it. */
+function buildTx(ops: xdr.Operation[]): string {
+  const account = new Account(Keypair.random().publicKey(), "0");
+  const b = new TransactionBuilder(account, { fee: "100", networkPassphrase: PASSPHRASE });
+  for (const op of ops) b.addOperation(op);
+  return b.setTimeout(30).build().toXDR();
+}
 
 describe("enforceFeeCap", () => {
   it("accepts a simulated fee at or below the cap", () => {
@@ -69,5 +156,41 @@ describe("consumeSponsorBudget (FIX 3, fails closed)", () => {
     await expect(consumeSponsorBudget("100", budget, "testnet")).rejects.toMatchObject({
       code: "sponsor_budget_exceeded",
     });
+  });
+});
+
+describe("needsSponsorRebuild (routing predicate — RA-9/FIX-1)", () => {
+  it.each(["v2", "v1", "delegates"] as const)(
+    "returns true for a single-op invoke with a %s address credential (the sponsor-rebuild shape)",
+    (kind) => {
+      // V2 is what passkey-kit@0.14 actually signs; all address-bound variants
+      // must route to the sponsor rebuild, none skipped.
+      expect(needsSponsorRebuild(buildTx([invokeOp([kind])]), PASSPHRASE)).toBe(true);
+    },
+  );
+
+  it("returns false when ANY auth entry is source-account (a deploy — relayer handles it)", () => {
+    expect(needsSponsorRebuild(buildTx([invokeOp(["source"])]), PASSPHRASE)).toBe(false);
+    // Mixed: one address + one source-account still fails the every() guard.
+    expect(needsSponsorRebuild(buildTx([invokeOp(["v2", "source"])]), PASSPHRASE)).toBe(false);
+  });
+
+  it("returns false for a multi-op tx (only single-op invokes are rebuilt)", () => {
+    expect(needsSponsorRebuild(buildTx([invokeOp(["v2"]), invokeOp(["v2"])]), PASSPHRASE)).toBe(
+      false,
+    );
+  });
+
+  it("returns false for an invoke with empty auth (nothing to attribute)", () => {
+    expect(needsSponsorRebuild(buildTx([invokeOp([])]), PASSPHRASE)).toBe(false);
+  });
+
+  it("returns false for a non-invokeHostFunction op", () => {
+    const bump = Operation.bumpSequence({ bumpTo: "0" });
+    expect(needsSponsorRebuild(buildTx([bump]), PASSPHRASE)).toBe(false);
+  });
+
+  it("returns false for an unparseable xdr rather than throwing", () => {
+    expect(needsSponsorRebuild("not-an-xdr", PASSPHRASE)).toBe(false);
   });
 });

--- a/services/worker-service/package.json
+++ b/services/worker-service/package.json
@@ -5,7 +5,7 @@
   "description": "Async jobs: deterministic build workers, retries, dead-letter handling, heavy simulations",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
     "start": "tsx --env-file-if-exists=../../.env src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"


### PR DESCRIPTION
A read-only re-audit of the merged remediation (#228/#230) surfaced two **High** findings on the funding path plus a systemic test-fixture defect. This branch closes them. Same rules as prior branches: failing test first, one commit per fix, per-finding `Status: CLOSED` blocks in `docs/security-audit.md`.

Full gate green: **18/18 typecheck, all workspace test suites pass** under CI-mirrored conditions (`TEST_DATABASE_URL` + `CI_REQUIRE_DB=1`).

## 🔴 RA-2 — Spend-budget ceiling was not atomic (proof it's closed)

The rolling-window budget ran check-and-record as one conditional-INSERT. Under READ COMMITTED, N concurrent same-key requests all read the same committed sum, all pass the `WHERE`, and all commit — overshooting the ceiling. This is the **sole binding funding-path control** (the gateway per-IP limit doesn't bind), so the overshoot is a direct sponsor-XLM drain past the FIX-3 ceiling.

**Proven against real Postgres 16** (12 truly-parallel own-connection consumers, ceiling of 1):
- **Before the fix: 10 of 12 inserted** (massive overshoot).
- **After the fix: exactly 1.**

Fix: run check+insert inside a transaction guarded by `pg_advisory_xact_lock(hashtext('<line>:<network>'))` **taken before the aggregate read**. Same-key callers serialize (lock released at commit); different keys never block.

**A second defect was found and fixed: the concurrency test was decorative.** It skipped locally *and* fired `Promise.all` over one drizzle pool — which serializes on the pool, so it never actually raced (it passed even against the broken code). That is why RA-2 shipped. The test is rewritten to use N independent single-connection pools; it now **fails against the pre-fix code and passes with the lock**. CI sets `CI_REQUIRE_DB=1` so the DB integration suites **fail rather than silently skip** if Postgres goes missing — verified: with the DB absent, the suites error out, they do not skip.

## 🔴 RA-1 — Route scope gate matched only the V1 credential string

`scope.ts` and the extension `tx-signer.ts` filtered auth entries on the exact V1 type `sorobanCredentialsAddress`. But `passkey-kit@0.14` **never emits V1** — it upgrades every signed entry in place to `sorobanCredentialsAddressV2`. So the V1-only match:
- **(fail-closed break, live on testnet)** returned no subjects for every real submit → 403 on every legitimate `/wallet/submit`; the extension signer signed nothing.
- **(scope bypass)** skipped an attacker V2 leg in a mixed V1+V2 tx, letting it ride the funded sponsor rebuild past the C1/H1/V2 control.

Both sites now resolve the address across all three address-bound variants (V1, V2, with-delegates). Fixtures are kit-derived (default to V2), with an explicit mixed-V1+V2 bypass test.

## RA-9 — Fixture-defect pattern (the reason RA-1 shipped green)

RA-1 was a test failure as much as a code failure: `scope.test.ts` built V1 fixtures, so the suite validated the bug. Auditing every XDR-decoding assertion for the same class:
- **FIX 2** derivation gate — kit-derived, robust ✓
- **FIX 1** `needsSponsorRebuild` — had **no test**; added one (V2/delegates/source-account/op-guards)
- **L1** `buildAddPolicyXdr` — built a 3-element Signer vec; reshaped to the kit's real **5-element** `Policy` tuple with an arity assertion

## 🟡 RA-4 — Persistence fail-closed guard was inert on the deploy targets

FIX 7 gated fail-closed on `NODE_ENV === "production"`, but **nothing sets `NODE_ENV=production`** on the deploy targets — so the guard silently degraded to in-memory (fail-open by default), quietly undoing FIX 7. This compounds with RA-2: an atomic ledger is half a fix if the ledger may not survive a DB blip.

Fixed by **inverting the default** rather than patching a manifest: in-memory now requires an explicit signal (`NODE_ENV=development|test` or `ALLOW_INMEMORY=1`); an **unset** `NODE_ENV` fails closed. Dev scripts set `NODE_ENV=development`; deployed `start` stays unset and fails closed unless a DB is wired.

A repo-wide inertness sweep (19 env checks, 7 fail-open) found **verification-service had no backstop at all** — now fixed — and a new latent finding **RA-10** (attestor mainnet guard bypassed by an unset passphrase), filed and tracked with M5.

## Notes
- Branched on the #230 tip; now stacks cleanly on `main` (which #230 merged into).
- **M1** (session capability), **RA-5** (cleanup liabilities), **RA-6** (detach wiring) are deliberately **not** here — they go on a separate `security/session-capability` branch.
- Mainnet remains **NO-GO** until M1 lands and the two V6 dashboard facts (L2 port firewalling, M9 autoDeploy/branch-protection) are confirmed; every verdict stays conditional on the unaudited `vellar-sdk`/`passkey-kit` (the V1→V2 upgrade that drives RA-1 lives in that unread kit).

## Out-of-scope commit carried here: cleanup-wizard e2e fix

`fix(web): un-latch the cleanup wizard's cancel ref on remount` is **not** a
funding-path change — it is here because it was blocking this PR's CI.

Both mocked cleanup e2e specs (`apps/web/e2e/cleanup.spec.ts`) were failing: the
wizard reached the merge card and then sat on *"Waiting for this transaction to
appear on the network…"* forever, so `/Account closed/` never rendered. The bug
is in `apps/web/app/cleanup/page.tsx` — the unmount effect latched
`cancelledRef` to `true` and nothing ever reset it, making the ref write-once.
React StrictMode mounts → unmounts → remounts, so the remounted wizard began
already cancelled: `watch()` returned before it could advance the stage.

This is **pre-existing on `main`**, introduced by #230's Next `16.2.10 → 16.3.0`
bump (dev-server StrictMode behaviour), not by anything in this branch. `main`'s
own run just fails at the format check first and never reaches the e2e step, so
it is currently masked there.

Covered by a new StrictMode-remount case in `page.test.tsx` whose `watch` mock
honours the `cancelled` callback the way the real watcher does — it fails
without the ref reset and passes with it.

**Test plan (local, this branch):** 6/6 `@ci` Playwright specs green (was 4
passed / 2 failed) · 60/60 `@vellar/web` unit tests · `tsc --noEmit` clean ·
`next build` clean.

**Caveat:** happy to split this into its own PR against `main` if you'd rather
keep this branch purely funding-path — it is a self-contained 5-line change plus
its test.
