### PR TITLE
feat(landing): playground section + nav link

### DIFF
--- a/apps/web/app/landing/landing.css
+++ b/apps/web/app/landing/landing.css
@@ -797,6 +797,47 @@
   line-height: 1.6;
 }
 
+/* ---- Playground — live testnet labs ---------------------------- */
+
+.lp .lp-play {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: var(--lp-sp-12);
+  align-items: center;
+}
+.lp .lp-playgrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--lp-sp-4);
+}
+.lp .lp-playcard {
+  padding: var(--lp-sp-6);
+  clip-path: var(--lp-clip-br-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--lp-sp-2);
+}
+.lp .lp-playcard--mint {
+  background: var(--lp-mint-soft);
+}
+.lp .lp-playcard--coral {
+  background: var(--lp-coral-soft);
+}
+.lp .lp-playcard--lime {
+  background: var(--lp-lime-soft);
+}
+.lp .lp-playcard--sun {
+  background: var(--lp-sun-soft);
+}
+.lp .lp-playcard p {
+  color: var(--lp-ink-soft);
+  font-size: var(--lp-fs-sm);
+  line-height: 1.6;
+}
+.lp .lp-play + .lp-cta-row {
+  margin-top: var(--lp-sp-12);
+}
+
 /* ---- Everyday actions — spread accordion ----------------------
    One row of slats; exactly one expanded at a time. The width change is
    flex-grow ONLY (every slat has flex-basis 0, so siblings absorb the
@@ -1681,6 +1722,10 @@
   .lp .lp-trace-pin {
     min-height: 0;
   }
+  .lp .lp-play {
+    grid-template-columns: 1fr;
+    gap: var(--lp-sp-8);
+  }
 }
 
 @media (max-width: 700px) {
@@ -1691,6 +1736,12 @@
     grid-template-columns: 1fr;
   }
   /* Two-up compact grids — the mobile pattern for stacked card sections */
+  .lp .lp-playgrid {
+    gap: var(--lp-sp-3);
+  }
+  .lp .lp-playcard {
+    padding: var(--lp-sp-4);
+  }
   .lp .lp-hero-cards {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: var(--lp-sp-4) var(--lp-sp-3);

--- a/apps/web/app/landing/lp-nav.tsx
+++ b/apps/web/app/landing/lp-nav.tsx
@@ -58,6 +58,9 @@ export function LpNav() {
           <a href="https://explorer.vellar.xyz/" onClick={close}>
             Explorer
           </a>
+          <a href="https://playground.vellar.xyz/" onClick={close}>
+            Playground
+          </a>
         </div>
         <Link href="/app" className="lp-btn lp-btn--forest">
           Launch app

--- a/apps/web/app/landing/playground.tsx
+++ b/apps/web/app/landing/playground.tsx
@@ -1,0 +1,81 @@
+import { Chips, Frame, LpButton, MonoRow, MonoRows, SectionHead } from "./ui";
+
+const LABS = [
+  {
+    tone: "mint",
+    title: "Learn the flow",
+    body: "Make a real API payment and inspect every hop, the 402 challenge, the signed header, the settled 200.",
+  },
+  {
+    tone: "coral",
+    title: "Break it",
+    body: "Corrupt a payment five different ways, or try to poison the Bazaar catalog, and watch the facilitator refuse every one.",
+  },
+  {
+    tone: "lime",
+    title: "The Bazaar, live",
+    body: "Browse every resource the facilitator has observed, each one with a working pay button.",
+  },
+  {
+    tone: "sun",
+    title: "Quest mode",
+    body: "Five levels that walk the whole protocol, from your first payment to bonds and settlement.",
+  },
+] as const;
+
+/** Playground — the whole stack running live on testnet, framed around
+ *  the break-it labs (refusing bad payments is the product working). */
+export function Playground() {
+  return (
+    <section className="lp-sec" id="playground">
+      <div className="lp-wrap">
+        <SectionHead
+          eyebrow="Playground"
+          title={
+            <>
+              Don&apos;t take our word for it, <em>go break it.</em>
+            </>
+          }
+          lead="The playground runs the whole Vellar stack live on Stellar testnet. Your first payment funds a real wallet for you, then every settlement, every budget check, and every refusal happens on-chain, and you can inspect all of it."
+        />
+        <div className="lp-play" data-reveal-group>
+          <div className="lp-playgrid">
+            {LABS.map((l) => (
+              <div className={`lp-playcard lp-playcard--${l.tone}`} key={l.title}>
+                <h4>{l.title}</h4>
+                <p>{l.body}</p>
+              </div>
+            ))}
+          </div>
+          <Frame corner="br" color="coral">
+            <div className="lp-pcard">
+              <div className="lp-pcard-top">
+                <span>Break it, live</span>
+                <span>⌁</span>
+              </div>
+              <Chips
+                items={[
+                  { label: "Tamper signature", on: true },
+                  { label: "Reuse nonce" },
+                  { label: "Overspend" },
+                ]}
+              />
+              <MonoRows>
+                <MonoRow label="GET /v1/research" value="402" tone="bad" />
+                <MonoRow label="X-PAYMENT header" value="tampered" tone="bad" />
+                <MonoRow label="facilitator verify" value="✗ refused" tone="bad" />
+                <MonoRow label="funds moved" value="0.00" tone="ok" />
+              </MonoRows>
+              <span className="lp-verified">✓ Nothing charged, that&apos;s the point</span>
+            </div>
+          </Frame>
+        </div>
+        <div className="lp-cta-row" data-reveal>
+          <LpButton href="https://playground.vellar.xyz/" variant="sun">
+            Open the playground →
+          </LpButton>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,6 +2,7 @@ import { LpShell } from "./landing/shell";
 import { Hero } from "./landing/hero";
 import { X402Pillars } from "./landing/pillars";
 import { TraceSection } from "./landing/trace";
+import { Playground } from "./landing/playground";
 import { EverydayRail } from "./landing/everyday";
 import { Platforms } from "./landing/platforms";
 import { ExtensionSteps } from "./landing/steps";
@@ -19,6 +20,7 @@ export default function Landing() {
       <Hero />
       <X402Pillars />
       <TraceSection />
+      <Playground />
       <EverydayRail />
       <Platforms />
       <ExtensionSteps />


### PR DESCRIPTION
Adds a Playground section to the landing page, placed right after the pinned 402→200 trace so the story reads "watch the flow, now run it yourself".

**Copy** was written from the live product at https://playground.vellar.xyz: real testnet settlements, a wallet funded on your first payment, the break-it labs, the Bazaar catalog, and quest mode. The section leads with the strongest hook, "Don't take our word for it, go break it."

**Layout** stays inside the paper & signals system: a 2×2 grid of soft-fill cut-corner cards (mint / coral / lime / sun) beside a coral-framed console mock showing a tampered payment being refused, with the corruption chips and a "funds moved: 0.00" punchline. One sun CTA opens the playground.

**Nav**: Playground joins Docs and Explorer as an external link (also in the mobile menu).

**Responsive**: cards keep the two-up compact grid on phones, the section stacks to one column at tablet width, zero horizontal overflow measured at 390px.

Verified: typecheck, production build, 62/62 web tests, desktop + phone screenshots.