### PR TITLE
Session capability + cleanup ordering + policy-detach test (M1/RA-3, RA-5, RA-6)

### DIFF
--- a/apps/web/lib/connector-factory.ts
+++ b/apps/web/lib/connector-factory.ts
@@ -9,7 +9,7 @@ import {
 } from "vellar-sdk";
 import { walletConfig } from "./config";
 import { createHttpWalletBackend } from "./http-backend";
-import { policyAttachArgs } from "./policy-signer";
+import { createPolicySignerActions } from "./policy-signer";
 
 // Builds the real PasskeyKit-backed wallet runtime. The connector and the
 // payment client MUST share one PasskeyKit instance — the connected passkey's
@@ -113,37 +113,34 @@ export function getWalletRuntime(): Promise<WalletRuntime> {
         });
         return { hash, expiresAt: new Date(expirationSeconds * 1000).toISOString() };
       },
+      // Policy attach/detach is wired through createPolicySignerActions
+      // (policy-signer.ts) so the standalone-signer + recovery-key invariants
+      // are unit-tested at the WIRING layer (RA-6), not just at the pure
+      // policyAttachArgs. The browser-only passkey-kit enums are injected.
       async attachPolicy(policyContractId) {
-        const { SignerStore } = await import("passkey-kit");
-        // Standalone policy signer (SignerLimits = None) — see policy-signer.ts
-        // and security-audit.md V3: this is what lets the admin passkey detach a
-        // rejecting policy without its consent. policyAttachArgs pins the shape.
-        const args = policyAttachArgs(policyContractId);
-        const store = args.store === "Persistent" ? SignerStore.Persistent : SignerStore.Temporary;
-        const tx = await kit.addPolicy(args.policyContractId, args.limits, store, args.expiration);
-        const signed = (await kit.sign(tx)) ?? tx;
-        const { hash } = await backend.submitTransaction({
-          signedXdr: typeof signed === "string" ? signed : (signed as { toXDR(): string }).toXDR(),
-          network: config.network,
-        });
-        return { hash };
+        const { SignerKey, SignerStore } = await import("passkey-kit");
+        return policySignerActions({ SignerKey, SignerStore }).attachPolicy(policyContractId);
       },
       async detachPolicy(policyContractId) {
-        // Recovery path (security-audit.md V3 / FIX 5): the admin passkey removes
-        // the policy signer WITHOUT the policy's consent — the wallet's
-        // is_sole_self_removal exception skips a rejecting policy for its own
-        // removal, so this un-bricks a wallet stuck behind a reject-everything
-        // policy (e.g. verified_only with no live attestation).
-        const { SignerKey } = await import("passkey-kit");
-        const tx = await kit.remove(SignerKey.Policy(policyContractId));
-        const signed = (await kit.sign(tx)) ?? tx;
-        const { hash } = await backend.submitTransaction({
-          signedXdr: typeof signed === "string" ? signed : (signed as { toXDR(): string }).toXDR(),
-          network: config.network,
-        });
-        return { hash };
+        const { SignerKey, SignerStore } = await import("passkey-kit");
+        return policySignerActions({ SignerKey, SignerStore }).detachPolicy(policyContractId);
       },
     };
+
+    /** Bind the extracted actions to this runtime's kit + backend + network,
+     * given the lazily-imported passkey-kit enums. */
+    function policySignerActions(enums: {
+      SignerKey: { Policy(id: string): unknown };
+      SignerStore: { Persistent: unknown; Temporary: unknown };
+    }) {
+      return createPolicySignerActions({
+        kit: kit as unknown as Parameters<typeof createPolicySignerActions>[0]["kit"],
+        backend,
+        network: config.network,
+        SignerKey: enums.SignerKey,
+        SignerStore: enums.SignerStore,
+      });
+    }
   })();
   return runtimePromise;
 }

--- a/apps/web/lib/policy-signer.test.ts
+++ b/apps/web/lib/policy-signer.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { policyAttachArgs } from "./policy-signer";
+import { describe, expect, it, vi } from "vitest";
+import { createPolicySignerActions, policyAttachArgs } from "./policy-signer";
 
 describe("policyAttachArgs — standalone-signer invariant (V3/FIX 5)", () => {
   it("attaches a policy with NO SignerLimits (limits === undefined)", () => {
@@ -19,5 +19,90 @@ describe("policyAttachArgs — standalone-signer invariant (V3/FIX 5)", () => {
 
   it("passes the policy contract id through unchanged", () => {
     expect(policyAttachArgs("CPOLICY").policyContractId).toBe("CPOLICY");
+  });
+});
+
+// RA-6: the invariant was pinned ONLY at the pure helper. The WIRING — what the
+// connector actually passes to kit.addPolicy / kit.remove — was untested, so a
+// refactor that inlined a SignerLimits map (making the policy a required
+// co-signer) would ship green. These tests drive the real attach/detach actions
+// with a fake kit and assert what the kit is actually called with.
+describe("createPolicySignerActions — attach/detach wiring (RA-6)", () => {
+  function fakes() {
+    const calls = {
+      addPolicy: [] as unknown[][],
+      remove: [] as unknown[],
+      signed: 0,
+      submitted: [] as { signedXdr: string; network: string }[],
+    };
+    const kit = {
+      addPolicy: vi.fn((...args: unknown[]) => {
+        calls.addPolicy.push(args);
+        return Promise.resolve("attach-xdr");
+      }),
+      remove: vi.fn((signerKey: unknown) => {
+        calls.remove.push(signerKey);
+        return Promise.resolve("detach-xdr");
+      }),
+      sign: vi.fn((tx: string) => {
+        calls.signed++;
+        return Promise.resolve(`signed:${tx}`);
+      }),
+    };
+    // Fake SignerKey.Policy so we can assert detach targets the policy key.
+    const SignerKey = { Policy: (id: string) => ({ tag: "Policy", id }) };
+    const SignerStore = { Persistent: "PERSISTENT", Temporary: "TEMPORARY" };
+    const backend = {
+      submitTransaction: vi.fn((req: { signedXdr: string; network: string }) => {
+        calls.submitted.push(req);
+        return Promise.resolve({ hash: "txhash" });
+      }),
+    };
+    return { calls, kit, backend, SignerKey, SignerStore };
+  }
+
+  it("attachPolicy calls kit.addPolicy with limits === undefined (standalone SignerLimits(None))", async () => {
+    const { calls, kit, backend, SignerKey, SignerStore } = fakes();
+    const actions = createPolicySignerActions({
+      kit: kit as never,
+      backend: backend as never,
+      network: "testnet",
+      SignerKey: SignerKey as never,
+      SignerStore: SignerStore as never,
+    });
+
+    const res = await actions.attachPolicy("CPOLICY");
+
+    expect(calls.addPolicy).toHaveLength(1);
+    const [policyId, limits, store, expiration] = calls.addPolicy[0]!;
+    expect(policyId).toBe("CPOLICY");
+    // THE load-bearing assertion at the wiring layer: NO SignerLimits map.
+    expect(limits).toBeUndefined();
+    expect(store).toBe(SignerStore.Persistent);
+    expect(expiration).toBeUndefined();
+    // It signs and submits on the configured network.
+    expect(calls.signed).toBe(1);
+    expect(calls.submitted[0]).toMatchObject({ network: "testnet" });
+    expect(res.hash).toBe("txhash");
+  });
+
+  it("detachPolicy removes exactly SignerKey.Policy(contractId) — the consent-free recovery key", async () => {
+    const { calls, kit, backend, SignerKey, SignerStore } = fakes();
+    const actions = createPolicySignerActions({
+      kit: kit as never,
+      backend: backend as never,
+      network: "testnet",
+      SignerKey: SignerKey as never,
+      SignerStore: SignerStore as never,
+    });
+
+    await actions.detachPolicy("CPOLICY");
+
+    expect(calls.remove).toHaveLength(1);
+    // Removal must target the Policy signer key (not some other key), or the
+    // is_sole_self_removal recovery path doesn't apply.
+    expect(calls.remove[0]).toEqual({ tag: "Policy", id: "CPOLICY" });
+    expect(calls.signed).toBe(1);
+    expect(calls.submitted[0]).toMatchObject({ network: "testnet" });
   });
 });

--- a/apps/web/lib/policy-signer.ts
+++ b/apps/web/lib/policy-signer.ts
@@ -38,3 +38,73 @@ export function policyAttachArgs(policyContractId: string): PolicyAttachArgs {
     expiration: undefined,
   };
 }
+
+// --- Attach/detach WIRING (RA-6) --------------------------------------------
+//
+// The invariant above (standalone SignerLimits(None) → detachable) was pinned
+// only at the pure helper; the code that actually calls kit.addPolicy/kit.remove
+// lived inline in connector-factory and was untested — so a refactor inlining a
+// SignerLimits map would ship green. The attach/detach flow is extracted here so
+// the wiring is unit-tested with a fake kit: attach MUST pass limits===undefined,
+// and detach MUST remove exactly SignerKey.Policy(id) (the key the wallet's
+// is_sole_self_removal exception recognizes). The passkey-kit enums are injected
+// (they touch browser APIs) so this module stays SSR/test-safe.
+
+/** Minimal structural view of the passkey-kit surface the actions use. */
+export interface PolicySignerKit {
+  addPolicy(
+    policyContractId: string,
+    limits: undefined,
+    store: unknown,
+    expiration: undefined,
+  ): Promise<unknown>;
+  remove(signerKey: unknown): Promise<unknown>;
+  sign(tx: unknown): Promise<unknown>;
+}
+
+export interface PolicySignerBackend {
+  submitTransaction(req: { signedXdr: string; network: string }): Promise<{ hash: string }>;
+}
+
+export interface PolicySignerDeps {
+  kit: PolicySignerKit;
+  backend: PolicySignerBackend;
+  network: string;
+  /** passkey-kit SignerKey (SignerKey.Policy) — injected (browser-only). */
+  SignerKey: { Policy(id: string): unknown };
+  /** passkey-kit SignerStore enum — injected (browser-only). */
+  SignerStore: { Persistent: unknown; Temporary: unknown };
+}
+
+function toXdr(signed: unknown, fallback: unknown): string {
+  const value = signed ?? fallback;
+  return typeof value === "string" ? value : (value as { toXDR(): string }).toXDR();
+}
+
+/** The policy attach/detach actions, wired to a kit + backend. Extracted from
+ * connector-factory so the standalone-signer + recovery-key invariants are
+ * tested at the WIRING layer (RA-6), not just at policyAttachArgs. */
+export function createPolicySignerActions(deps: PolicySignerDeps) {
+  const { kit, backend, network, SignerKey, SignerStore } = deps;
+  return {
+    async attachPolicy(policyContractId: string): Promise<{ hash: string }> {
+      // Standalone policy signer (SignerLimits = None) — policyAttachArgs pins
+      // the shape; passing limits here would make it a required co-signer and
+      // risk an unremovable rejecting policy (V3).
+      const args = policyAttachArgs(policyContractId);
+      const store = args.store === "Persistent" ? SignerStore.Persistent : SignerStore.Temporary;
+      const tx = await kit.addPolicy(args.policyContractId, args.limits, store, args.expiration);
+      const signed = await kit.sign(tx);
+      return backend.submitTransaction({ signedXdr: toXdr(signed, tx), network });
+    },
+
+    async detachPolicy(policyContractId: string): Promise<{ hash: string }> {
+      // Recovery path (V3 / FIX 5): remove the policy signer WITHOUT the policy's
+      // consent. Must target SignerKey.Policy so the wallet's
+      // is_sole_self_removal exception applies.
+      const tx = await kit.remove(SignerKey.Policy(policyContractId));
+      const signed = await kit.sign(tx);
+      return backend.submitTransaction({ signedXdr: toXdr(signed, tx), network });
+    },
+  };
+}

--- a/docs/architecture-analysis.md
+++ b/docs/architecture-analysis.md
@@ -1,0 +1,306 @@
+# Vellar Wallet — Architecture Analysis
+
+> Read-only architectural analysis of the Vellar Stellar smart-wallet monorepo.
+> No files were modified to produce it. Every claim carries a `file:line` citation;
+> inferences are marked `(inferred)`. Produced by 12 parallel subsystem readers +
+> 2 cross-cutting sweeps (auth end-to-end; data/secret handling), reconciled by a
+> completeness critic that walked the repo tree and spot-checked load-bearing claims.
+
+**The one-line summary:** Vellar's backend has _no application-layer authentication or
+authorization on any route_ — this is deliberate. Passkeys sign client-side, the backend
+is a stateless relayer, and the real authorization lives on-chain (`__check_auth` + policy
+contracts) and in the extension's per-origin grant model. The exposure is concentrated in
+the side effects that are _not_ gated on-chain (sponsor-fund spend, session ops) and in the
+fact that the gateway trust boundary is enforced by network topology, not by code.
+
+---
+
+## 1. Stack
+
+A pnpm + Turborepo TypeScript monorepo (Node ≥ 22) fronting a Rust/Soroban contract
+workspace. The backend runs TypeScript directly via `tsx` — no build step in production.
+
+**Languages & runtimes**
+
+- TypeScript 5.9, ESM throughout; pnpm `11.9.0`, Turborepo `2.5.4` — `package.json:4-21`, `pnpm-workspace.yaml:1-4`
+- Node ≥ 22 in `engines`, but `render.yaml` pins `NODE_VERSION=20` for the deployed backend — a direct conflict nothing enforces — `package.json:5-7`, `render.yaml:26-28`
+- Rust 1.94.0, target `wasm32v1-none`, `soroban-sdk 27.0.0` — `contracts/rust-toolchain.toml:2-3`, `contracts/Cargo.toml:28`
+
+**Frameworks & libraries**
+
+- Backend: Fastify 5 on every service; zod 4 for input validation; Drizzle ORM 0.45 + `pg` — `services/*/package.json`, `services/wallet-service/src/server.ts:20-42`
+- Web: Next.js 16 + React 19 (App Router, client-only), TanStack Query, Zustand, react-hook-form + zod, Tailwind 4 — `apps/web/package.json:17-45`
+- Extension: WXT 0.20 (Manifest V3) + React 19 popup — `apps/extension/package.json:23-33`, `wxt.config.ts`
+- Wallet/passkey: third-party `passkey-kit ^0.14.0` does the real WebAuthn ceremonies and Soroban auth-entry signing, in-browser — `apps/web/lib/connector-factory.ts:52-61`, `apps/extension/lib/tx-signer.ts:51-61`
+
+**Databases & external services**
+
+- Postgres 16 (per-service Drizzle migrations); documented in-memory fallback when `DATABASE_URL` is unset. Redis 7 is provisioned in local docker-compose but no runtime code depends on it, and no deploy manifest provisions it — `infra/docker/docker-compose.yml:6-32`, `README.md:37-39`
+- OpenZeppelin Relayer (testnet) for fee-sponsored submission; Soroban RPC + Horizon (testnet defaults) — `services/wallet-service/src/config.ts:18-27`, `services/lifecycle-service/src/horizon.ts:44`
+- Deterministic build image (`rust:1.94.0` + `stellar-cli 26.1.0`) run by the worker for byte-for-byte contract verification — `infra/docker/verification-builder.Dockerfile:21,26`
+
+**On-chain components**
+
+- Three deployed Soroban contracts: two spending-limit policy templates, a verified-recipient policy, and an attestation registry — `contracts/Cargo.toml:13-18`
+- The smart account itself is external: the deployed wallet is `kalepail/passkey-kit`'s audited wasm (pinned by git commit `50981cc`); this repo's `contracts/smart-account/` is an empty reserved directory, so `__check_auth` / secp256r1 WebAuthn verification is **not in-repo** — `contracts/Cargo.toml:9-10,40`
+
+**Deploy topology (important)**
+
+Three deploy manifests coexist. `vercel.json` deploys only `apps/web`; `railway.json` and
+`render.yaml` both deploy the combined single-process `@vellar/all-in-one` backend
+(gateway + wallet + lifecycle + policy + verification in one Node process).
+**worker-service and permission-service are deployed nowhere.** With no worker in the hosted
+topology, contract-verification jobs sit in `status='submitted'` forever, and there is no
+on-chain attestor. — `services/all-in-one/package.json:12-18`, `render.yaml`, `railway.json`
+
+---
+
+## 2. Component map
+
+**Apps**
+
+| Module                       | Owns                                                                                                                                                                                                                                                          | Depends on                                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `apps/web` (Next.js 16)      | Client-only frontend. Zero server surface — no `app/api` handlers, no middleware, no server actions. Passkey ceremonies + signing in-browser; POSTs signed XDR to the gateway; reads balances/tx-status directly from RPC/Horizon.                            | passkey-kit, vellar-sdk (npm), @vellar/{provider-sdk, verification-sdk, ui, types}, api-gateway |
+| `apps/extension` (WXT / MV3) | Companion signing surface. Injects `window.vela` into every page via a MAIN-world content script; relays zod-validated envelopes through an isolated bridge to a background worker; enforces per-origin grants + explicit popup approval for every signature. | passkey-kit, @vellar/provider-sdk, device WebCrypto key, Soroban RPC                            |
+| `apps/docs` (markdown)       | 8 git-tracked docs (API reference, security model, core flows). Documentation-only, not a workspace member — but it _is_ the only product spec that ships in git history.                                                                                     | —                                                                                               |
+
+**Shared packages**
+
+| Package                                       | Status & role                                                                                                                                                                                                                                                                                                     |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@vellar/service-kit`                         | **Shared backend bootstrap** — health route, structured event log, DB-connect wrapper with credential redaction, listen/shutdown lifecycle, Prometheus metrics. Provides **no** auth, CORS, rate-limit, CSRF, or body validation; all opt-in helpers, default bind `0.0.0.0`. `packages/service-kit/src/index.ts` |
+| `@vellar/provider-sdk`                        | The real dApp↔extension wire protocol: zod schemas for 6 methods, page-side provider, per-origin permission model + `normalizeOrigin`. Shared by extension and web.                                                                                                                                               |
+| `@vellar/passkey`                             | WebAuthn _support detection_ + error normalization **only** — no credential create/assert. The real ceremonies live in `passkey-kit`. `packages/passkey/src/support.ts`                                                                                                                                           |
+| `@vellar/verification-sdk`                    | Fetch client for the verification API + trust-signal label mapping.                                                                                                                                                                                                                                               |
+| `@vellar/types`                               | Dependency-free domain model (session, policy schema, verification records, cleanup plans).                                                                                                                                                                                                                       |
+| `@vellar/ui`                                  | One component: `TrustBadge`.                                                                                                                                                                                                                                                                                      |
+| `@vellar/policy-sdk`, `@vellar/lifecycle-sdk` | **Empty stubs** (`export {}`). Policy-client work was deliberately shipped inside the external `vellar-sdk` npm package instead. `packages/policy-sdk/src/index.ts:1-3`, `BUILD-PLAN.md:175`                                                                                                                      |
+
+> Note: the formerly-planned `packages/wallet-sdk` was deleted; web + extension now consume
+> the externally published `vellar-sdk ^0.4.0` (a separate repo, not auditable here). The root
+> CLAUDE.md repo map and technical-doc.md still list `wallet-sdk` — they are stale on this
+> point. `docs/decisions.md:214-224`
+
+**Backend services**
+
+| Service                | Owns                                                                                                                                                                                                | Port           |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `api-gateway`          | The single public entry point. helmet, per-IP rate limit, CORS allowlist, body-size cap, JSON-content-type CSRF check, then a transparent reverse proxy of 4 path prefixes. **No auth logic.**      | 4000           |
+| `wallet-service`       | keyId→contractId mapping, session records, audit log, relays client-signed XDR. Holds the fee-sponsor key.                                                                                          | 4001           |
+| `lifecycle-service`    | Stateless classic-account cleanup/merge _planner_; builds unsigned XDR, never signs or submits.                                                                                                     | 4002           |
+| `policy-service`       | Validate/generate policy definitions; sponsor-funded on-chain policy-instance deploys.                                                                                                              | 4003           |
+| `verification-service` | Accepts contract-source submissions, persists them; the DB row _is_ the job queue.                                                                                                                  | 4004           |
+| `worker-service`       | Polls the shared DB, rebuilds contracts in a sandboxed Docker container, compares wasm hashes, mirrors verdicts on-chain. Holds the attestor key — deliberately isolated from sponsor-key services. | 4005 (metrics) |
+| `permission-service`   | **Empty stub** (`export {}`). The dApp-permission store it was named for lives entirely in the extension.                                                                                           | —              |
+| `all-in-one`           | Not a server — a process shim that `await import`s five services into one process for demo hosting. Excludes the worker (untrusted builds must not share a process with sponsor keys).              | $PORT          |
+
+**Contracts (Soroban / Rust)**
+
+- **spending-limit / token-spending-limit** — cumulative rolling-window allowance over SEP-41 transfers; the token-scoped variant binds the budget to one token. Evaluated as a required co-signer inside the wallet's `__check_auth`. `contracts/policy-templates/spending-limit/src/lib.rs:205-305`
+- **verified-recipient** — rejects any authorization touching a contract without a live attestation; makes a cross-contract `is_verified` call per context. `contracts/policy-templates/verified-recipient/src/lib.rs:158-211`
+- **attestation-registry** — a single rotatable attestor writes time-bounded `(contract, wasm_hash, expires_ledger)` records; config is constructor-immutable, no upgrade/setter functions. `contracts/attestation-registry/src/lib.rs:124-180`
+
+---
+
+## 3. Data flow
+
+Every mutating flow follows the same shape: the browser or extension does the signing, the
+backend relays already-signed XDR, and Stellar's `__check_auth` is the real gate. Validation
+at the services is zod shape-checking only.
+
+**Backend HTTP entry points** (every route is reachable unauthenticated — see §5)
+
+| Method | Route                                               | Enters → validation → touches → leaves                                                                                                                                                                                            |
+| ------ | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| POST   | `/wallet/create`                                    | {keyId, contractId, network, signedTx} (zod). Submits signedTx _before_ persisting → relayer or sponsor-RPC → writes wallets + session + audit rows. `wallet-service/src/server.ts:76`                                            |
+| POST   | `/wallet/connect`                                   | {keyId, network}. Looks up wallet, mints a session UUID. **No WebAuthn assertion verified** — possession of a keyId string is sufficient. `wallet-service/src/server.ts:109`                                                      |
+| POST   | `/wallet/submit`                                    | {signedXdr, network}. Submits arbitrary XDR; the sponsor path rebuilds address-auth txs around the server sponsor account at a hardcoded 10,000,000-stroop fee bid. `wallet-service/src/server.ts:128`, `sponsor.ts:26-60`        |
+| GET    | `/wallet/session/:id`                               | Returns a session record by UUID. `wallet-service/src/server.ts:154`                                                                                                                                                              |
+| GET    | `/wallet/sessions`                                  | ?contractId&network → lists **all** sessions for any supplied contractId. No ownership check. `wallet-service/src/server.ts:163`                                                                                                  |
+| DELETE | `/wallet/session/:id`                               | Revokes any session by id. Privileged, unauthenticated. `wallet-service/src/server.ts:172`                                                                                                                                        |
+| POST   | `/policies/validate` · `/generate`                  | Validate against a fixed template registry; generate a content-hashed policy record. `policy-service/src/server.ts:93-119`                                                                                                        |
+| POST   | `/policies/:id/simulate`                            | Dry-run the instance deploy (build + simulate, no submit). `policy-service/src/server.ts:124`                                                                                                                                     |
+| POST   | `/policies/:id/deploy-instance`                     | Wallet address (C-address regex) → **sponsor-funded on-chain deploy** bound to that address, signed by `SPONSOR_SECRET_KEY`. No proof the caller owns the wallet. `policy-service/src/server.ts:156`, `deploy.ts:102`             |
+| POST   | `/policies/deploy`                                  | Marks any policyId "deployed" with a **client-supplied txHash** — never verified on-chain. `policy-service/src/server.ts:206`                                                                                                     |
+| POST   | `/lifecycle/inspect` · `plan` · `execute` · `merge` | Reads any classic account from Horizon; builds **unsigned** cleanup/merge XDR for any account→destination. Merge refuses if blockers remain. Safe only because the user must still sign. `lifecycle-service/src/server.ts:40-133` |
+| POST   | `/verification/submit`                              | {contractId, repoUrl/commit \| archiveRef, toolchain}. `repoUrl` is `z.string().url()` with no host allowlist → SSRF-shaped input flows to the build worker. Persists a job row. `verification-service/src/server.ts:149`, `:95`  |
+| GET    | `/verification/:contractId` · `/status`             | Public read — the trust-badge lookup for web + extension. `verification-service/src/server.ts:193-222`                                                                                                                            |
+| GET    | `/health`, `/metrics`                               | On every service, unauthenticated. `/metrics` is Prometheus text. `packages/service-kit/src/index.ts:15-17`, `metrics.ts:131`                                                                                                     |
+
+**Non-HTTP entry points**
+
+- **Worker build-poll loop** — self-rescheduling `setTimeout` (250ms busy / 5s idle). Claims `status='submitted'` rows via `FOR UPDATE SKIP LOCKED`; Postgres is the queue (no Redis/BullMQ). `worker-service/src/loop.ts:75-106`, `pg-job-store.ts:19-30`
+- **Attestation upgrade sweep** — `setInterval`, 10-min default, only when attestor key + registry id are set; revokes attestations for upgraded/vanished contracts. `worker-service/src/index.ts:105-107`
+- **Extension provider methods** (message handlers, not HTTP): `connect · sign_transaction · get_address · disconnect · pair · pair_status`, routed page→content-script→background. `apps/extension/lib/router.ts:37-99`
+- **Contract public functions** — registry `upsert/revoke/set_attestor` (attestor-auth) + unauthenticated reads; each policy's `install/uninstall/policy__/config`. `contracts/*/src/lib.rs`
+- **CI PR-guard workflows** — two `pull_request_target` jobs auto-close non-maintainer PRs (to main, or touching files outside `contrib/`). No cron schedules exist anywhere. `.github/workflows/close-prs-*.yml`
+
+**The two signing flows, end to end**
+
+- **web · send / policy / pairing:** Client builds tx → passkey-kit signs auth entries in-browser (WebAuthn) → explicit review dialog → POST signed XDR to `/wallet/submit` → server relays → RPC polling tracks confirmation. The server never holds the passkey.
+- **extension · dApp signing:** Page → `window.postMessage` → isolated bridge → background derives **trusted origin from the sender** (never page data) → router checks a per-origin grant → popup approval (every tx) → device Ed25519 key signs → signed XDR returned. No silent signing.
+
+---
+
+## 4. Trust boundaries
+
+Two boundaries are correctly enforced (the extension origin model and the on-chain
+`__check_auth`). One is enforced only by network topology, not by code — and that gap is
+where the exposure concentrates.
+
+```
+Browser/dApp  ──[CORS·ratelimit·CSRF]──►  api-gateway  ──[NO AUTH·plain HTTP]──►  downstream services  ──[sponsor/relayer key]──►  Stellar chain
+(untrusted)      (authenticates origin,      (the one         (bind 0.0.0.0, trust           (signed XDR;          (__check_auth +
+                  not user)                   server-side       anything on the port)          value auth is          policy contracts —
+                                              boundary)                                         here)                  the real gate)
+```
+
+**CRITICAL GAP — gateway boundary is topology-only.** Every downstream service binds
+`0.0.0.0` with no shared secret, signed header, or mTLS. If any downstream port (4001-4004)
+is exposed, it bypasses _all_ gateway controls — CORS, rate-limit, body cap, CSRF. In the
+`all-in-one` deployment they are co-located on localhost, but each still listens on its own
+`0.0.0.0` port; isolation depends entirely on the platform publishing only `$PORT`.
+`api-gateway/src/server.ts:122-152`, `service-kit/src/index.ts:88`
+
+**Boundaries ranked by how well they hold**
+
+| Strength      | Boundary                        | Enforcement                                                                                                                                                                                                          |
+| ------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| STRONG        | Page → extension background     | Origin derived from the browser-supplied content-script sender, never page data; every message zod-validated; every signature needs popup approval. `background.ts:41-44`, `permissions.ts:38-49`                    |
+| STRONG        | Service → Stellar chain         | On-chain `__check_auth` validates passkey signatures; wrongly-signed XDR simply fails. Delegated entirely to the chain. `wallet-service/src/server.ts:128-152`                                                       |
+| STRONG        | Untrusted source → build worker | Builds run `--network=none`, `--read-only`, `cap-drop=ALL`, non-root, resource-capped; worker kept out of the sponsor-key process by design. `worker-service/src/executor.ts:188-222`                                |
+| ORIGIN-ONLY   | Internet → api-gateway          | CORS allowlist + per-IP rate limit + 1 MiB body cap + JSON-content-type CSRF check. Authenticates origin, not identity; rate-limit is in-memory per-process with no `trustProxy`. `api-gateway/src/server.ts:70-117` |
+| TOPOLOGY-ONLY | Gateway → downstream services   | No authentication of any kind. Reachability is the only control. `api-gateway/src/server.ts:122-152`                                                                                                                 |
+| UNENFORCED    | Caller → sponsor-funded spend   | `/policies/:id/deploy-instance` and the `/wallet/submit` sponsor path let any unauthenticated caller spend sponsor funds for an arbitrary wallet/contract. `policy-service/src/server.ts:156`, `sponsor.ts:26-60`    |
+
+---
+
+## 5. AuthN / AuthZ model
+
+The backend has **no application-layer authentication or authorization on any route.** This
+was grep-verified: across all services, the only match for `authorization|bearer|jwt|x-api-key`
+is a Soroban XDR type name (`SorobanAuthorizationEntry`).
+
+**The model.** Identity is established client-side by the WebAuthn/passkey ceremony (via
+`passkey-kit`), which produces signed Stellar XDR. The backend never verifies a WebAuthn
+attestation or assertion, issues no token, and checks no caller identity — it is a stateless
+relayer. Security rests on (a) Stellar validating the passkey-signed on-chain auth entry, and
+(b) the extension's per-origin grant model. `docs/decisions.md:441`, `wallet-service/src/server.ts:16-18`
+
+**What passes for a session.** A "session" is an opaque `crypto.randomUUID()` row
+(`wallet_sessions`) returned to the client at create/connect. Since RA-3/M1 it is a **bearer
+capability, scoped to the session routes only**: possession authorizes listing / reading /
+revoking the sessions of the account that session is bound to, and **nothing else** — it grants
+no signing or funding authority (those remain on-chain via `__check_auth`), and no other route
+reads it. It **expires on a 7-day sliding window** (matching the device signer's 7-day expiry;
+`lastActiveAt` + `expiresAt` slide forward only on an authorized use), and it travels only in the
+`Authorization: Bearer` header / request body — never a URL — so the credential never lands in a
+request log. `wallet-service/src/server.ts` (session routes), `db/schema.ts` (`expires_at`)
+
+**Where authorization is real:**
+
+- **wallet-service · session capability** — the session id is a bearer capability for the session
+  routes (list / read / revoke), bound to `contractId + network`, 7-day sliding expiry (RA-3/M1).
+  It is deliberately narrow: it authorizes ONLY those routes and is not honored anywhere else, so it
+  does not become the app-layer auth the design otherwise omits. `wallet-service/src/server.ts`
+- **extension · per-origin grants** — `connect` / `view_address` / `sign` capabilities, keyed to `origin + network`. A `sign` grant only lets a dApp _ask_; every individual transaction still requires fresh popup approval. Pairing a different address wipes all grants. `router.ts:87-94`, `state.ts:56-61`
+- **on-chain · policy contracts** — the device signer is a **7-day expiring Ed25519 co-signer**; policy contracts enforce spending limits and recipient allowlists inside `__check_auth`; contexts targeting the wallet's own admin surface are always rejected. `connector-factory.ts:87-106`, `spending-limit/src/lib.rs:235-239`
+
+**Unauthenticated privileged actions.** Because value transfer is gated on-chain, most
+unauthenticated routes leak or waste rather than steal. These are the exceptions where the
+side effect is real:
+
+| Impact     | Action                               | Consequence                                                                                                                                        |
+| ---------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FUNDS      | `POST /policies/:id/deploy-instance` | Any caller makes the sponsor pay to deploy a policy instance bound to an arbitrary wallet — no ownership proof. `policy-service/src/server.ts:156` |
+| FUNDS      | `POST /wallet/submit` (sponsor path) | Any caller submits address-auth XDR and the server pays fees (10M-stroop bid) for arbitrary contracts. `sponsor.ts:26-60`                          |
+| INTEGRITY  | `DELETE /wallet/session/:id`         | Anyone with a session id revokes it — no ownership check. `wallet-service/src/server.ts:172`                                                       |
+| DISCLOSURE | `GET /wallet/sessions`               | Lists all sessions for any (public) contractId supplied in the query. `wallet-service/src/server.ts:163`                                           |
+| INTEGRITY  | `POST /policies/deploy`              | Marks any policy "deployed" with an unverified client-supplied txHash. `policy-service/src/server.ts:206`                                          |
+| IDENTITY   | `POST /wallet/connect`               | keyId lookup alone yields a session — no proof-of-possession of the credential. `wallet-service/src/server.ts:109`                                 |
+
+**CORS & CSRF posture.** Applied **only at the gateway**: CORS restricted to configured
+origins (`GET/POST/DELETE`); CSRF mitigated by requiring `application/json` on mutations (415
+otherwise), valid because the API is cookieless. Downstream services register no CORS and
+re-check nothing — they rely on being unreachable. The client attaches no cookie,
+Authorization header, or `credentials` option, so the cookieless-CSRF rationale is internally
+consistent. `api-gateway/src/server.ts:81-116`, `http-backend.ts:56-62`
+
+---
+
+## 6. Data classification
+
+The design deliberately avoids server custody of user keys — passkeys sign client-side and
+the backend only ever receives signed XDR. But the backend holds three classes of operational
+Stellar secrets, and real testnet secret values sit in the working tree (all gitignored, none
+in git history).
+
+**Secrets & keys**
+
+| Secret                | Held by                        | Storage / exposure                                                                                                                                                                                                                       |
+| --------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SPONSOR_SECRET_KEY`  | wallet-service, policy-service | Stellar secret funding fee-sponsorship + policy deploys. Env-injected; a real testnet value is in the local gitignored `.env`. Compromise = drain of the sponsor account. `sponsor.ts:43`, `deploy.ts:102`                               |
+| `RELAYER_API_KEY`     | wallet-service                 | OpenZeppelin relayer credential. Transmitted server-side to the relayer over HTTPS; never shipped to the browser by design. `config.ts:23`, `relayer-passkey.ts:14-17`                                                                   |
+| `ATTESTOR_SECRET_KEY` | worker-service _only_          | On-chain attestation signer, deliberately never co-located with sponsor keys. **Absent from `.env.example` and every deploy manifest** — its provisioning is undetermined. `worker-service/src/config.ts:42`, `registry-submitter.ts:39` |
+| Device Ed25519 key    | extension (client)             | **Non-extractable** WebCrypto key in IndexedDB — signs but can never be exported, even by extension code. Only the public key hex crosses to the web app. Strong handling. `device-key.ts:23-27,66`                                      |
+| Passkey private key   | platform authenticator         | Never leaves the device; the server never sees it. No server key custody by design. `docs/decisions.md:441`                                                                                                                              |
+| `VERCEL_OIDC_TOKEN`   | working tree                   | Live short-lived JWTs in `.env.local` / `apps/web/.env.local`. Gitignored, never in history; worth rotating if the machine is shared. `apps/web/.env.local:2`                                                                            |
+
+**Persisted data — pseudonymous, no PII**
+
+- **No emails, handles, or PII** in any migration. The `username` field at onboarding is optional and never persisted server-side. `services/*/drizzle/0000_init.sql`
+- `keyId` (base64 WebAuthn credential id) stored plaintext as the wallet primary key — a stable user-linkable identifier, not cryptographically secret, but the sole authentication factor for `/wallet/connect`. `wallet-service/src/db/schema.ts:10`
+- `activity_logs.data` jsonb holds only contractId / network / txHash / sessionId — pseudonymous on-chain identifiers, no key material. `wallet-service/src/server.ts:104`
+- `verification_records` stores developer-supplied build metadata (repoUrl, commit, toolchain, flags) plus the worker-written build log — which is returned **publicly** and can leak build-host paths/environment detail. `verification-service/src/server.ts:229-232`
+
+**Logging.** No secret or request-body logging found. Services use Fastify/pino defaults
+(method/url/status only) — request bodies and headers are not logged, and no `pino redact` is
+configured because none is needed. The one redaction helper, `redactDbUrl`, masks Postgres
+credentials before the degrade warning. `service-kit/src/index.ts:66-76`. Client-side config
+in `NEXT_PUBLIC_*` (RPC URL, wasm hash, API URL) is intentionally public; no server secret is
+exposed through it. Unauthenticated `/metrics` on every service exposes operational telemetry,
+not PII.
+
+---
+
+## 7. Assumptions the code makes
+
+**Implied, not enforced** (where surprises live):
+
+- **Downstream ports are private.** Services bind `0.0.0.0` with no service-to-service auth; if a port is exposed, every gateway control is bypassed. `service-kit/src/index.ts:88`
+- **Possession of a keyId equals wallet ownership.** `/wallet/connect` mints a session from a keyId string with no WebAuthn assertion verified. And `/wallet/create` never checks that `signedTx` actually deploys `contractId` or that `keyId` controls it — a malicious client could map its keyId to someone else's contract. `wallet-service/src/server.ts:81-125`
+- **Callers own the wallet they name.** Sponsor-funded deploys and session listing/revocation trust a caller-supplied address/id with no ownership binding. `policy-service/src/server.ts:156`
+- **The `network` field matches the configured RPC.** A request claiming `network:'mainnet'` is still submitted through the testnet-defaulted submitter; `network` is only a storage/metrics label. `wallet-service/src/config.ts:31-32`
+- **Sponsor/relayer/attestor keys are testnet.** Code comments assume it; nothing enforces it. On mainnet the unauthenticated sponsor endpoints become real financial exposure. `wallet-service/src/config.ts:11-13`
+- **`repoUrl` is safe for the worker to fetch.** Any syntactically valid URL passes — including internal/SSRF-shaped targets; the worker `git clone`s it on the host. `verification-service/src/server.ts:95`
+
+**Relied upon (mostly benign):**
+
+- **In-memory fallback is dev-only.** With no `DATABASE_URL`, a misconfigured production would run statelessly (data lost on restart) behind only a warning — health checks still pass. `wallet-service/src/index.ts:57-61`
+- **MV3 sender origin is unforgeable.** The entire extension origin-security model rests on this browser guarantee — a correct assumption given the isolated-world model. `background.ts:41`
+- **A stranded `building` row is re-claimable.** A comment promises reclaim-after-timeout, but **no reaper exists** — a worker crash mid-build strands the record in `building` forever. `worker-service/src/loop.ts:38`, `pg-job-store.ts:22`
+- **Horizon responses match asserted shapes.** lifecycle-service uses `as` casts with no runtime validation; ≤200 offers assumed (no pagination), and >100 cleanup ops would produce an invalid single transaction. `lifecycle-service/src/horizon.ts:47-56`, `builder.ts:41-42`
+- **The spending window is fixed, not sliding.** Reset-on-elapse means up to 2× the daily limit can move across a window boundary in under `window_seconds`. `spending-limit/src/lib.rs:270-284`
+- **One wasm hash fits all policy templates.** policy-service wires a single `SPENDING_POLICY_WASM_HASH` for every template; a `verified_only` deploy would use the spending wasm — it survives only because the constructor reverts in simulation. `policy-service/src/index.ts:12-21`
+
+---
+
+## 8. Gaps & open questions
+
+Things not determinable from the code alone. These change the risk assessment materially.
+
+- **Q1 — Which deploy target is actually live (Render, Railway, or neither)?** The entire gateway-as-boundary model depends on ports 4001-4004 being unreachable, which no file in the repo can prove. Does the live platform expose only `$PORT`?
+- **Q2 — Is worker-service deployed anywhere?** No deploy config references it or provisions `ATTESTOR_SECRET_KEY`. Without it, hosted contract verification can never complete and there is no on-chain attestor. Is it run out-of-band, and in which mode (Docker sandbox vs. stub executor)?
+- **Q3 — Are the sponsor / relayer / attestor keys strictly testnet in the live environment?** Nothing in code enforces it, and the unauthenticated sponsor-funded endpoints become real financial exposure on mainnet.
+- **Q4 — Is any server-side auth planned before V1** (session validation, WebAuthn assertion verification, service-to-service auth), or is "the on-chain signature is the authorization" the intended end state? There is zero scaffolding for it today, and `permission-service` is an empty stub.
+- **Q5 — Where does the authoritative product spec live going forward?** `technical-doc.md`, `idea.md`, `BUILD-PLAN.md`, `CLAUDE.md`, and `docs/decisions.md` are all gitignored — they exist only in the working tree. A fresh clone has none of them. Is there a backup elsewhere?
+- **Q6 — The `vellar-sdk` npm package and the `vellar-facilitator` service live outside this repo.** They carry the actual passkey ceremony, session store, and x402 payment/authorization model — none of which is auditable here. Do their repos exist, and who controls publishing? (The x402 surface that dominates the web app's landing copy has no implementation in this repo; it presumably lives in that SDK.)
+- **Q7 — Should `/metrics` be network-restricted or auth-gated in production?** It is unauthenticated on every service, and in `all-in-one` the gateway's public `/metrics` exposes the combined series of every co-located service.
+
+---
+
+_Method: 12 parallel subsystem readers + 2 cross-cutting sweeps (auth end-to-end; data/secret
+handling), reconciled by a completeness critic that walked the repo tree for coverage holes
+and spot-checked load-bearing security claims against the cited files. Read-only — no files
+were modified._

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -808,8 +808,17 @@ real account state, and the wizard surfaces a raw `op_underfunded`. No fund loss
 and the `/lifecycle/merge` preflight re-inspects live state (409 while blockers remain), so no
 irreversible merge on partial cleanup — a liveness/correctness bug, not a safety one. Untested.
 
-> **Status (RA-5): OPEN.** Cancel offers before payments (or subtract `selling_liabilities` from the
-> paid amount); parse `selling_liabilities` in `horizon.ts`; add a balance-plus-same-asset-offer test.
+> **Status (RA-5): CLOSED.** `collectCleanupOps` now emits **offer cancels first**, then balance
+> payouts + trustline removals, then data deletes (`builder.ts`). Cancelling first frees the selling
+> liabilities, so by the time each payment runs (ops execute sequentially within the tx) the full
+> asset balance is spendable — no `op_underfunded`. Chosen over parsing `selling_liabilities` and
+> subtracting it from the paid amount: reordering makes the tx correct by construction (the liability
+> is gone before the payment), whereas subtracting would leave the liability-locked remainder stranded
+> on the account and still block the trustline removal — so parsing `selling_liabilities` was
+> considered and deliberately not needed. Tests (`builder.test.ts`, `server.test.ts`): an account
+> holding an asset it also sells on an open offer emits the cancel before the payment (asserted every
+> `manageSellOffer` precedes every `payment`), and the end-to-end op order is now
+> `manageSellOffer → payment → changeTrust → manageData`.
 
 ### RA-6 — V3 detach invariant is pinned only at the pure helper; the attach/detach wiring is untested 🟡 Medium `[my code]`
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -147,6 +147,19 @@ read oracle. Same build-box gating as H2.
   session read/revoke with the caller's own opaque session id as a bearer capability; stop
   letting a bare public contractId enumerate ids.
 
+  > **Status (M1/RA-3): CLOSED.** The session routes are now gated on a bearer session capability
+  > (`Authorization: Bearer <sessionId>`), and — importantly — **the premise this finding was rated
+  > on has changed:** a session id is no longer "not an access token." It is now a **narrow bearer
+  > capability** for the session routes (list / read / revoke), scoped to the account it is bound to,
+  > with a 7-day sliding expiry (matching the device signer; expired == absent). It authorizes ONLY
+  > those routes — a non-drift test asserts a valid session id grants nothing on `/wallet/submit` or
+  > `/wallet/create` — so it does not become the app-layer auth the design omits. The reasoning that
+  > depended on "sessions gate no authority" is superseded (see the architecture-analysis update);
+  > the impact-if-leaked is now bounded by expiry and by the capability's narrow scope, and the id no
+  > longer appears in a logged URL (routes moved the id to the header/body) or in the audit log (a
+  > truncated `sha256` ref is stored, never the raw id). Enumeration/mass-revoke are closed:
+  > listing/revoke require a live capability for that exact account.
+
 - **M2 — deploy-instance has no spend cap of its own `[my code]`** — `policy-service/src/server.ts:156`.
   Sole caller-side throttle is the ineffective gateway per-IP limit; distributed callers drain
   faster than 120/min implies. **Fix:** global/per-sponsor deploy budget in policy-service.
@@ -474,7 +487,7 @@ read oracle. Same build-box gating as H2.
 4. **M4** — gate `verified_only` out of the mainnet policy builder until a mainnet registry
    exists (see V3 re-rating).
 
-**Before public testnet exposure (a real build box / public submit endpoint):** 5. **H2 + H3** — repoUrl allowlist + private build logs. 6. **M1** — authorize session read/revoke with the caller's own session id. 7. **M6** — fail-closed boot + DB-aware health. 8. **M8** — bump fast-uri.
+**Before public testnet exposure (a real build box / public submit endpoint):** 5. **H2 + H3** — repoUrl allowlist + private build logs. 6. **M1** — ~~authorize session read/revoke with the caller's own session id~~ **DONE** (RA-3/M1: bearer session capability, 7-day sliding expiry, hashed audit ref). 7. **M6** — fail-closed boot + DB-aware health. 8. **M8** — bump fast-uri.
 
 **Can wait (hardening / latent):** M3, M7, M9, L1–L7, I1.
 
@@ -687,9 +700,31 @@ never implemented. Impact is bounded — sessions gate **no** on-chain authority
 on-chain via `__check_auth`; web connected-state derives from SDK localStorage) — so this is device-
 management DoS + session-graph disclosure, **not** an authz bypass.
 
-> **Status (RA-3): OPEN.** "Open finding with doc text implying otherwise" is the worst of both.
-> Implement the bearer-capability ownership guard on both routes and add a 401/403 test for a
-> non-owning caller; keep the impact note accurate (no on-chain authority).
+> **Status (RA-3): CLOSED (branch `security/session-capability`).** Implemented as a bearer session
+> capability, and the finding's own premise ("sessions gate no authority") was updated everywhere it
+> was reasoned from, not just where it was stated:
+>
+> - **Guard.** `GET /wallet/sessions`, the new `GET /wallet/session` (own session), and the new
+>   `POST /wallet/sessions/revoke` all require `Authorization: Bearer <sessionId>` resolving to a
+>   **live** session **bound to the exact account** being read/revoked. Missing / unknown / expired /
+>   wrong-account bearer all return an identical `401 unauthorized`, so no response reveals whether an
+>   id was ever valid. Enumeration and cross-account mass-revoke are closed.
+> - **Expiry.** Sessions now carry `expires_at` (schema migration `0002`) and expire on a **7-day
+>   sliding window** matching the device signer (`SESSION_TTL_MS`; noted in-code that the two
+>   lifetimes are coupled). `find`/`listByContract` treat an expired row as **absent**; `touch` slides
+>   `lastActiveAt`+`expiresAt` only on an authorized use, so a rejected/expired id cannot extend its
+>   own life. This fixes the pre-existing never-updated `lastActiveAt` (it was harmless for a label,
+>   not for a capability).
+> - **No credential in logs.** The id moved out of the URL (path/query) into the header/body —
+>   Fastify logs URLs but not headers/bodies — and the audit log stores a **truncated `sha256(id)`**
+>   ref, never the raw id.
+> - **No auth drift.** A non-drift test asserts a valid session id on `Authorization` grants nothing
+>   on `/wallet/submit` or `/wallet/create` (they still validate their own bodies) — the capability
+>   stays narrow and does not become the app-layer auth the design deliberately omits.
+> - **Premise sweep.** The "not an access token / gates no authority" reasoning in
+>   `docs/architecture-analysis.md` (the "What passes for a session" + "Where authorization is real"
+>   passages) and in the M1 finding above was corrected — a conclusion built on the old premise, not
+>   just the sentence, so a later reader doesn't re-derive the stale rating.
 
 ### RA-4 — `ALLOW_INMEMORY` fail-closed boot guard is **inert** on the deploy targets 🟡 Medium `[my code]`
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -834,9 +834,17 @@ another key's `SignerLimits` map, as the verified-recipient doc-comment contempl
 **green** and re-introduce the V3 permanent-fund-lock (a reject-everything policy could then block its
 own removal). No live bypass today; a test-coverage gap on a fund-lock-critical invariant.
 
-> **Status (RA-6): OPEN.** Add an integration test that drives the real `connector-factory` attach
-> and asserts the emitted signer is standalone `SignerLimits(None)`, and a detach test through the
-> real `kit.remove` path — so the shape breaks a test if a refactor changes it.
+> **Status (RA-6): CLOSED.** The attach/detach wiring is extracted from `connector-factory.ts` into
+> `createPolicySignerActions` (`apps/web/lib/policy-signer.ts`) and unit-tested with a fake kit at the
+> WIRING layer, not just at the pure `policyAttachArgs`. The tests assert what the kit is actually
+> called with: `attachPolicy` calls `kit.addPolicy(id, limits, store, expiration)` with
+> **`limits === undefined`** (standalone `SignerLimits(None)` — the shape that triggers the wallet's
+> `is_sole_self_removal` exception), `store = Persistent`, no expiration; `detachPolicy` calls
+> `kit.remove(SignerKey.Policy(id))` (the exact key the recovery exception recognizes). Crucially,
+> `connector-factory` now **delegates to that same `createPolicySignerActions`**, so the production
+> path is the tested path — the refactor the finding feared (inlining a `SignerLimits` map to make the
+> policy a required co-signer) would now break these tests instead of shipping green. The browser-only
+> `SignerKey`/`SignerStore` enums are injected, keeping the action module SSR/test-safe.
 
 ### RA-7 — `isBlockedAddress` misses hex-form IPv4-mapped + NAT64 IPv6 ℹ️ Info `[my code]`
 

--- a/services/lifecycle-service/src/builder.test.ts
+++ b/services/lifecycle-service/src/builder.test.ts
@@ -25,6 +25,13 @@ function decode(xdr: string) {
   return { ops: tx.operations.length, sequence: BigInt(tx.sequence) };
 }
 
+/** Decode a step's XDR and return its ordered op types. */
+function opTypes(xdr: string): string[] {
+  const tx = TransactionBuilder.fromXDR(xdr, PASSPHRASE);
+  if ("innerTransaction" in tx) throw new Error("unexpected fee-bump tx");
+  return tx.operations.map((o) => o.type);
+}
+
 const dataKeys = (n: number) => Array.from({ length: n }, (_, i) => `k${i}`);
 
 describe("buildCleanupSteps (L6 op-split)", () => {
@@ -75,6 +82,82 @@ describe("buildCleanupSteps (L6 op-split)", () => {
     const steps = buildCleanupSteps(account({ dataKeys: dataKeys(150) }), DEST, PASSPHRASE);
     expect(steps).toHaveLength(2);
     expect(steps[0]!.title).not.toBe(steps[1]!.title);
+  });
+});
+
+describe("buildCleanupSteps — offer/liability ordering (RA-5)", () => {
+  const USDC = { assetType: "credit_alphanum4", assetCode: "USDC", assetIssuer: DEST };
+
+  it("cancels offers BEFORE paying out balances (frees selling liabilities first)", () => {
+    // An account holding 100 USDC AND selling 40 USDC on an open offer: 40 is a
+    // selling liability, so only 60 is spendable. If the payment of the full 100
+    // ran before the cancel it would op_underfunded. The cancel must come first.
+    const steps = buildCleanupSteps(
+      account({
+        balances: [
+          { assetType: "native", balance: "100.0" },
+          { ...USDC, balance: "100" },
+        ],
+        offers: [
+          {
+            id: "7",
+            sellingAssetType: "credit_alphanum4",
+            sellingAssetCode: "USDC",
+            sellingAssetIssuer: DEST,
+            buyingAssetType: "native",
+            price: "1.0",
+          },
+        ],
+        openOffers: 1,
+      }),
+      DEST,
+      PASSPHRASE,
+    );
+    expect(steps).toHaveLength(1);
+    const types = opTypes(steps[0]!.xdr);
+    // Order: cancel the offer, THEN pay the balance, THEN remove the trustline.
+    expect(types).toEqual(["manageSellOffer", "payment", "changeTrust"]);
+    // Specifically: every manageSellOffer precedes every payment.
+    const lastCancel = types.lastIndexOf("manageSellOffer");
+    const firstPayment = types.indexOf("payment");
+    expect(lastCancel).toBeLessThan(firstPayment);
+  });
+
+  it("orders cancels before payments even across MANY offers and balances", () => {
+    const steps = buildCleanupSteps(
+      account({
+        balances: [
+          { assetType: "native", balance: "50.0" },
+          { ...USDC, balance: "10" },
+          { assetType: "credit_alphanum4", assetCode: "EURC", assetIssuer: DEST, balance: "5" },
+        ],
+        offers: [
+          {
+            id: "1",
+            sellingAssetType: "credit_alphanum4",
+            sellingAssetCode: "USDC",
+            sellingAssetIssuer: DEST,
+            buyingAssetType: "native",
+            price: "1",
+          },
+          {
+            id: "2",
+            sellingAssetType: "credit_alphanum4",
+            sellingAssetCode: "EURC",
+            sellingAssetIssuer: DEST,
+            buyingAssetType: "native",
+            price: "1",
+          },
+        ],
+        openOffers: 2,
+      }),
+      DEST,
+      PASSPHRASE,
+    );
+    const types = opTypes(steps[0]!.xdr);
+    const lastCancel = types.lastIndexOf("manageSellOffer");
+    const firstPayment = types.indexOf("payment");
+    expect(firstPayment).toBeGreaterThan(lastCancel);
   });
 });
 

--- a/services/lifecycle-service/src/builder.ts
+++ b/services/lifecycle-service/src/builder.ts
@@ -47,26 +47,20 @@ interface CleanupOp {
   action: string;
 }
 
-/** Collects every cleanup operation in dependency order (transfer before
- * trustline removal), each paired with its description. */
+/** Collects every cleanup operation in DEPENDENCY order (RA-5), each paired with
+ * its description. The order matters for on-chain success:
+ *   1. cancel offers  — an open sell offer locks the offered amount as a SELLING
+ *      LIABILITY, so it is not spendable. Cancelling first frees it; otherwise a
+ *      payment of the full balance below hits op_underfunded (only balance minus
+ *      liabilities is movable) and the whole tx fails.
+ *   2. pay out balances then remove each trustline — transfer before its removal.
+ *   3. delete data entries.
+ */
 function collectCleanupOps(account: HorizonAccount, destination: string): CleanupOp[] {
   const out: CleanupOp[] = [];
 
-  for (const balance of account.balances) {
-    if (balance.assetType === "native") continue;
-    const asset = toAsset(balance.assetCode, balance.assetIssuer);
-    if (Number(balance.balance) > 0) {
-      out.push({
-        op: Operation.payment({ destination, asset, amount: balance.balance }),
-        action: `send ${balance.balance} ${asset.getCode()} to the destination`,
-      });
-    }
-    out.push({
-      op: Operation.changeTrust({ asset, limit: "0" }),
-      action: `remove the ${asset.getCode()} trustline`,
-    });
-  }
-
+  // 1. Cancel offers first — frees selling liabilities so the payments below can
+  //    move the full asset balance.
   for (const offer of account.offers) {
     out.push({
       op: Operation.manageSellOffer({
@@ -86,6 +80,23 @@ function collectCleanupOps(account: HorizonAccount, destination: string): Cleanu
     });
   }
 
+  // 2. Pay out each non-native balance, then remove its trustline.
+  for (const balance of account.balances) {
+    if (balance.assetType === "native") continue;
+    const asset = toAsset(balance.assetCode, balance.assetIssuer);
+    if (Number(balance.balance) > 0) {
+      out.push({
+        op: Operation.payment({ destination, asset, amount: balance.balance }),
+        action: `send ${balance.balance} ${asset.getCode()} to the destination`,
+      });
+    }
+    out.push({
+      op: Operation.changeTrust({ asset, limit: "0" }),
+      action: `remove the ${asset.getCode()} trustline`,
+    });
+  }
+
+  // 3. Delete data entries.
   for (const key of account.dataKeys) {
     out.push({
       op: Operation.manageData({ name: key, value: null }),

--- a/services/lifecycle-service/src/server.test.ts
+++ b/services/lifecycle-service/src/server.test.ts
@@ -223,10 +223,13 @@ describe("POST /lifecycle/execute", () => {
     expect(step.hash).toMatch(/^[0-9a-f]{64}$/);
 
     const tx = TransactionBuilder.fromXDR(step.xdr, Networks.TESTNET);
+    // RA-5: offer cancels come FIRST — cancelling frees any selling liabilities
+    // so the subsequent payment can move the full asset balance without hitting
+    // op_underfunded. Payments then precede their trustline removals.
     expect("operations" in tx && tx.operations.map((o) => o.type)).toEqual([
+      "manageSellOffer", // cancel offer 42 (frees liabilities first)
       "payment", // USDC to destination
       "changeTrust", // remove USDC trustline
-      "manageSellOffer", // cancel offer 42
       "manageData", // delete "config"
     ]);
     expect(tx.signatures).toHaveLength(0); // UNSIGNED — user signs externally

--- a/services/wallet-service/drizzle/0002_add_session_expiry.sql
+++ b/services/wallet-service/drizzle/0002_add_session_expiry.sql
@@ -1,0 +1,17 @@
+-- RA-3/M1: a session id is now a bearer capability for the session routes, so
+-- it must expire (7-day sliding window). Add expires_at NOT NULL.
+--
+-- Backfill any pre-existing rows to created_at + 7 days so the ADD COLUMN does
+-- not fail on a non-empty table and no legacy session is immortal; new inserts
+-- always set expires_at explicitly. (The spend_ledger table already exists from
+-- 0001 — drizzle-kit re-emitted it here from a stale snapshot; that create is
+-- dropped and only the session change is kept.)
+ALTER TABLE "wallet_sessions"
+  ADD COLUMN IF NOT EXISTS "expires_at" timestamp with time zone;
+--> statement-breakpoint
+UPDATE "wallet_sessions"
+  SET "expires_at" = "created_at" + interval '7 days'
+  WHERE "expires_at" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "wallet_sessions"
+  ALTER COLUMN "expires_at" SET NOT NULL;

--- a/services/wallet-service/drizzle/meta/0002_snapshot.json
+++ b/services/wallet-service/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,227 @@
+{
+  "id": "db155d8b-6364-467a-878a-6da10e06dd14",
+  "prevId": "e6af907e-477a-4787-9a9f-f1f56362c7da",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spend_ledger": {
+      "name": "spend_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stroops": {
+          "name": "stroops",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "spend_ledger_line_network_at_idx": {
+          "name": "spend_ledger_line_network_at_idx",
+          "columns": [
+            {
+              "expression": "line",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_sessions": {
+      "name": "wallet_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wallets_key_id_network_pk": {
+          "name": "wallets_key_id_network_pk",
+          "columns": [
+            "key_id",
+            "network"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/wallet-service/drizzle/meta/_journal.json
+++ b/services/wallet-service/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1786200000000,
       "tag": "0001_spend_ledger",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1786232234891,
+      "tag": "0002_add_session_expiry",
+      "breakpoints": true
     }
   ]
 }

--- a/services/wallet-service/src/db/pg-repository.test.ts
+++ b/services/wallet-service/src/db/pg-repository.test.ts
@@ -88,6 +88,10 @@ describe.skipIf(!DATABASE_URL)("pg repositories", () => {
   });
 
   describe("session repository", () => {
+    // Far-future expiry so these round-trip/list tests aren't clock-sensitive;
+    // expiry behavior itself is covered by its own test below.
+    const FAR = "2099-01-01T00:00:00.000Z";
+
     it("round-trips sessions and misses cleanly on junk ids", async () => {
       const repo = createPgSessionRepository(handle.db);
       const record = {
@@ -96,6 +100,7 @@ describe.skipIf(!DATABASE_URL)("pg repositories", () => {
         network: "testnet" as const,
         createdAt: "2026-07-16T10:00:00.000Z",
         lastActiveAt: "2026-07-16T11:00:00.000Z",
+        expiresAt: FAR,
       };
       await repo.insert(record);
       await expect(repo.find(record.id)).resolves.toEqual(record);
@@ -108,6 +113,7 @@ describe.skipIf(!DATABASE_URL)("pg repositories", () => {
         contractId: "C1",
         network: "testnet" as const,
         createdAt: "2026-07-16T10:00:00.000Z",
+        expiresAt: FAR,
       };
       await repo.insert({ ...base, id: "older", lastActiveAt: "2026-07-16T10:00:00.000Z" });
       await repo.insert({ ...base, id: "newer", lastActiveAt: "2026-07-16T12:00:00.000Z" });
@@ -122,6 +128,53 @@ describe.skipIf(!DATABASE_URL)("pg repositories", () => {
       expect(listed.map((s) => s.id)).toEqual(["newer", "older"]);
     });
 
+    it("treats an expired session as ABSENT for find and listByContract (RA-3)", async () => {
+      const repo = createPgSessionRepository(handle.db);
+      const asOf = new Date("2026-08-09T00:00:00.000Z");
+      const expired = {
+        id: "expired-1",
+        contractId: "CEXP",
+        network: "testnet" as const,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        lastActiveAt: "2026-08-01T00:00:00.000Z",
+        expiresAt: "2026-08-08T00:00:00.000Z", // before asOf
+      };
+      await repo.insert(expired);
+      // Expired == missing: no response distinguishes "expired" from "never existed".
+      await expect(repo.find("expired-1", asOf)).resolves.toBeUndefined();
+      await expect(repo.listByContract("CEXP", "testnet", asOf)).resolves.toEqual([]);
+    });
+
+    it("touch slides a live session forward but no-ops on an expired one (RA-3)", async () => {
+      const repo = createPgSessionRepository(handle.db);
+      const asOf = new Date("2026-08-09T00:00:00.000Z");
+      const newExpiry = new Date("2026-08-16T00:00:00.000Z");
+      await repo.insert({
+        id: "live-1",
+        contractId: "CT",
+        network: "testnet",
+        createdAt: "2026-08-08T00:00:00.000Z",
+        lastActiveAt: "2026-08-08T00:00:00.000Z",
+        expiresAt: "2026-08-15T00:00:00.000Z", // after asOf → live
+      });
+      await expect(repo.touch("live-1", asOf, newExpiry)).resolves.toBe(true);
+      const after = await repo.find("live-1", asOf);
+      expect(after?.expiresAt).toBe(newExpiry.toISOString());
+      expect(after?.lastActiveAt).toBe(asOf.toISOString());
+
+      // An already-expired session cannot extend its own life.
+      await repo.insert({
+        id: "dead-1",
+        contractId: "CT",
+        network: "testnet",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        lastActiveAt: "2026-08-01T00:00:00.000Z",
+        expiresAt: "2026-08-08T00:00:00.000Z", // before asOf → expired
+      });
+      await expect(repo.touch("dead-1", asOf, newExpiry)).resolves.toBe(false);
+      await expect(repo.touch("never", asOf, newExpiry)).resolves.toBe(false);
+    });
+
     it("delete returns true once and false for missing ids", async () => {
       const repo = createPgSessionRepository(handle.db);
       await repo.insert({
@@ -130,6 +183,7 @@ describe.skipIf(!DATABASE_URL)("pg repositories", () => {
         network: "testnet",
         createdAt: new Date().toISOString(),
         lastActiveAt: new Date().toISOString(),
+        expiresAt: FAR,
       });
       await expect(repo.delete("to-revoke")).resolves.toBe(true);
       await expect(repo.delete("to-revoke")).resolves.toBe(false);
@@ -175,7 +229,10 @@ describe.skipIf(!DATABASE_URL)("pg repositories", () => {
       expect(connect.statusCode).toBe(200);
       expect(connect.json().contractId).toBe("CE2E");
 
-      const session = await app.inject({ url: `/wallet/session/${connect.json().sessionId}` });
+      const session = await app.inject({
+        url: "/wallet/session",
+        headers: { authorization: `Bearer ${connect.json().sessionId}` },
+      });
       expect(session.statusCode).toBe(200);
       expect(session.json().contractId).toBe("CE2E");
 

--- a/services/wallet-service/src/db/pg-repository.ts
+++ b/services/wallet-service/src/db/pg-repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, gt } from "drizzle-orm";
 import type { Network } from "@vellar/types";
 import {
   DuplicateWalletError,
@@ -67,23 +67,47 @@ export function createPgSessionRepository(db: Db): SessionRepository {
         network: record.network,
         createdAt: new Date(record.createdAt),
         lastActiveAt: new Date(record.lastActiveAt),
+        expiresAt: new Date(record.expiresAt),
       });
     },
 
-    async find(id) {
-      const rows = await db.select().from(walletSessions).where(eq(walletSessions.id, id)).limit(1);
+    async find(id, asOf = new Date()) {
+      // Expired rows are ABSENT: filter on expiresAt in the query, so an expired
+      // id is indistinguishable from a missing one (no "was once valid" signal).
+      const rows = await db
+        .select()
+        .from(walletSessions)
+        .where(and(eq(walletSessions.id, id), gt(walletSessions.expiresAt, asOf)))
+        .limit(1);
       const row = rows[0];
       if (!row) return undefined;
       return toSessionRecord(row);
     },
 
-    async listByContract(contractId, network) {
+    async listByContract(contractId, network, asOf = new Date()) {
       const rows = await db
         .select()
         .from(walletSessions)
-        .where(and(eq(walletSessions.contractId, contractId), eq(walletSessions.network, network)))
+        .where(
+          and(
+            eq(walletSessions.contractId, contractId),
+            eq(walletSessions.network, network),
+            gt(walletSessions.expiresAt, asOf),
+          ),
+        )
         .orderBy(desc(walletSessions.lastActiveAt));
       return rows.map(toSessionRecord);
+    },
+
+    async touch(id, at, newExpiresAt) {
+      // Only a currently-live row slides forward — a rejected/expired id (past
+      // expiresAt) matches nothing and cannot extend its own life.
+      const updated = await db
+        .update(walletSessions)
+        .set({ lastActiveAt: at, expiresAt: newExpiresAt })
+        .where(and(eq(walletSessions.id, id), gt(walletSessions.expiresAt, at)))
+        .returning({ id: walletSessions.id });
+      return updated.length > 0;
     },
 
     async delete(id) {
@@ -103,6 +127,7 @@ function toSessionRecord(row: typeof walletSessions.$inferSelect) {
     network: row.network as Network,
     createdAt: row.createdAt.toISOString(),
     lastActiveAt: row.lastActiveAt.toISOString(),
+    expiresAt: row.expiresAt.toISOString(),
   };
 }
 

--- a/services/wallet-service/src/db/schema.ts
+++ b/services/wallet-service/src/db/schema.ts
@@ -26,12 +26,16 @@ export const wallets = pgTable(
 );
 
 export const walletSessions = pgTable("wallet_sessions", {
-  // text, not uuid: junk ids in GET /wallet/session/:id must 404, not 500 on cast.
+  // text, not uuid: junk ids in a session lookup must 404, not 500 on cast.
   id: text("id").primaryKey(),
   contractId: text("contract_id").notNull(),
   network: text("network").notNull(),
   createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull(),
   lastActiveAt: timestamp("last_active_at", { withTimezone: true, mode: "date" }).notNull(),
+  // A session id is a bearer capability for the session routes (RA-3/M1), so it
+  // expires: 7-day sliding window, enforced by the guard. Rows past this are
+  // treated as absent. NOT NULL so a pre-expiry row can never read as immortal.
+  expiresAt: timestamp("expires_at", { withTimezone: true, mode: "date" }).notNull(),
 });
 
 export const activityLogs = pgTable("activity_logs", {

--- a/services/wallet-service/src/repository.ts
+++ b/services/wallet-service/src/repository.ts
@@ -42,13 +42,26 @@ export interface SessionRecord {
   network: Network;
   createdAt: string;
   lastActiveAt: string;
+  /** When this session capability expires (ISO). A session id is a bearer
+   * capability for the session routes (security-audit.md RA-3/M1), so it MUST
+   * die: 7-day sliding window, matching the device signer's 7-day expiry — if
+   * one lifetime changes, change both. `find`/`listByContract` treat an expired
+   * row as ABSENT so an expired id never authorizes anything (and never gets a
+   * response distinguishing "expired" from "never existed"). */
+  expiresAt: string;
 }
 
 export interface SessionRepository {
   insert(record: SessionRecord): Promise<void>;
-  find(id: string): Promise<SessionRecord | undefined>;
-  /** Active sessions for an account, most recently active first (§5.1 device management). */
-  listByContract(contractId: string, network: Network): Promise<SessionRecord[]>;
+  /** Returns the session ONLY if it exists and is not expired (as of `asOf`,
+   * default now) — an expired session is indistinguishable from a missing one. */
+  find(id: string, asOf?: Date): Promise<SessionRecord | undefined>;
+  /** Non-expired sessions for an account, most recently active first (§5.1). */
+  listByContract(contractId: string, network: Network, asOf?: Date): Promise<SessionRecord[]>;
+  /** Slides a session forward on AUTHORIZED use: sets lastActiveAt=`at` and
+   * expiresAt=`at`+window. No-op (returns false) if the id is absent/expired, so
+   * a rejected id can never extend its own life. */
+  touch(id: string, at: Date, newExpiresAt: Date): Promise<boolean>;
   /** Revokes a session; false when it didn't exist. */
   delete(id: string): Promise<boolean>;
 }
@@ -87,17 +100,26 @@ export function createMemoryWalletRepository(): WalletRepository {
 
 export function createMemorySessionRepository(): SessionRepository {
   const sessions = new Map<string, SessionRecord>();
+  const isLive = (s: SessionRecord, asOf: Date) => new Date(s.expiresAt).getTime() > asOf.getTime();
   return {
     async insert(record) {
       sessions.set(record.id, record);
     },
-    async find(id) {
-      return sessions.get(id);
+    async find(id, asOf = new Date()) {
+      const s = sessions.get(id);
+      return s && isLive(s, asOf) ? s : undefined;
     },
-    async listByContract(contractId, network) {
+    async listByContract(contractId, network, asOf = new Date()) {
       return [...sessions.values()]
-        .filter((s) => s.contractId === contractId && s.network === network)
+        .filter((s) => s.contractId === contractId && s.network === network && isLive(s, asOf))
         .sort((a, b) => b.lastActiveAt.localeCompare(a.lastActiveAt));
+    },
+    async touch(id, at, newExpiresAt) {
+      const s = sessions.get(id);
+      if (!s || !isLive(s, at)) return false;
+      s.lastActiveAt = at.toISOString();
+      s.expiresAt = newExpiresAt.toISOString();
+      return true;
     },
     async delete(id) {
       return sessions.delete(id);

--- a/services/wallet-service/src/server.test.ts
+++ b/services/wallet-service/src/server.test.ts
@@ -53,7 +53,12 @@ describe("POST /wallet/create", () => {
     expect(body.txHash).toBe("txhash123");
     expect(body.sessionId).toMatch(/[0-9a-f-]{36}/);
 
-    const session = await server.inject({ url: `/wallet/session/${body.sessionId}` });
+    // The returned session id is the caller's capability — fetchable via the
+    // bearer, not a URL path (RA-3/M1).
+    const session = await server.inject({
+      url: "/wallet/session",
+      headers: { authorization: `Bearer ${body.sessionId}` },
+    });
     expect(session.statusCode).toBe(200);
     expect(session.json().contractId).toBe("CCONTRACT");
 
@@ -180,14 +185,6 @@ describe("POST /wallet/submit", () => {
       payload: { signedXdr: "" },
     });
     expect(res.statusCode).toBe(400);
-  });
-});
-
-describe("GET /wallet/session/:id", () => {
-  it("404s for unknown sessions", async () => {
-    const server = build(workingSubmitter());
-    const res = await server.inject({ url: "/wallet/session/does-not-exist" });
-    expect(res.statusCode).toBe(404);
   });
 });
 
@@ -462,7 +459,9 @@ describe("POST /wallet/submit funding-path scoping (C1/H1/V2)", () => {
   });
 });
 
-describe("session management (§5.1)", () => {
+describe("session management (§5.1) — bearer capability (RA-3/M1)", () => {
+  const bearer = (id: string) => ({ authorization: `Bearer ${id}` });
+
   async function createAndConnect(server: FastifyInstance) {
     const create = await server.inject({
       method: "POST",
@@ -480,49 +479,185 @@ describe("session management (§5.1)", () => {
     };
   }
 
-  it("lists sessions for an account", async () => {
+  it("create/connect return a session id the client can present as a capability", async () => {
+    const server = build(workingSubmitter());
+    const { createSessionId, connectSessionId } = await createAndConnect(server);
+    expect(createSessionId).toMatch(/[0-9a-f-]{36}/);
+    expect(connectSessionId).toMatch(/[0-9a-f-]{36}/);
+  });
+
+  it("lists sessions ONLY with a valid bearer bound to that contract+network", async () => {
     const server = build(workingSubmitter());
     const { createSessionId, connectSessionId } = await createAndConnect(server);
 
-    const res = await server.inject({
+    // No bearer -> 401 (was previously an open enumeration endpoint).
+    const noAuth = await server.inject({
       url: "/wallet/sessions?contractId=CCONTRACT&network=testnet",
     });
-    expect(res.statusCode).toBe(200);
-    const ids = res.json().sessions.map((s: { id: string }) => s.id);
-    expect(ids).toHaveLength(2);
+    expect(noAuth.statusCode).toBe(401);
+
+    // Valid bearer for this account -> 200 with the account's sessions.
+    const ok = await server.inject({
+      url: "/wallet/sessions?contractId=CCONTRACT&network=testnet",
+      headers: bearer(createSessionId),
+    });
+    expect(ok.statusCode).toBe(200);
+    const ids = ok.json().sessions.map((s: { id: string }) => s.id);
     expect(ids).toContain(createSessionId);
     expect(ids).toContain(connectSessionId);
   });
 
-  it("returns an empty list for unknown accounts and rejects bad queries", async () => {
+  it("rejects a bearer for a DIFFERENT contract than the one queried (no cross-account read)", async () => {
     const server = build(workingSubmitter());
-    const empty = await server.inject({ url: "/wallet/sessions?contractId=CX&network=testnet" });
-    expect(empty.json().sessions).toEqual([]);
-
-    const bad = await server.inject({ url: "/wallet/sessions?network=devnet" });
-    expect(bad.statusCode).toBe(400);
+    const { createSessionId } = await createAndConnect(server);
+    const res = await server.inject({
+      url: "/wallet/sessions?contractId=COTHER&network=testnet",
+      headers: bearer(createSessionId),
+    });
+    expect(res.statusCode).toBe(401);
   });
 
-  it("revokes a session and audits it", async () => {
+  it("rejects an unknown/garbage bearer with 401 (never 500)", async () => {
+    const server = build(workingSubmitter());
+    await createAndConnect(server);
+    const res = await server.inject({
+      url: "/wallet/sessions?contractId=CCONTRACT&network=testnet",
+      headers: bearer("not-a-real-session"),
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("GET /wallet/session returns the caller's OWN session from the bearer (no id in the URL)", async () => {
+    const server = build(workingSubmitter());
+    const { createSessionId } = await createAndConnect(server);
+    const res = await server.inject({ url: "/wallet/session", headers: bearer(createSessionId) });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().id).toBe(createSessionId);
+    expect(res.json().contractId).toBe("CCONTRACT");
+    // No bearer -> 401.
+    expect((await server.inject({ url: "/wallet/session" })).statusCode).toBe(401);
+  });
+
+  it("revokes another session on the SAME account via POST body (id never in the URL) + audits a HASHED ref", async () => {
     const audit = createMemoryAuditLog();
     const server = build(workingSubmitter(), audit);
-    const { connectSessionId } = await createAndConnect(server);
+    const { createSessionId, connectSessionId } = await createAndConnect(server);
 
+    // Revoke the connect session using the create session as the capability.
     const revoke = await server.inject({
-      method: "DELETE",
-      url: `/wallet/session/${connectSessionId}`,
+      method: "POST",
+      url: "/wallet/sessions/revoke",
+      headers: bearer(createSessionId),
+      payload: { targetSessionId: connectSessionId },
     });
     expect(revoke.statusCode).toBe(204);
 
-    const gone = await server.inject({ url: `/wallet/session/${connectSessionId}` });
-    expect(gone.statusCode).toBe(404);
-    expect((await audit.list()).map((e) => e.type)).toContain("session.revoked");
+    // The revoked session is now gone (absent).
+    const gone = await server.inject({ url: "/wallet/session", headers: bearer(connectSessionId) });
+    expect(gone.statusCode).toBe(401);
+
+    // Audit records the event but NOT the raw session id — only a hashed ref.
+    const events = await audit.list();
+    const revoked = events.find((e) => e.type === "session.revoked");
+    expect(revoked).toBeTruthy();
+    const serialized = JSON.stringify(revoked);
+    expect(serialized).not.toContain(connectSessionId);
+    expect(serialized).not.toContain(createSessionId);
+    expect(revoked?.data.sessionRef).toMatch(/^[0-9a-f]{12}$/); // truncated sha256
   });
 
-  it("404s when revoking a session that doesn't exist", async () => {
+  it("cannot revoke a session on a DIFFERENT account (cross-account revoke blocked)", async () => {
     const server = build(workingSubmitter());
-    const res = await server.inject({ method: "DELETE", url: "/wallet/session/nope" });
-    expect(res.statusCode).toBe(404);
+    const { createSessionId } = await createAndConnect(server);
+    // A second account.
+    const other = await server.inject({
+      method: "POST",
+      url: "/wallet/create",
+      payload: { ...createBody, keyId: "key-other", contractId: "COTHER2" },
+    });
+    const otherSessionId = other.json().sessionId as string;
+
+    // Try to revoke the other account's session using OUR capability.
+    const res = await server.inject({
+      method: "POST",
+      url: "/wallet/sessions/revoke",
+      headers: bearer(createSessionId),
+      payload: { targetSessionId: otherSessionId },
+    });
+    expect(res.statusCode).toBe(404); // the target isn't on our account → not found for us
+    // The other session is still alive.
+    expect(
+      (await server.inject({ url: "/wallet/session", headers: bearer(otherSessionId) })).statusCode,
+    ).toBe(200);
+  });
+
+  it("revoke without a bearer is refused (401), not performed", async () => {
+    const server = build(workingSubmitter());
+    const { connectSessionId } = await createAndConnect(server);
+    const res = await server.inject({
+      method: "POST",
+      url: "/wallet/sessions/revoke",
+      payload: { targetSessionId: connectSessionId },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("an EXPIRED session bearer is treated as ABSENT (401, indistinguishable from never-existed)", async () => {
+    // Drive time forward past the 7-day TTL via injected clock.
+    let clock = new Date("2026-08-09T00:00:00.000Z");
+    app = buildServer({ submitter: workingSubmitter(), now: () => clock });
+    const create = await app.inject({ method: "POST", url: "/wallet/create", payload: createBody });
+    const sid = create.json().sessionId as string;
+    // Within TTL: works.
+    expect((await app.inject({ url: "/wallet/session", headers: bearer(sid) })).statusCode).toBe(
+      200,
+    );
+    // 8 days later: expired → 401, same as a bogus id.
+    clock = new Date("2026-08-17T00:00:01.000Z");
+    const expired = await app.inject({ url: "/wallet/session", headers: bearer(sid) });
+    const bogus = await app.inject({ url: "/wallet/session", headers: bearer("nope") });
+    expect(expired.statusCode).toBe(401);
+    expect(bogus.statusCode).toBe(401);
+    expect(expired.json()).toEqual(bogus.json());
+  });
+
+  it("rejects a bad list query (400) before touching auth", async () => {
+    const server = build(workingSubmitter());
+    const bad = await server.inject({ url: "/wallet/sessions?network=devnet" });
+    expect(bad.statusCode).toBe(400);
+  });
+});
+
+describe("session capability does NOT drift into general auth (RA-3 scope)", () => {
+  const bearer = (id: string) => ({ authorization: `Bearer ${id}` });
+
+  it("a valid session id on Authorization does NOT authorize /wallet/submit, /wallet/create, or bypass their own guards", async () => {
+    const server = build(workingSubmitter());
+    const create = await server.inject({
+      method: "POST",
+      url: "/wallet/create",
+      payload: createBody,
+    });
+    const sid = create.json().sessionId as string;
+
+    // /wallet/create still validates its body regardless of the bearer.
+    const badCreate = await server.inject({
+      method: "POST",
+      url: "/wallet/create",
+      headers: bearer(sid),
+      payload: {},
+    });
+    expect(badCreate.statusCode).toBe(400);
+
+    // /wallet/submit still validates its body regardless of the bearer — the
+    // session capability grants nothing here.
+    const badSubmit = await server.inject({
+      method: "POST",
+      url: "/wallet/submit",
+      headers: bearer(sid),
+      payload: {},
+    });
+    expect(badSubmit.statusCode).toBe(400);
   });
 });
 

--- a/services/wallet-service/src/server.ts
+++ b/services/wallet-service/src/server.ts
@@ -1,4 +1,5 @@
-import Fastify, { type FastifyInstance } from "fastify";
+import { createHash } from "node:crypto";
+import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
 import { z } from "zod";
 import {
   registerHealth,
@@ -49,6 +50,33 @@ const listSessionsQuerySchema = z.object({
   network: networkSchema,
 });
 
+const revokeSessionBodySchema = z.object({
+  targetSessionId: z.string().min(1),
+});
+
+// A session id is a BEARER CAPABILITY for the session routes (security-audit.md
+// RA-3/M1): possession authorizes listing/reading/revoking sessions for the
+// account that session is bound to — nothing else. It expires on a 7-day sliding
+// window, matching the device signer's 7-day expiry (apps/extension L4); if one
+// lifetime changes, change both. It is NOT a general auth token: no other route
+// reads it, and it never grants signing or funding authority (those are on-chain
+// via __check_auth).
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** A non-reversible reference to a session id for the audit log — the raw id is
+ * a credential and must not be written to storage in plaintext. */
+function sessionRef(id: string): string {
+  return createHash("sha256").update(id).digest("hex").slice(0, 12);
+}
+
+/** The bearer session id from the Authorization header, or undefined. */
+function bearerSessionId(request: FastifyRequest): string | undefined {
+  const header = request.headers.authorization;
+  if (!header) return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return match?.[1];
+}
+
 export interface WalletServiceDeps {
   submitter: TransactionSubmitter;
   wallets?: WalletRepository;
@@ -81,16 +109,35 @@ export function buildServer(deps: WalletServiceDeps): FastifyInstance {
   registerMetrics(app, "wallet-service");
 
   async function openSession(contractId: string, network: "testnet" | "mainnet") {
-    const timestamp = now().toISOString();
+    const at = now();
+    const timestamp = at.toISOString();
     const record: SessionRecord = {
       id: crypto.randomUUID(),
       contractId,
       network,
       createdAt: timestamp,
       lastActiveAt: timestamp,
+      expiresAt: new Date(at.getTime() + SESSION_TTL_MS).toISOString(),
     };
     await sessions.insert(record);
     return record;
+  }
+
+  /** Resolve the caller's live session capability from the bearer, or undefined
+   * when there is no header, the id is unknown, or the session has expired (an
+   * expired session is ABSENT — no response distinguishes it from a bogus id).
+   * On success it SLIDES the session forward (lastActiveAt + expiresAt), so only
+   * an authorized use extends its life; a rejected id cannot. */
+  async function resolveSessionCapability(
+    request: FastifyRequest,
+  ): Promise<SessionRecord | undefined> {
+    const id = bearerSessionId(request);
+    if (!id) return undefined;
+    const at = now();
+    const session = await sessions.find(id, at);
+    if (!session) return undefined;
+    await sessions.touch(id, at, new Date(at.getTime() + SESSION_TTL_MS));
+    return session;
   }
 
   app.post("/wallet/create", async (request, reply) => {
@@ -242,33 +289,58 @@ export function buildServer(deps: WalletServiceDeps): FastifyInstance {
     }
   });
 
-  app.get("/wallet/session/:id", async (request, reply) => {
-    const { id } = request.params as { id: string };
-    const session = await sessions.find(id);
-    if (!session) return reply.code(404).send({ error: "session_not_found" });
+  // Session/device management (technical-doc.md §5.1). Every route below is
+  // gated on a bearer SESSION CAPABILITY (RA-3/M1): the caller proves control of
+  // a live session on the account before reading or revoking its sessions. The
+  // session id travels ONLY in the Authorization header / request body, never in
+  // a URL path or query — Fastify logs request URLs but not headers/bodies, so a
+  // credential must not sit in a logged URL. `unauthorized` is returned
+  // identically for a missing, unknown, expired, or wrong-account bearer, so no
+  // response reveals whether an id was ever valid.
+
+  // The caller's OWN session (from the bearer). No id in the URL.
+  app.get("/wallet/session", async (request, reply) => {
+    const session = await resolveSessionCapability(request);
+    if (!session) return reply.code(401).send({ error: "unauthorized" });
     return reply.send(session);
   });
 
-  // Session/device management (technical-doc.md §5.1: users can manage
-  // active sessions/devices).
+  // List the sessions for an account. The bearer must be a live session bound to
+  // exactly the queried contract+network — no cross-account enumeration.
   app.get("/wallet/sessions", async (request, reply) => {
     const parsed = listSessionsQuerySchema.safeParse(request.query);
     if (!parsed.success) {
       return reply.code(400).send({ error: "invalid_query", details: parsed.error.issues });
     }
     const { contractId, network } = parsed.data;
+    const session = await resolveSessionCapability(request);
+    if (!session || session.contractId !== contractId || session.network !== network) {
+      return reply.code(401).send({ error: "unauthorized" });
+    }
     return reply.send({ sessions: await sessions.listByContract(contractId, network) });
   });
 
-  app.delete("/wallet/session/:id", async (request, reply) => {
-    const { id } = request.params as { id: string };
-    const existing = await sessions.find(id);
-    if (!existing) return reply.code(404).send({ error: "session_not_found" });
-    await sessions.delete(id);
+  // Revoke a session on the caller's OWN account. The target id is in the BODY
+  // (not the URL), and must belong to the same account as the bearer — a target
+  // on another account reads as not-found (no cross-account revoke, and the
+  // response does not confirm the target exists elsewhere).
+  app.post("/wallet/sessions/revoke", async (request, reply) => {
+    const session = await resolveSessionCapability(request);
+    if (!session) return reply.code(401).send({ error: "unauthorized" });
+    const parsed = revokeSessionBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_body", details: parsed.error.issues });
+    }
+    const target = await sessions.find(parsed.data.targetSessionId, now());
+    if (!target || target.contractId !== session.contractId || target.network !== session.network) {
+      return reply.code(404).send({ error: "session_not_found" });
+    }
+    await sessions.delete(target.id);
+    // Audit the event with a HASHED reference, never the raw id (a credential).
     await audit.record("session.revoked", {
-      sessionId: id,
-      contractId: existing.contractId,
-      network: existing.network,
+      sessionRef: sessionRef(target.id),
+      contractId: target.contractId,
+      network: target.network,
     });
     return reply.code(204).send();
   });


### PR DESCRIPTION
Second batch of re-audit fixes, scoped to the session/cleanup/policy surface (the funding-path Highs shipped in #231). Failing test first, one commit per fix, per-finding `Status: CLOSED` blocks in `docs/security-audit.md`.

Full gate green: **18/18 typecheck, all workspace test suites pass** under CI-mirrored conditions (`TEST_DATABASE_URL` + `CI_REQUIRE_DB=1`); `format:check` clean.

## M1 / RA-3 — session id is now a scoped bearer capability

M1 was open: `GET /wallet/sessions` and `DELETE /wallet/session/:id` had no ownership check — anyone knowing a victim's public C-address could enumerate their session ids and revoke them all. The finding was rated "not an authz bypass" **because sessions gated no authority** — this change makes them a *narrow* capability and updates every place that reasoned from the old premise.

- **Guard:** the session routes require `Authorization: Bearer <sessionId>` resolving to a **live** session **bound to the exact account** being read/revoked. Missing / unknown / expired / wrong-account all return an identical `401`, so no response reveals whether an id was ever valid. Enumeration + cross-account mass-revoke closed.
- **Expiry:** sessions now carry `expires_at` (migration `0002`) on a **7-day sliding window matching the device signer** (coupling noted in-code); `find`/`listByContract` treat expired as absent; `touch` slides forward only on an authorized use (a rejected/expired id can't extend itself). Fixes the pre-existing never-updated `lastActiveAt`.
- **No credential in logs:** the id moved out of the URL into the header/body (Fastify logs URLs, not headers/bodies) via reshaped routes (`GET /wallet/session` for own, `POST /wallet/sessions/revoke` with the target in the body); the audit log stores a **truncated `sha256(id)`** ref, never the raw id.
- **No auth drift:** a non-drift test asserts a valid session id grants nothing on `/wallet/submit` or `/wallet/create` — the capability stays narrow, not app-layer auth.
- **Premise sweep** (like "rolling window" x8): corrected the "not an access token / gates no authority" reasoning in `architecture-analysis.md` (session + authorization passages), the M1 finding rationale, the RA-3 status, and the remediation checklist — the conclusions built on the premise, not just the sentence.

## RA-5 — cleanup cancels offers before paying out balances

`collectCleanupOps` emitted payments (full balance) before offer cancels. For an account holding an asset it also sells on an open offer, the offered amount is a **selling liability** (not spendable), so paying the full balance first hit `op_underfunded` and the whole cleanup tx failed. Reordered: **cancel offers first** (frees liabilities), then payouts + trustline removals, then data deletes. Chosen over subtracting `selling_liabilities` (which would strand the locked remainder and still block trustline removal). Op order is now `manageSellOffer → payment → changeTrust → manageData`.

## RA-6 — the V3 detach invariant is now tested at the wiring layer

The fund-lock-critical invariant (standalone `SignerLimits(None)` → the wallet's `is_sole_self_removal` exception lets the admin passkey detach a reject-everything policy) was pinned **only at the pure `policyAttachArgs` helper**; the code that calls `kit.addPolicy`/`kit.remove` lived inline in `connector-factory` and was untested — a refactor inlining a `SignerLimits` map would ship green and re-introduce the permanent-fund-lock. Extracted the flow into `createPolicySignerActions`, tested with a fake kit (`attach` asserts `limits === undefined`; `detach` asserts `kit.remove(SignerKey.Policy(id))`), and `connector-factory` now **delegates to that tested function** — the feared refactor now breaks the test.

## Notes
- Branched from merged `main` (which now includes #231).
- **RA-10** (attestor mainnet guard bypassable by an unset passphrase) is deliberately **not** here — it's a worker-service guard-correctness defect, not the M5 design decision, and goes on its own `security/attestor-guard-hardening` branch (fail-closed on ambiguous passphrase + a repo-wide sweep for guards gating on a secret/passphrase *presence* rather than a flag).
- Mainnet remains **NO-GO** until the M5 multisig attestor and the two V6 dashboard facts are resolved; every verdict stays conditional on the unaudited `vellar-sdk`/`passkey-kit`.