### PR TITLE
docs: fix README drift — verification-service port, wallet-sdk retirement, apps/docs status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ The SDK that powers Vellar is published separately as
 
 ## Layout
 
-Monorepo (pnpm + Turborepo): `apps/` (web, extension, docs) · `packages/` (shared SDKs/UI/types) · `services/` (backend) · `contracts/` (Soroban) · `infra/`.
+Monorepo (pnpm + Turborepo): `apps/web` + `apps/extension` (the two workspace apps; `apps/docs` is pre-written content for a future docs site, not a runnable app yet) · `packages/` (shared UI/types/passkey/provider/policy/verification/lifecycle SDKs + service-kit — the core wallet client SDK itself now lives outside this repo, see below) · `services/` (backend) · `contracts/` (Soroban) · `infra/`.
+
+Both `apps/web` and `apps/extension` depend directly on the published
+[`vellar-sdk`](https://github.com/Vellar-Wallet/vellar-sdk) npm package for
+wallet/session/payment/x402 logic, the same as any third-party integrator
+would — there is no in-repo `packages/wallet-sdk` (retired 2026-07-25 to stop
+two hand-synced copies from drifting; see `docs/decisions.md`).
 
 ## Getting started
 
@@ -48,7 +54,7 @@ pnpm typecheck
    ```
 
    Ports: web `:3000`, gateway `:4000`, wallet `:4001`, lifecycle `:4002`,
-   policy `:4003`, Postgres `:5433`, Redis `:6380`.
+   policy `:4003`, verification `:4004`, Postgres `:5433`, Redis `:6380`.
 
 3. **Verify:** `curl localhost:4000/health` and open `http://localhost:3000`.
 


### PR DESCRIPTION
## What's wrong today

- `README.md`'s local-dev port list omits `verification-service` (`:4004`) — it's V1-complete, live-verified byte-for-byte against a deployed contract, starts automatically via `pnpm dev`, and the gateway already proxies `/verification/*` to it. It just never got added to the README when it shipped.
- The Layout line's "packages/ (shared SDKs/UI/types)" doesn't reflect that `packages/wallet-sdk` was retired 2026-07-25 (`docs/decisions.md`) — the core wallet/session/payment/x402 SDK is now the published `vellar-sdk` npm package, which `apps/web` and `apps/extension` both depend on directly.
- `apps/docs` is listed as a peer of web/extension, but it's markdown-only content for a future docs site (no `package.json`, not a pnpm workspace member) per the BUILD-PLAN backlog.

## What this changes

Three targeted README corrections — port list, an added paragraph on where the wallet SDK actually lives, and a clarified Layout line. No code changes.

## Test plan

- [x] Verified every port against each service's `portFromEnv` default in source
- [x] Verified `vellar-sdk` is a real, imported dependency in both `apps/web` and `apps/extension`, per `docs/decisions.md`'s 2026-07-25 entry
- [x] Verified `apps/docs` has no `package.json` and isn't picked up by the pnpm workspace glob