### PR TITLE
Fix server↔client seam drift: session client orphan + create-budget V5 + cleanup chunks + verification log (RA-11)

### DIFF
--- a/apps/web/app/cleanup/page.tsx
+++ b/apps/web/app/cleanup/page.tsx
@@ -21,7 +21,16 @@ import {
 type Wizard =
   | { stage: "input" }
   | { stage: "plan"; plan: CleanupPlan }
-  | { stage: "cleanup"; step: CleanupStep; watching: boolean; timedOut: boolean }
+  // Cleanup may be SPLIT into multiple transactions (>100 ops); `steps` holds
+  // all of them and `index` is the one the user is signing now. The wizard walks
+  // every step in order before it advances to the merge.
+  | {
+      stage: "cleanup";
+      steps: CleanupStep[];
+      index: number;
+      watching: boolean;
+      timedOut: boolean;
+    }
   | { stage: "merge"; step: CleanupStep; watching: boolean; timedOut: boolean }
   | { stage: "done" };
 
@@ -66,9 +75,8 @@ export default function Cleanup() {
     run(async () => {
       const { steps } = await executeCleanup(accountId.trim(), destination.trim());
       if (steps.length === 0) return startMerge();
-      const step = steps[0]!;
-      setWizard({ stage: "cleanup", step, watching: true, timedOut: false });
-      void watch(step, "cleanup");
+      setWizard({ stage: "cleanup", steps, index: 0, watching: true, timedOut: false });
+      void watchCleanup(steps, 0);
     });
 
   const startMerge = () =>
@@ -78,15 +86,35 @@ export default function Cleanup() {
       void watch(step, "merge");
     });
 
-  async function watch(step: CleanupStep, stage: "cleanup" | "merge") {
+  // Walk each cleanup chunk in order: watch chunk `index`, and on confirmation
+  // advance to the next chunk (not straight to merge) until all are signed —
+  // only then build the merge. Dropping chunks 2..N left large accounts
+  // partially cleaned and dead-ended at a 409-on-merge.
+  async function watchCleanup(steps: CleanupStep[], index: number) {
+    const step = steps[index]!;
+    const seen = await watchTransaction(step.hash, { cancelled: () => cancelledRef.current });
+    if (cancelledRef.current) return;
+    if (!seen) {
+      setWizard({ stage: "cleanup", steps, index, watching: false, timedOut: true });
+      return;
+    }
+    const next = index + 1;
+    if (next < steps.length) {
+      setWizard({ stage: "cleanup", steps, index: next, watching: true, timedOut: false });
+      void watchCleanup(steps, next);
+    } else {
+      await startMerge();
+    }
+  }
+
+  async function watch(step: CleanupStep, stage: "merge") {
     const seen = await watchTransaction(step.hash, { cancelled: () => cancelledRef.current });
     if (cancelledRef.current) return;
     if (!seen) {
       setWizard({ stage, step, watching: false, timedOut: true });
       return;
     }
-    if (stage === "cleanup") await startMerge();
-    else setWizard({ stage: "done" });
+    setWizard({ stage: "done" });
   }
 
   return (
@@ -214,15 +242,33 @@ export default function Cleanup() {
           </section>
         )}
 
-        {(wizard.stage === "cleanup" || wizard.stage === "merge") && (
+        {wizard.stage === "cleanup" && (
           <SigningStepCard
-            step={wizard.step}
-            isMerge={wizard.stage === "merge"}
+            step={wizard.steps[wizard.index]!}
+            isMerge={false}
+            progress={
+              wizard.steps.length > 1
+                ? { current: wizard.index + 1, total: wizard.steps.length }
+                : undefined
+            }
             watching={wizard.watching}
             timedOut={wizard.timedOut}
             onKeepWaiting={() => {
               setWizard({ ...wizard, watching: true, timedOut: false });
-              void watch(wizard.step, wizard.stage);
+              void watchCleanup(wizard.steps, wizard.index);
+            }}
+          />
+        )}
+
+        {wizard.stage === "merge" && (
+          <SigningStepCard
+            step={wizard.step}
+            isMerge
+            watching={wizard.watching}
+            timedOut={wizard.timedOut}
+            onKeepWaiting={() => {
+              setWizard({ ...wizard, watching: true, timedOut: false });
+              void watch(wizard.step, "merge");
             }}
           />
         )}
@@ -260,12 +306,15 @@ export default function Cleanup() {
 function SigningStepCard({
   step,
   isMerge,
+  progress,
   watching,
   timedOut,
   onKeepWaiting,
 }: {
   step: CleanupStep;
   isMerge: boolean;
+  /** For a split cleanup: which transaction of how many. */
+  progress?: { current: number; total: number };
   watching: boolean;
   timedOut: boolean;
   onKeepWaiting: () => void;
@@ -278,6 +327,11 @@ function SigningStepCard({
       style={{ padding: 22, display: "flex", flexDirection: "column", gap: 12 }}
     >
       <span className="eyebrow">{step.title}</span>
+      {progress && (
+        <p style={{ fontSize: 13, color: "var(--muted2)" }}>
+          Transaction {progress.current} of {progress.total} — sign and submit each in order.
+        </p>
+      )}
       <p style={{ fontSize: 14, color: "var(--muted)" }}>{step.description}</p>
       {isMerge && (
         <p

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -20,8 +20,18 @@ export default function Settings() {
   const session = useWalletSession();
   const actions = useWalletActions();
 
-  const sessions = useSessions(session?.accountId, session?.network ?? "testnet");
-  const revoke = useRevokeSession(session?.accountId, session?.network ?? "testnet");
+  // The caller's own session id is the M1 bearer capability for the list/revoke
+  // routes (RA-3) — thread it through so the device list loads and revokes apply.
+  const sessions = useSessions(
+    session?.accountId,
+    session?.network ?? "testnet",
+    session?.serverSessionId,
+  );
+  const revoke = useRevokeSession(
+    session?.accountId,
+    session?.network ?? "testnet",
+    session?.serverSessionId,
+  );
 
   async function revokeSession(id: string) {
     await revoke.mutateAsync(id);

--- a/apps/web/app/verify/page.tsx
+++ b/apps/web/app/verify/page.tsx
@@ -143,7 +143,6 @@ function Explorer() {
 }
 
 function RecordCard({ record }: { record: PublicVerificationRecord }) {
-  const [showLog, setShowLog] = useState(false);
   return (
     <article
       className="neo-card"
@@ -191,27 +190,21 @@ function RecordCard({ record }: { record: PublicVerificationRecord }) {
           </>
         )}
       </dl>
-      {record.log && (
-        <div>
-          <button className="btn btn-ghost btn-sm" onClick={() => setShowLog((s) => !s)}>
-            {showLog ? "Hide build log" : "Show build log"}
-          </button>
-          {showLog && (
-            <pre
-              style={{
-                marginTop: 8,
-                padding: 12,
-                background: "var(--neo-bg, #111)",
-                borderRadius: 8,
-                fontSize: 12,
-                overflowX: "auto",
-                whiteSpace: "pre-wrap",
-              }}
-            >
-              {record.log}
-            </pre>
-          )}
-        </div>
+      {/* H3/FIX 6 (#229): the raw build log is no longer exposed by the API — it
+          leaked host paths / internal IPs. The server now returns a sanitized
+          public `statusDetail` (e.g. "Build failed (clone_failed)."). */}
+      {record.statusDetail && (
+        <p
+          style={{
+            marginTop: 8,
+            padding: 12,
+            background: "var(--neo-bg, #111)",
+            borderRadius: 8,
+            fontSize: 13,
+          }}
+        >
+          {record.statusDetail}
+        </p>
       )}
     </article>
   );

--- a/apps/web/e2e/cleanup.spec.ts
+++ b/apps/web/e2e/cleanup.spec.ts
@@ -133,6 +133,99 @@ test.describe("inspect and close account (mocked gateway + Horizon) @ci", () => 
     expect(called.merge).toBe(true);
   });
 
+  test("multi-transaction split: signs EVERY cleanup chunk before merging (FIX C)", async ({
+    page,
+  }) => {
+    // A >100-op account splits cleanup into multiple txs. The wizard must walk
+    // ALL chunks, then merge. The old wizard signed only steps[0] and dead-ended
+    // at a 409-on-merge; here, reaching "Account closed" proves both chunks were
+    // watched (the Horizon mock sees every tx, so getting to merge requires the
+    // full walk) and we assert the SECOND chunk's tx was polled.
+    const seen = new Set<string>();
+    await page.route("**/transactions/**", async (route) => {
+      seen.add(new URL(route.request().url()).pathname.split("/").pop() ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ successful: true }),
+      });
+    });
+    await page.route("**/lifecycle/**", async (route) => {
+      const url = route.request().url();
+      if (url.endsWith("/lifecycle/plan")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            plan: {
+              accountId: OLD_ACCOUNT,
+              destination: DESTINATION,
+              mergeReady: false,
+              estimatedTransactions: 3,
+              blockers: [
+                { type: "data", description: "Many data entries", actionRequired: "Delete them" },
+              ],
+            },
+          }),
+        });
+        return;
+      }
+      if (url.endsWith("/lifecycle/execute")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            steps: [
+              {
+                title: "Clean up the account (1/2)",
+                description: "Sign chunk 1",
+                hash: "chunk1hash",
+                xdr: "AAAA...chunk1",
+              },
+              {
+                title: "Clean up the account (2/2)",
+                description: "Sign chunk 2",
+                hash: "chunk2hash",
+                xdr: "AAAA...chunk2",
+              },
+            ],
+          }),
+        });
+        return;
+      }
+      if (url.endsWith("/lifecycle/merge")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            step: {
+              title: "Merge account",
+              description: "Sign this to merge and close",
+              hash: "mergehash",
+              xdr: "AAAA...merge",
+            },
+          }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto("/cleanup");
+    await page.getByPlaceholder("G...", { exact: true }).fill(OLD_ACCOUNT);
+    await page.getByPlaceholder(/classic account, not your smart wallet/).fill(DESTINATION);
+    await page.getByRole("button", { name: "Inspect account" }).click();
+    await expect(page.getByText("Cleanup plan")).toBeVisible();
+    await page.getByRole("button", { name: "Start cleanup" }).click();
+
+    // Reaching the terminal state requires walking BOTH cleanup chunks then the
+    // merge — the old single-chunk wizard would stall at merge (409) here.
+    await expect(page.getByText(/Account closed/i)).toBeVisible();
+    // The second chunk's tx was actually watched (not dropped).
+    expect(seen.has("chunk2hash")).toBe(true);
+    expect(seen.has("mergehash")).toBe(true);
+  });
+
   test("fast path: already merge-ready → straight to merge → closed", async ({ page }) => {
     await page.route("**/lifecycle/**", async (route) => {
       const url = route.request().url();

--- a/apps/web/lib/http-backend.test.ts
+++ b/apps/web/lib/http-backend.test.ts
@@ -187,7 +187,7 @@ describe("session client ↔ server seam (real buildServer)", () => {
     } finally {
       await app.close();
     }
-  });
+  }, 20_000);
 
   it("listSessions WITHOUT a bearer is rejected by the real server (seam would hide this with a mock)", async () => {
     const { app, client } = await seamBackend();
@@ -200,7 +200,7 @@ describe("session client ↔ server seam (real buildServer)", () => {
     } finally {
       await app.close();
     }
-  });
+  }, 20_000);
 
   it("revokeSession: hits the REAL /wallet/sessions/revoke route and actually revokes (not a silent no-op)", async () => {
     const { app, client } = await seamBackend();
@@ -226,7 +226,7 @@ describe("session client ↔ server seam (real buildServer)", () => {
     } finally {
       await app.close();
     }
-  });
+  }, 20_000);
 
   it("revokeSession THROWS on a non-existent target (no 404-swallowed-as-success)", async () => {
     const { app, client } = await seamBackend();
@@ -239,7 +239,7 @@ describe("session client ↔ server seam (real buildServer)", () => {
     } finally {
       await app.close();
     }
-  });
+  }, 20_000);
 
   it("revokeSession without a valid bearer is rejected (401), not silently accepted", async () => {
     const { app, client } = await seamBackend();
@@ -251,5 +251,5 @@ describe("session client ↔ server seam (real buildServer)", () => {
     } finally {
       await app.close();
     }
-  });
+  }, 20_000);
 });

--- a/apps/web/lib/http-backend.test.ts
+++ b/apps/web/lib/http-backend.test.ts
@@ -127,54 +127,129 @@ describe("submitTransaction", () => {
   });
 });
 
-describe("listSessions", () => {
-  it("GETs sessions with the account and network in the query", async () => {
-    const record = {
-      id: "s1",
-      contractId: "C1",
+// SEAM-CROSSING integration tests (security-audit.md RA-3 / seam-drift lesson):
+// the real http-backend client driven against the REAL wallet-service buildServer
+// — NOT a mocked fetch. Mocked-fetch client tests can only assert that the client
+// does what the client does; they cannot catch a server contract change (M1
+// renamed the session routes and added a required bearer, and the old
+// mocked-fetch tests happily pinned the client calling the REMOVED route and
+// swallowing the resulting 404 as success). Any route the client calls is
+// exercised here against the actual server so the two sides must AGREE.
+describe("session client ↔ server seam (real buildServer)", () => {
+  // Adapt Fastify's inject() to a fetch-shaped function the client can call.
+  async function seamBackend() {
+    const { buildServer } = await import("@vellar/wallet-service/server");
+    const app = buildServer({
+      submitter: { submit: async () => ({ hash: "txhash" }) },
+    });
+    await app.ready();
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      const u = new URL(url);
+      const res = await app.inject({
+        method: (init?.method ?? "GET") as "GET" | "POST",
+        url: u.pathname + u.search,
+        headers: (init?.headers as Record<string, string>) ?? {},
+        payload: init?.body ? (init.body as string) : undefined,
+      });
+      // 204/205/304 must have a null body per the Fetch spec.
+      const nullBody = res.statusCode === 204 || res.statusCode === 205 || res.statusCode === 304;
+      return new Response(nullBody ? null : res.body, {
+        status: res.statusCode,
+        headers: { "content-type": (res.headers["content-type"] as string) ?? "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const client = createHttpWalletBackend("http://seam.test", fetchImpl);
+    return { app, client };
+  }
+
+  /** Create a wallet+session via the real client and return the caller's own
+   * session id (the M1 bearer). */
+  async function openSession(client: ReturnType<typeof createHttpWalletBackend>) {
+    const { sessionId } = await client.submitWalletCreation({
+      keyId: "key-seam",
+      contractId: "CSEAM",
       network: "testnet",
-      createdAt: "2026-07-16T10:00:00.000Z",
-      lastActiveAt: "2026-07-16T10:00:00.000Z",
-    };
-    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { sessions: [record] }));
-    const backend = createHttpWalletBackend("http://api.test", fetchImpl);
-
-    await expect(backend.listSessions({ contractId: "C1", network: "testnet" })).resolves.toEqual({
-      sessions: [record],
+      signedTx: "signed-deploy-xdr",
     });
-    expect(fetchImpl).toHaveBeenCalledWith(
-      "http://api.test/wallet/sessions?contractId=C1&network=testnet",
-    );
+    return sessionId;
+  }
+
+  it("listSessions: the client sends the bearer the server requires (would 401 without it)", async () => {
+    const { app, client } = await seamBackend();
+    try {
+      const bearer = await openSession(client);
+      const { sessions } = await client.listSessions({
+        contractId: "CSEAM",
+        network: "testnet",
+        bearerSessionId: bearer,
+      });
+      expect(sessions.map((s) => s.id)).toContain(bearer);
+    } finally {
+      await app.close();
+    }
   });
 
-  it("throws on failure", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(500, { error: "boom" }));
-    const backend = createHttpWalletBackend("http://api.test", fetchImpl);
-    await expect(
-      backend.listSessions({ contractId: "C1", network: "testnet" }),
-    ).rejects.toBeInstanceOf(WalletApiError);
-  });
-});
-
-describe("revokeSession", () => {
-  it("DELETEs the session", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
-    const backend = createHttpWalletBackend("http://api.test", fetchImpl);
-    await backend.revokeSession("sess-1");
-    expect(fetchImpl).toHaveBeenCalledWith("http://api.test/wallet/session/sess-1", {
-      method: "DELETE",
-    });
+  it("listSessions WITHOUT a bearer is rejected by the real server (seam would hide this with a mock)", async () => {
+    const { app, client } = await seamBackend();
+    try {
+      await openSession(client);
+      // Call the client's list with an empty bearer — the real server 401s.
+      await expect(
+        client.listSessions({ contractId: "CSEAM", network: "testnet", bearerSessionId: "" }),
+      ).rejects.toMatchObject({ status: 401 });
+    } finally {
+      await app.close();
+    }
   });
 
-  it("treats an already-revoked session (404) as success", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(404, { error: "session_not_found" }));
-    const backend = createHttpWalletBackend("http://api.test", fetchImpl);
-    await expect(backend.revokeSession("gone")).resolves.toBeUndefined();
+  it("revokeSession: hits the REAL /wallet/sessions/revoke route and actually revokes (not a silent no-op)", async () => {
+    const { app, client } = await seamBackend();
+    try {
+      // Two sessions on the same account; revoke the second using the first's bearer.
+      const bearer = await openSession(client);
+      const connect = await client.lookupContractId({ keyId: "key-seam", network: "testnet" });
+      const target = (connect as { sessionId: string }).sessionId;
+
+      await client.revokeSession({ bearerSessionId: bearer, targetSessionId: target });
+
+      // The revoked session is GONE — presenting it as a bearer now 401s.
+      await expect(
+        client.listSessions({ contractId: "CSEAM", network: "testnet", bearerSessionId: target }),
+      ).rejects.toMatchObject({ status: 401 });
+      // The caller's own session still works.
+      const { sessions } = await client.listSessions({
+        contractId: "CSEAM",
+        network: "testnet",
+        bearerSessionId: bearer,
+      });
+      expect(sessions.map((s) => s.id)).not.toContain(target);
+    } finally {
+      await app.close();
+    }
   });
 
-  it("throws on server failures", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(500, { error: "boom" }));
-    const backend = createHttpWalletBackend("http://api.test", fetchImpl);
-    await expect(backend.revokeSession("s")).rejects.toBeInstanceOf(WalletApiError);
+  it("revokeSession THROWS on a non-existent target (no 404-swallowed-as-success)", async () => {
+    const { app, client } = await seamBackend();
+    try {
+      const bearer = await openSession(client);
+      // A bogus target on our own account → server 404 session_not_found → client MUST throw.
+      await expect(
+        client.revokeSession({ bearerSessionId: bearer, targetSessionId: "does-not-exist" }),
+      ).rejects.toMatchObject({ status: 404 });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("revokeSession without a valid bearer is rejected (401), not silently accepted", async () => {
+    const { app, client } = await seamBackend();
+    try {
+      const bearer = await openSession(client);
+      await expect(
+        client.revokeSession({ bearerSessionId: "not-a-session", targetSessionId: bearer }),
+      ).rejects.toMatchObject({ status: 401 });
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/apps/web/lib/http-backend.ts
+++ b/apps/web/lib/http-backend.ts
@@ -39,12 +39,20 @@ export interface SessionRecord {
 }
 
 export interface WalletApiClient extends WalletBackend, PaymentSubmitBackend {
+  /** List the sessions for an account. `bearerSessionId` is the CALLER's own
+   * live session id (WalletSession.serverSessionId) — the M1 bearer capability
+   * (security-audit.md RA-3): the server requires it and scopes the list to the
+   * account that session is bound to. */
   listSessions(input: {
     contractId: string;
     network: string;
+    bearerSessionId: string;
   }): Promise<{ sessions: SessionRecord[] }>;
-  /** Revoking an already-gone session is a no-op, not an error. */
-  revokeSession(id: string): Promise<void>;
+  /** Revoke `targetSessionId` (which may be a different device on the same
+   * account), authorized by the caller's own live session `bearerSessionId`.
+   * A revoke that does not apply (unknown/cross-account target) is a real error,
+   * NOT a silent success — see the 404 handling below. */
+  revokeSession(input: { bearerSessionId: string; targetSessionId: string }): Promise<void>;
 }
 
 export function createHttpWalletBackend(
@@ -53,10 +61,12 @@ export function createHttpWalletBackend(
 ): WalletApiClient {
   const base = apiUrl.replace(/\/+$/, "");
 
-  async function post(path: string, body: unknown): Promise<Response> {
+  async function post(path: string, body: unknown, bearer?: string): Promise<Response> {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (bearer) headers.authorization = `Bearer ${bearer}`;
     return fetchImpl(`${base}${path}`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers,
       body: JSON.stringify(body),
     });
   }
@@ -87,19 +97,26 @@ export function createHttpWalletBackend(
       return (await res.json()) as { hash: string };
     },
 
-    // Session/device management (technical-doc.md §5.1).
-    async listSessions({ contractId, network }: { contractId: string; network: string }) {
+    // Session/device management (technical-doc.md §5.1). Both routes carry the
+    // M1 bearer capability (Authorization header, RA-3) — the session id is a
+    // credential, so it travels in the header/body, never the URL.
+    async listSessions({ contractId, network, bearerSessionId }) {
       const query = new URLSearchParams({ contractId, network });
-      const res = await fetchImpl(`${base}/wallet/sessions?${query}`);
+      const res = await fetchImpl(`${base}/wallet/sessions?${query}`, {
+        headers: { authorization: `Bearer ${bearerSessionId}` },
+      });
       if (!res.ok) throw await toApiError(res);
       return (await res.json()) as { sessions: SessionRecord[] };
     },
 
-    async revokeSession(id: string) {
-      const res = await fetchImpl(`${base}/wallet/session/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
-      if (!res.ok && res.status !== 404) throw await toApiError(res);
+    async revokeSession({ bearerSessionId, targetSessionId }) {
+      // POST /wallet/sessions/revoke: the target id is in the BODY (not the URL,
+      // which Fastify logs), authorized by the caller's own session bearer. A
+      // non-2xx is a REAL failure and MUST throw — the old client swallowed a
+      // 404 as success, which silently no-op'd every revoke when the route was
+      // renamed. Revocation is a security control; it must fail loudly.
+      const res = await post("/wallet/sessions/revoke", { targetSessionId }, bearerSessionId);
+      if (!res.ok) throw await toApiError(res);
     },
   };
 }

--- a/apps/web/lib/sessions.ts
+++ b/apps/web/lib/sessions.ts
@@ -18,19 +18,43 @@ const sessionsKey = (contractId: string | undefined, network: Network) => [
   network,
 ];
 
-export function useSessions(contractId: string | undefined, network: Network) {
+// bearerSessionId is the caller's OWN live session id (WalletSession
+// .serverSessionId) — the M1 bearer capability the list/revoke routes require
+// (RA-3). Without it the routes 401, so the query stays disabled until it is
+// available (e.g. a session resumed from localStorage before the server id is
+// known).
+export function useSessions(
+  contractId: string | undefined,
+  network: Network,
+  bearerSessionId: string | undefined,
+) {
   return useQuery({
     queryKey: sessionsKey(contractId, network),
-    enabled: contractId !== undefined,
+    enabled: contractId !== undefined && bearerSessionId !== undefined,
     queryFn: async () =>
-      (await api().listSessions({ contractId: contractId as string, network })).sessions,
+      (
+        await api().listSessions({
+          contractId: contractId as string,
+          network,
+          bearerSessionId: bearerSessionId as string,
+        })
+      ).sessions,
   });
 }
 
-export function useRevokeSession(contractId: string | undefined, network: Network) {
+export function useRevokeSession(
+  contractId: string | undefined,
+  network: Network,
+  bearerSessionId: string | undefined,
+) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (sessionId: string) => api().revokeSession(sessionId),
+    mutationFn: (targetSessionId: string) => {
+      if (!bearerSessionId) {
+        throw new Error("Cannot revoke a session without a live session of your own.");
+      }
+      return api().revokeSession({ bearerSessionId, targetSessionId });
+    },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: sessionsKey(contractId, network) }),
   });
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "postcss": "^8.5.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.0",
+    "@vellar/wallet-service": "workspace:*"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -16,5 +16,15 @@ export default defineConfig({
     globals: true,
     include: ["**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next", "e2e"],
+    server: {
+      deps: {
+        // passkey-kit and its SDK deps ship raw TypeScript; Vitest must
+        // transform them (Node's loader refuses to type-strip node_modules).
+        // Needed by the http-backend seam test, which imports the real
+        // wallet-service buildServer (whose derivation path pulls passkey-kit).
+        // Mirrors next.config transpilePackages + wallet-service's vitest.
+        inline: ["passkey-kit", "passkey-kit-sdk", "sac-sdk"],
+      },
+    },
   },
 });

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -725,6 +725,14 @@ management DoS + session-graph disclosure, **not** an authz bypass.
 >   `docs/architecture-analysis.md` (the "What passes for a session" + "Where authorization is real"
 >   passages) and in the M1 finding above was corrected — a conclusion built on the old premise, not
 >   just the sentence, so a later reader doesn't re-derive the stale rating.
+>
+> **⚠ CORRECTION (RA-11, branch `security/session-client-seam`): "CLOSED" above was SERVER-ONLY.**
+> The scoped re-audit of this surface found the M1 commit reshaped the server routes but **orphaned
+> the web client** — `listSessions` sent no bearer (permanent 401) and `revokeSession` DELETEd the
+> removed route and swallowed the 404 as success (revoke was a silent fail-open no-op). The guard was
+> correct but _unreachable by the real client_, and the client's mocked-fetch tests pinned the broken
+> behavior. Fixed under RA-11 with a **seam-crossing** test (real client ↔ real `buildServer`). The
+> server-side facts in this block hold; the feature is only now delivered end-to-end.
 
 ### RA-4 — `ALLOW_INMEMORY` fail-closed boot guard is **inert** on the deploy targets 🟡 Medium `[my code]`
 
@@ -883,6 +891,16 @@ permissive side.** If a decision needs a signal, make the signal explicit and re
 its absence, and cross-check any value that has to keep a default for another purpose (like a
 passphrase needed for signing).
 
+> **⚠ CORRECTION (RA-11): the sweep missed a 4th related site — a DIFFERENT axis of the same class.**
+> This sweep hunted _defaulted-value_ network inference. But `wallet-service`'s **create** budget line
+> keyed its network off the **request body** (`parsed.data.network`), not off config — a
+> _body-vs-config_ variant of "a security decision trusting an untrusted/wrong source." It survived
+> because it wasn't a `?? default` shape. Found by the #232 re-audit (H-3), fixed under RA-11: the
+> create line now meters on `deps.budgetNetwork` (from `resolveNetwork`), and **all three
+> `tryConsume` sites are re-confirmed to key off server config** (sponsor, create, policy-deploy). The
+> rule generalizes: a network/security label must come from server config, whether the risk is a
+> permissive _default_ or a trusted _request body_.
+
 ### RA-5 — Cleanup builder pays the full asset balance **before** cancelling offers (ignores selling liabilities) 🟡 Medium `[my code]`
 
 `services/lifecycle-service/src/builder.ts:59` (+ `horizon.ts` never parses `selling_liabilities`).
@@ -907,6 +925,12 @@ irreversible merge on partial cleanup — a liveness/correctness bug, not a safe
 > holding an asset it also sells on an open offer emits the cancel before the payment (asserted every
 > `manageSellOffer` precedes every `payment`), and the end-to-end op order is now
 > `manageSellOffer → payment → changeTrust → manageData`.
+>
+> **⚠ CORRECTION (RA-11): "end-to-end" was builder-only.** The re-audit found the cleanup WIZARD
+> consumer signed only `steps[0]` of a multi-transaction split (>100 ops) and dead-ended at a 409
+> merge, so end-to-end cleanup was NOT delivered for large accounts. The builder ordering + split
+> are correct (safety held — no fund loss, merge preflight fail-closed); the wizard is fixed under
+> RA-11 to walk every chunk, with a multi-chunk e2e proven to catch the drop.
 
 ### RA-6 — V3 detach invariant is pinned only at the pure helper; the attach/detach wiring is untested 🟡 Medium `[my code]`
 
@@ -933,6 +957,13 @@ own removal). No live bypass today; a test-coverage gap on a fund-lock-critical 
 > path is the tested path — the refactor the finding feared (inlining a `SignerLimits` map to make the
 > policy a required co-signer) would now break these tests instead of shipping green. The browser-only
 > `SignerKey`/`SignerStore` enums are injected, keeping the action module SSR/test-safe.
+>
+> **⚠ CORRECTION (RA-11): the "production path is the tested path" claim is slightly too strong.**
+> The re-audit's L-3 found the `connector-factory → createPolicySignerActions` DELEGATION edge itself
+> is untested (no `connector-factory` test exists; the helper is imported directly), so a refactor
+> that _abandons_ the helper and inlines a `SignerLimits` map would still ship green. The wiring
+> assertion inside `createPolicySignerActions` is real and load-bearing; the residual gap is the thin
+> forwarding wrapper. Low — tracked as RA-11/L-3, a cheap follow-up on a fund-lock invariant.
 
 ### RA-7 — `isBlockedAddress` misses hex-form IPv4-mapped + NAT64 IPv6 ℹ️ Info `[my code]`
 
@@ -998,14 +1029,77 @@ the way the kit actually produces the value.
 > lines it mirrors. Rule going forward: any test asserting on a decoded passkey-kit XDR shape must be
 > built from (or pinned against) the real kit shape, never hand-fit to the parser.
 
+### RA-11 — Server↔client SEAM DRIFT: contract changes shipped without updating (or seam-testing) the consumer 🔴 High `[my code]`
+
+A **scoped re-audit of the #232 session surface** (M1 introduced a bearer capability to a design with
+no app-layer auth — the same category that produced RA-1/RA-2) found the server-side capability
+**genuinely sound** (narrow scope, expiry-as-absence, no window-slide-on-reject, no leakage, hashed
+audit ref verified) — but the **client** was orphaned, and the pattern turned out to span multiple PRs.
+This is the sibling of RA-9: **RA-9 was tests asserting what the code does rather than what the
+_library_ produces; RA-11 is tests asserting what each _side_ does rather than what the two sides
+_agree on_.** A contract change between server and client needs a test that crosses the seam.
+
+Findings (fixed on branch `security/session-client-seam`):
+
+- **RA-11-A [High] — M1 orphaned the web session client (#232).** `apps/web/lib/http-backend.ts`:
+  `listSessions` sent no `Authorization` bearer → the M1 guard 401s → the device list never rendered;
+  `revokeSession` called the **removed** `DELETE /wallet/session/:id` → 404 → and **swallowed the 404
+  as success** → every user-initiated revoke was a silent fail-open no-op on the lost/compromised-device
+  path. The client's mocked-fetch tests pinned exactly this (asserting the removed URL + 404-as-success).
+  **Fix:** the client sends the bearer, `revokeSession` POSTs `/wallet/sessions/revoke` with
+  `{targetSessionId}` + bearer and **throws on any non-2xx** (the 404-swallow is gone; audited the rest
+  of `http-backend` — the only other status special-case, `lookupContractId`'s 404→undefined, is a
+  legitimate "unknown passkey" semantic, kept). The mocked-fetch session tests are **replaced by a
+  seam-crossing integration test**: the real client driven against the real `buildServer` (Fastify
+  `inject`→fetch adapter), covering every session route — **proven to catch the original bug** (reverting
+  to the old client fails 3 seam tests the old mocked tests passed). Added `@vellar/wallet-service/server`
+  subpath export + web devDep + the `passkey-kit` vitest inline-deps the server import needs.
+- **RA-11-B [High] — create budget metered on the request body, not server config (H-3, V5).** Covered
+  in the RA-10 sweep correction above: `wallet-service` create line keyed off `parsed.data.network`, so
+  an attacker POSTing a mismatched `network` split relayer-funded create spend across the
+  testnet/mainnet partitions (2× the effective ceiling). **Fix:** meter on `deps.budgetNetwork` from
+  `resolveNetwork`; all three `tryConsume` sites re-confirmed config-keyed.
+- **RA-11-C [Medium] — cleanup wizard dropped split chunks (M-1).** Covered in the RA-5 correction:
+  the wizard signed only `steps[0]` of a >100-op split and dead-ended at a 409 merge. **Fix:** the wizard
+  walks every chunk (progress "Transaction n of m") before merging; a multi-chunk e2e proves it.
+- **RA-11-D [Low] — a SECOND orphan from a DIFFERENT PR (#229).** The route-drift enumeration (run
+  because RA-11-A proved the class isn't PR-scoped) found #229's H3/FIX 6 stopped exposing the raw build
+  `log` on the verification API (it leaked host paths / internal IPs) and returns a sanitized
+  `statusDetail` — but `packages/verification-sdk`'s `PublicVerificationRecord` still declared `log?` and
+  omitted `statusDetail`, and `apps/web/app/verify/page.tsx` rendered a "Show build log" toggle behind
+  `record.log` (silently gone; `statusDetail` unreachable). Graceful degradation, not a crash. **Fix:**
+  SDK type + verify page consume `statusDetail`.
+- **RA-11-E [Low, residual] — `/policies/deploy` client not verifiable in-repo (#230).** L1 added
+  422/503 failure modes to `/policies/deploy`; its client lives in the **external** `vellar-sdk` npm
+  package (not in this repo), so its handling **cannot be confirmed here**. Flagged for review against
+  the separate `vellar-sdk` repo — if that client assumes 2xx, it's a candidate third orphan.
+
+Route-drift enumeration verdict (all 5 PRs): the wallet `/create` + `/submit` new 403/503 modes are
+**correctly** handled by the web client's typed-error path; `/wallet/session*` (RA-11-A) and the
+verification `log` field (RA-11-D) were orphaned; `/policies/deploy` (RA-11-E) is external-only.
+
+> **Status (RA-11): A/B/C/D CLOSED (branch `security/session-client-seam`), each with a test proven to
+> catch its bug; the seam-crossing test is the durable fix — it makes the whole class recur-proof for
+> the wallet session routes. E (external SDK) and the RA-6/L-3 delegation-edge gap remain as flagged
+> follow-ups.** Lesson recorded: **any server↔client contract change needs a seam-crossing test; a
+> mocked-fetch client test can only assert what the client does.**
+
 ### Re-audit bottom line
 
 - **Closed by passing test (verified by reading assertions):** C1/H1/V2, V1 derivation gate, H2, H3,
-  M2, M6-readiness, M7, L1, L3, L4, L5, L6/L6b.
+  M2, M6-readiness, M7, L1, L3, L4, L5, L6/L6b; RA-1, RA-2, RA-9 (#231); RA-4, RA-10 + the
+  network-label class (#233); RA-3/M1, RA-5, RA-6 **server-side** (#232); **RA-11-A/B/C** (client seam,
+  create-budget V5, cleanup-chunk walk) + **RA-11-D** (verification `statusDetail`), each with a
+  seam-crossing or bug-catching test (#`security/session-client-seam`).
 - **Closed by doc/config/deferral (NOT code-fixed):** M3, M4, M5, M8, M9 (see RA-8).
-- **Open / partial:** RA-1, RA-2 (funding-path Highs), RA-3 (M1), RA-4, RA-5, RA-6, RA-7.
-- **Mainnet: NO-GO** until RA-1, RA-2, M1 are fixed+tested, plus the deferred prerequisites (M5
-  multisig attestor, V3 detach UI) and the two V6 dashboard facts (L2 port firewalling, M9
-  autoDeploy/branch-protection) are confirmed. Every verdict remains conditional on the **unaudited**
+- **Open / partial:** RA-7 (latent IPv6, Info); RA-11-E (`/policies/deploy` external `vellar-sdk`
+  client — unverifiable in-repo); RA-6/L-3 (connector-factory delegation-edge test — cheap follow-up);
+  RA-3's L-1/L-2/L-5 (list-route inject-clock seam, sibling-id exposure, stale-record display — all Low,
+  acceptable-with-documentation).
+- **Mainnet: NO-GO** until the deferred prerequisites (M5 multisig attestor, V3 detach UI) are done, the
+  two V6 dashboard facts (L2 port firewalling, M9 autoDeploy/branch-protection) are confirmed, and
+  RA-11-E is checked against the external `vellar-sdk`. The funding-path Highs (RA-1/RA-2) and the
+  session/client Highs (RA-11-A/B) are now fixed+tested. Every verdict remains conditional on the
+  **unaudited**
   `vellar-sdk` / `passkey-kit` (passkey ceremony, session store, address derivation this repo
   enforces against — and the V1→V2 credential upgrade that drives RA-1 lives in that unread kit).

--- a/packages/verification-sdk/src/index.ts
+++ b/packages/verification-sdk/src/index.ts
@@ -9,9 +9,12 @@ import type { VerificationRecord, VerificationStatus } from "@vellar/types";
 
 export type { VerificationRecord, VerificationStatus };
 
-/** A public verification record as returned by the API (build log included). */
+/** A public verification record as returned by the API. The raw build log is
+ * NOT exposed (H3/FIX 6 — it leaked host paths / internal IPs); the API returns
+ * a sanitized `statusDetail` instead. */
 export interface PublicVerificationRecord extends VerificationRecord {
-  log?: string;
+  /** Sanitized, public-safe failure/status detail (e.g. "Build failed (clone_failed)."). */
+  statusDetail?: string;
 }
 
 /** The cheap trust-signal lookup used by the badge. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.0
         version: 19.2.3(@types/react@19.2.17)
+      '@vellar/wallet-service':
+        specifier: workspace:*
+        version: link:../../services/wallet-service
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0

--- a/services/wallet-service/package.json
+++ b/services/wallet-service/package.json
@@ -28,6 +28,7 @@
     "vitest": "^3.2.0"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./server": "./src/server.ts"
   }
 }

--- a/services/wallet-service/src/index.ts
+++ b/services/wallet-service/src/index.ts
@@ -99,6 +99,9 @@ if (dbHandle) {
   budget = createUnavailableBudget();
 }
 deps.budget = budget;
+// Create budget line meters on the server-config network (V5/RA-3), same source
+// as the sponsor line — never the request body.
+deps.budgetNetwork = budgetNetwork;
 
 // Now build the submitter (sponsor path metered by the same budget).
 let submitter = config.relayer

--- a/services/wallet-service/src/server.test.ts
+++ b/services/wallet-service/src/server.test.ts
@@ -310,6 +310,7 @@ describe("POST /wallet/create budget line (FIX 3)", () => {
     app = buildServer({
       submitter: workingSubmitter(),
       networkPassphrase: PASSPHRASE,
+      budgetNetwork: "testnet",
       budget: { tryConsume },
     });
     const res = await app.inject({
@@ -319,6 +320,30 @@ describe("POST /wallet/create budget line (FIX 3)", () => {
     });
     expect(res.statusCode).toBe(201);
     expect(tryConsume).toHaveBeenCalledWith({ line: "create", network: "testnet", stroops: 0n });
+  });
+
+  it("meters the create budget on SERVER CONFIG network, never the request body (V5)", async () => {
+    // The RA-3-class defect: create metered on parsed.data.network (the body), so
+    // an attacker could POST network:"testnet" against a mainnet server and hit
+    // the idle testnet budget partition — splitting spend across two ceilings.
+    // Metering MUST key off deps.budgetNetwork (config), ignoring the body.
+    const derived = deriveWalletContractId(KEY_ID, { networkPassphrase: PASSPHRASE });
+    const tryConsume = vi.fn().mockResolvedValue({ ok: true });
+    app = buildServer({
+      submitter: workingSubmitter(),
+      networkPassphrase: PASSPHRASE,
+      budgetNetwork: "mainnet", // server is on mainnet…
+      budget: { tryConsume },
+    });
+    const res = await app.inject({
+      method: "POST",
+      url: "/wallet/create",
+      // …but the body claims testnet.
+      payload: { keyId: KEY_ID, contractId: derived, network: "testnet", signedTx: "xdr" },
+    });
+    expect(res.statusCode).toBe(201);
+    // Metering hit the CONFIG partition (mainnet), not the body (testnet).
+    expect(tryConsume).toHaveBeenCalledWith({ line: "create", network: "mainnet", stroops: 0n });
   });
 
   it("returns 503 (create_budget_exceeded) and does NOT submit when the budget refuses", async () => {

--- a/services/wallet-service/src/server.ts
+++ b/services/wallet-service/src/server.ts
@@ -7,6 +7,7 @@ import {
   domainMetrics,
   recordOutcome,
   type SpendBudget,
+  type BudgetNetwork,
 } from "@vellar/service-kit";
 import {
   createMemoryAuditLog,
@@ -95,6 +96,12 @@ export interface WalletServiceDeps {
    * returns 503. Unset = budgeting disabled (dev / no relayer). The sponsor
    * line is metered inside the submitter, where the fee is known. */
   budget?: SpendBudget;
+  /** Network label for the create budget ledger line — from SERVER CONFIG
+   * (resolveNetwork), NEVER the request body's network field (security-audit
+   * V5/RA-3). Required alongside `budget`; without it the create route cannot
+   * meter (fails closed). Metering on the body would let a caller split spend
+   * across the testnet/mainnet partitions and double the effective ceiling. */
+  budgetNetwork?: BudgetNetwork;
 }
 
 export function buildServer(deps: WalletServiceDeps): FastifyInstance {
@@ -180,7 +187,16 @@ export function buildServer(deps: WalletServiceDeps): FastifyInstance {
     if (deps.budget) {
       let allowed: boolean;
       try {
-        const r = await deps.budget.tryConsume({ line: "create", network, stroops: 0n });
+        // Meter on the SERVER-CONFIG network (V5/RA-3), never the request body:
+        // a body-keyed line would let a caller split spend across the
+        // testnet/mainnet partitions and double the effective ceiling. Fail
+        // closed if budgetNetwork wasn't wired alongside the budget.
+        if (!deps.budgetNetwork) throw new Error("budget configured without budgetNetwork");
+        const r = await deps.budget.tryConsume({
+          line: "create",
+          network: deps.budgetNetwork,
+          stroops: 0n,
+        });
         allowed = r.ok;
       } catch (err) {
         request.log.error(err, "create budget accounting failed; refusing");


### PR DESCRIPTION
The scoped re-audit of #232's session surface found the **server-side** capability sound, but the **web client was orphaned** — and the route-drift enumeration showed the drift spans multiple PRs. This branch fixes all of it, each with a test **proven to catch the original bug**.

Full gate green: **18/18 typecheck, all workspace suites pass** (CI-mirrored: `TEST_DATABASE_URL` + `CI_REQUIRE_DB=1`); `format:check` clean.

## The class (RA-11)
RA-9 was tests asserting what the **code** does vs what the **library** produces. RA-11 is tests asserting what each **side** does vs what the two sides **agree on**. A contract change between server and client needs a test that **crosses the seam** — a mocked-fetch client test can only assert what the client does.

## 🔴 FIX A (H-1) — session client orphaned by M1 (#232)
`listSessions` sent no bearer (permanent 401 → device list never rendered); `revokeSession` DELETEd the **removed** route and **swallowed the 404 as success** → every user-initiated revoke was a silent fail-open no-op (a security control that didn't work). The client's mocked-fetch tests pinned the broken behavior.
- Client now sends `Authorization: Bearer <own sessionId>`, POSTs `/wallet/sessions/revoke` with `{targetSessionId}`, and **throws on any non-2xx** (404-swallow gone; audited the rest — `lookupContractId`'s 404→undefined is a legit "unknown passkey" semantic, kept).
- **Seam-crossing integration test**: the real client driven against the real `buildServer` (Fastify `inject`→fetch adapter), covering every session route. **Proven to catch the bug** — reverting to the old client fails 3 seam tests the old mocked tests passed.

## 🔴 FIX B (H-3) — create budget metered on the request body, not server config (V5)
The create funding line keyed off `parsed.data.network`. The derivation gate never compares the body network, so an attacker builds a genuine mainnet deploy but POSTs `network:"testnet"` → metering hits the idle testnet partition → **2× the effective per-network create ceiling** + mislabeled audit. Fixed to meter on `deps.budgetNetwork` (from `resolveNetwork`). **Completeness audit** (the check #233 should have done): all three `tryConsume` sites re-confirmed config-keyed (sponsor, create, policy-deploy).

## 🟡 FIX C (M-1) — cleanup wizard dropped split chunks
The wizard signed only `steps[0]` of a >100-op split and dead-ended at a 409 merge; large accounts couldn't finish. (Safety held — no fund loss, merge preflight fail-closed.) Now walks every chunk (progress "Transaction n of m") before merging. **Multi-chunk e2e proves it** (reverting to `steps[0]`-only fails it).

## 🟢 FIX A2 (RA-11-D) — a SECOND orphan, from a DIFFERENT PR (#229)
The route-drift enumeration (run because the orphan class isn't PR-scoped) found #229's H3/FIX 6 stopped exposing the raw build `log` (it leaked host paths / internal IPs) and returns `statusDetail`, but `verification-sdk`'s type still declared `log?` and the verify page rendered a "Show build log" toggle. Graceful degradation. Fixed SDK type + verify page to use `statusDetail`.

## Answering "was the client orphaned twice?"
**Yes.** Route-drift enumeration across all 5 PRs: `/wallet/session*` (A) and the verification `log` field (D) were orphaned; `/wallet/create` + `/wallet/submit`'s new 403/503 modes are **correctly** handled by the client's typed-error path; **`/policies/deploy`** (#230, 422/503) has its client in the **external `vellar-sdk`** package — **not verifiable in-repo (RA-11-E, flagged)**.

## Doc
Corrected the stale CLOSED blocks the re-audit flagged (RA-3 server-only, RA-5 builder-only, RA-6 delegation-edge untested, RA-10 sweep missed the body-vs-config sibling) and updated the bottom line + mainnet verdict.

## Mainnet: still NO-GO
Funding-path Highs (RA-1/RA-2) and session/client Highs (RA-11-A/B) are now fixed+tested. Remaining: M5 multisig attestor + V3 detach UI (deferred), the two **V6 dashboard facts** (L2 port firewalling, M9 autoDeploy/branch-protection), and **RA-11-E** (check the external `vellar-sdk`'s `/policies/deploy` handling). Every verdict stays conditional on the **unaudited** `vellar-sdk`/`passkey-kit`.