### PR TITLE
nav: link the public transaction explorer from the landing page

### DIFF
--- a/apps/web/app/landing/nav.tsx
+++ b/apps/web/app/landing/nav.tsx
@@ -93,6 +93,9 @@ export function LandingNav() {
           <a href="https://docs.vellar.xyz/" onClick={close}>
             Docs
           </a>
+          <a href="https://explorer.vellar.xyz/" onClick={close}>
+            Explorer
+          </a>
         </div>
         <Link href="/app" className="btn btn-signal">
           Launch app


### PR DESCRIPTION
Adds explorer.vellar.xyz to the landing nav, right next to the existing Docs link.

Verified locally: scoped build (pnpm --filter web build) succeeds, and the link is confirmed present in the generated HTML output.