### PR TITLE
design(nav): group developer surfaces under a Developers dropdown

### DIFF
--- a/apps/web/app/landing/landing.css
+++ b/apps/web/app/landing/landing.css
@@ -461,6 +461,84 @@
   display: block;
 }
 
+/* Developers dropdown — hover or click to open, Escape closes. The panel
+   is a cut-corner paper card (two-layer clip border); its wrapper carries
+   a transparent top bridge so the pointer can cross the gap without the
+   wrapper firing mouseleave. */
+.lp .lp-nav-dd {
+  position: relative;
+}
+.lp .lp-nav-dd-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  color: var(--lp-ink);
+  font-family: inherit;
+  font-size: var(--lp-fs-sm);
+  font-weight: 600;
+  padding: 4px 0;
+  border-bottom: 3px solid transparent;
+  transition: border-color var(--lp-dur-fast) ease;
+}
+.lp .lp-nav-dd:hover .lp-nav-dd-btn,
+.lp .lp-nav-dd.open .lp-nav-dd-btn {
+  border-bottom-color: var(--lp-sun);
+}
+.lp .lp-nav-dd-btn svg {
+  transition: rotate var(--lp-dur-fast) ease;
+}
+.lp .lp-nav-dd.open .lp-nav-dd-btn svg {
+  rotate: 180deg;
+}
+.lp .lp-nav-dd-panel {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  translate: -50% 0;
+  padding-top: 10px;
+  display: none;
+  z-index: 41;
+}
+.lp .lp-nav-dd.open .lp-nav-dd-panel {
+  display: block;
+}
+.lp .lp-nav-dd-card {
+  position: relative;
+  min-width: 190px;
+  background: var(--lp-line-strong);
+  clip-path: var(--lp-clip-br-sm);
+  padding: var(--lp-sp-2);
+  display: flex;
+  flex-direction: column;
+}
+.lp .lp-nav-dd-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: var(--lp-paper);
+  clip-path: polygon(
+    1px 1px,
+    calc(100% - 1px) 1px,
+    calc(100% - 1px) calc(100% - 12.41px),
+    calc(100% - 12.41px) calc(100% - 1px),
+    1px calc(100% - 1px)
+  );
+}
+.lp .lp-nav-links .lp-nav-dd-card a {
+  display: block;
+  padding: 10px 14px;
+  border-bottom: none;
+  transition: background var(--lp-dur-fast) ease;
+}
+.lp .lp-nav-links .lp-nav-dd-card a:hover {
+  border-bottom: none;
+  background: var(--lp-mint-soft);
+}
+
 @media (max-width: 820px) {
   .lp .lp-nav {
     height: 64px;
@@ -490,6 +568,28 @@
     font-size: 2rem;
     font-weight: 700;
     border-bottom-width: 4px;
+  }
+  /* In the full-screen menu the dropdown flattens into plain links — the
+     wrappers dissolve (display: contents) and the button disappears. */
+  .lp .lp-nav-dd,
+  .lp .lp-nav-dd-panel,
+  .lp .lp-nav-dd-card {
+    display: contents;
+  }
+  .lp .lp-nav-dd-btn {
+    display: none;
+  }
+  .lp .lp-nav-dd-card::before {
+    content: none;
+  }
+  .lp .lp-nav-links .lp-nav-dd-card a,
+  .lp .lp-nav-links .lp-nav-dd-card a:hover {
+    padding: 4px 0;
+    background: none;
+    border-bottom: 4px solid transparent;
+  }
+  .lp .lp-nav-links .lp-nav-dd-card a:hover {
+    border-bottom-color: var(--lp-sun);
   }
 }
 

--- a/apps/web/app/landing/lp-nav.tsx
+++ b/apps/web/app/landing/lp-nav.tsx
@@ -2,27 +2,46 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { scrollToSection, useScrollSpy } from "./use-scroll-spy";
 
 /** Landing sections the nav tracks for scroll-spy highlighting. */
 const SECTIONS = [
   { id: "agents", label: "x402" },
   { id: "wallet", label: "Wallet" },
-  { id: "faq", label: "FAQ" },
 ] as const;
 
 const SECTION_IDS = SECTIONS.map((s) => s.id);
 
+/** Developer surfaces, grouped under one dropdown so the bar stays short. */
+const DEV_LINKS = [
+  { href: "https://docs.vellar.xyz/", label: "Docs" },
+  { href: "https://playground.vellar.xyz/", label: "Playground" },
+  { href: "https://explorer.vellar.xyz/", label: "Explorer" },
+] as const;
+
 /** Sticky paper nav for all .lp marketing pages. */
 export function LpNav() {
   const [open, setOpen] = useState(false);
-  const close = () => setOpen(false);
+  const [devOpen, setDevOpen] = useState(false);
+  const close = () => {
+    setOpen(false);
+    setDevOpen(false);
+  };
   // usePathname (not window.location read once on mount): the nav lives in the
   // shared layout, so client-side navigation must re-derive the active link.
   const path = usePathname() ?? "";
   const onLanding = path === "/";
   const section = useScrollSpy(SECTION_IDS, onLanding);
+
+  useEffect(() => {
+    if (!devOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setDevOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [devOpen]);
 
   const goTo = (id: string) => (e: React.MouseEvent) => {
     close();
@@ -49,18 +68,43 @@ export function LpNav() {
               {s.label}
             </Link>
           ))}
+          <div
+            className={`lp-nav-dd${devOpen ? " open" : ""}`}
+            onMouseEnter={() => setDevOpen(true)}
+            onMouseLeave={() => setDevOpen(false)}
+          >
+            <button
+              type="button"
+              className="lp-nav-dd-btn"
+              aria-haspopup="true"
+              aria-expanded={devOpen}
+              onClick={() => setDevOpen(!devOpen)}
+            >
+              Developers
+              <svg
+                width="10"
+                height="6"
+                viewBox="0 0 10 6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M1 1l4 4 4-4" />
+              </svg>
+            </button>
+            <div className="lp-nav-dd-panel">
+              <div className="lp-nav-dd-card">
+                {DEV_LINKS.map((l) => (
+                  <a key={l.href} href={l.href} onClick={close}>
+                    {l.label}
+                  </a>
+                ))}
+              </div>
+            </div>
+          </div>
           <Link href="/about" className={path === "/about" ? "active" : ""} onClick={close}>
             About
           </Link>
-          <a href="https://docs.vellar.xyz/" onClick={close}>
-            Docs
-          </a>
-          <a href="https://explorer.vellar.xyz/" onClick={close}>
-            Explorer
-          </a>
-          <a href="https://playground.vellar.xyz/" onClick={close}>
-            Playground
-          </a>
         </div>
         <Link href="/app" className="lp-btn lp-btn--forest">
           Launch app


### PR DESCRIPTION
The marketing nav had grown to seven links plus the CTA. This trims it to the important things and sections the rest by audience:

**x402 · Wallet · Developers ▾ · About · [Launch app]**

- **Developers** opens a cut-corner paper panel (the system's two-layer clip border) containing Docs, Playground and Explorer, the same audience clicks all three, so they earn one slot, not three.
- **FAQ** leaves the nav: it's reachable by scrolling and from the footer.
- The two scroll-spied section links (x402, Wallet) and the About active state are unchanged.

Behavior: opens on hover or click, closes on Escape or pointer-leave, `aria-haspopup`/`aria-expanded` set, chevron flips when open, and a transparent hover bridge spans the gap between button and panel. In the full-screen mobile menu the wrappers dissolve (`display: contents`) so the three links render flat like every other menu item.

Verified: typecheck, production build, 62/62 web tests, screenshots of the closed bar, the open dropdown, and the mobile menu.