### PR TITLE
fix(deps): force sac-sdk onto stable stellar-sdk — its pinned rc crashes the backend at import

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  sac-sdk>@stellar/stellar-sdk: ^16.0.1
   axios@>=1.0.0 <1.18.0: '>=1.18.1'
   fast-uri@4: '>=4.1.2'
   fast-uri@3: '>=3.1.4'
@@ -1907,11 +1908,6 @@ packages:
   '@stellar/stellar-sdk@14.6.1':
     resolution: {integrity: sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==}
     engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@stellar/stellar-sdk@16.0.0-rc.1':
-    resolution: {integrity: sha512-mkOQUsFgepFIxRFJLgjkLAkYQDBdNKgLpMM5yIWQcCUoXavb0gO1Dlw/hPqVg2KBKUKaXs2ljVLuB4x6bSWR0g==}
-    engines: {node: '>=22.0.0'}
     hasBin: true
 
   '@stellar/stellar-sdk@16.0.1':
@@ -5766,24 +5762,6 @@ snapshots:
       - debug
       - supports-color
 
-  '@stellar/stellar-sdk@16.0.0-rc.1':
-    dependencies:
-      '@noble/ed25519': 3.1.0
-      '@noble/hashes': 2.2.0
-      '@stellar/js-xdr': 4.0.0
-      axios: 1.18.1
-      base32.js: 0.1.0
-      bignumber.js: 11.1.5
-      buffer: 6.0.3
-      commander: 14.0.3
-      eventsource: 4.1.0
-      feaxios: 0.0.23
-      smol-toml: 1.7.0
-      uint8array-extras: 1.5.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@stellar/stellar-sdk@16.0.1':
     dependencies:
       '@noble/ed25519': 3.1.0
@@ -8206,7 +8184,7 @@ snapshots:
 
   sac-sdk@0.4.3:
     dependencies:
-      '@stellar/stellar-sdk': 16.0.0-rc.1
+      '@stellar/stellar-sdk': 16.0.1
       buffer: 6.0.3
     transitivePeerDependencies:
       - debug

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,12 @@ minimumReleaseAgeExclude:
 # (Dependabot alerts, 2026-07). All same-major, backward-compatible patch/minor
 # bumps. Re-check + prune when the direct deps that pull these in are upgraded.
 overrides:
+  # sac-sdk 0.4.3 hard-pins stellar-sdk 16.0.0-rc.1, whose ESM build is broken
+  # (imports a `config` export that @stellar/js-xdr@4 doesn't provide) and
+  # crashes the backend at first import on Render. Force it onto the stable
+  # 16.0.1 every first-party package already uses; drop when sac-sdk ships a
+  # release depending on a stable SDK.
+  "sac-sdk>@stellar/stellar-sdk": "^16.0.1"
   axios@>=1.0.0 <1.18.0: ">=1.18.1"
   # Blanket fast-uri pins: the range-scoped keys didn't catch parents that pin
   # an exact 4.1.0/3.1.3, so force the whole 3.x and 4.x lines to the patch.


### PR DESCRIPTION
## The failure

Every Render deploy of `vellar-backend` exits with status 1: the all-in-one service crashes at its first server-side import with

```
SyntaxError: The requested module '@stellar/js-xdr/src/config.js' does not provide an export named 'config'
  (from @stellar/stellar-sdk@16.0.0-rc.1 lib/esm/base/generated/curr_generated.js)
```

## The cause

`passkey-kit@0.14.0` → `sac-sdk@0.4.3` → hard-pinned `@stellar/stellar-sdk@16.0.0-rc.1`. The rc's ESM build was published against a js-xdr export that `@stellar/js-xdr@4.0.0` (its own resolved dependency) does not provide. Every first-party package uses stable `^16.0.1` (same js-xdr, fixed build), so the workspace carried both SDKs and the backend's import graph reached the broken one.

## The fix

One override in the existing `pnpm-workspace.yaml` overrides block (alongside the security pins), forcing `sac-sdk` onto `^16.0.1`. The rc disappears from the lockfile entirely (−24 lines); the graph dedupes to a single stellar-sdk. Drop the override when sac-sdk ships a release depending on a stable SDK.

## Verification

- `grep -c '16.0.0-rc.1' pnpm-lock.yaml` → 0
- The exact Render start command (`pnpm --filter @vellar/all-in-one start`) now clears the full import graph and stops at wallet-service's `DATABASE_URL` fail-closed guard — the expected halt with no local env; Render provides `DATABASE_URL` via `vellar-db`
- `pnpm --filter @vellar/all-in-one typecheck` clean