### PR TITLE
content(about): update contact email to david@vellar.xyz

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -101,8 +101,8 @@ export default function About() {
                 <LpButton href="https://github.com/Vellar-Wallet" variant="forest">
                   GitHub
                 </LpButton>
-                <LpButton href="mailto:hello@vellar.xyz" variant="outline">
-                  hello@vellar.xyz
+                <LpButton href="mailto:david@vellar.xyz" variant="outline">
+                  david@vellar.xyz
                 </LpButton>
               </div>
             </div>


### PR DESCRIPTION
Swaps the About page's contact button from hello@vellar.xyz to david@vellar.xyz. Footer's Contact link is intentionally left as-is.