### PR TITLE
feat(contrib): add transfer list suite route with allowlist and denylist checks (#104)

### DIFF
--- a/contrib/routes/issue-104-transfer-list-suite/README.md
+++ b/contrib/routes/issue-104-transfer-list-suite/README.md
@@ -1,0 +1,91 @@
+# Mock route: transfer list suite (Issue #104)
+
+Simulates per-account allowlist and denylist checks for proposed payment recipient transfers.
+
+## Features & Rules
+- Allowlists and denylists are maintained per sending account.
+- **Denylist Precedence**: A denylisted recipient is **always rejected**, even if also present on the allowlist.
+- **Clear Failure Reason**: `/check-transfer` returns `allowed: false` along with a human-readable `reason` field when a transfer is rejected.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/add-to-list` | Add a recipient to account's `allowlist` or `denylist`. |
+| POST | `/remove-from-list` | Remove a recipient from account's `allowlist` or `denylist`. |
+| POST / GET | `/check-transfer` | Check if proposed transfer from account to recipient is allowed. |
+
+## Endpoints Detail
+
+### 1. `POST /add-to-list`
+Request body:
+```json
+{
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "listType": "allowlist", // or "denylist"
+  "recipient": "GCXRECIPIENT222222222222222222222222222222222222222"
+}
+```
+Response:
+```json
+{
+  "success": true,
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "listType": "allowlist",
+  "recipient": "GCXRECIPIENT222222222222222222222222222222222222222",
+  "message": "Successfully added GCXRECIPIENT222222222222222222222222222222222222222 to allowlist for account GBXACCOUNT11111111111111111111111111111111111111111111"
+}
+```
+
+### 2. `POST /remove-from-list`
+Request body:
+```json
+{
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "listType": "denylist",
+  "recipient": "GCXRECIPIENT333333333333333333333333333333333333333"
+}
+```
+
+### 3. `POST /check-transfer`
+Request body:
+```json
+{
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "recipient": "GCXRECIPIENT222222222222222222222222222222222222222",
+  "amount": "100"
+}
+```
+Allowed response:
+```json
+{
+  "allowed": true,
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "recipient": "GCXRECIPIENT222222222222222222222222222222222222222",
+  "amount": "100",
+  "reason": null
+}
+```
+Denied response:
+```json
+{
+  "allowed": false,
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "recipient": "GCXRECIPIENT333333333333333333333333333333333333333",
+  "amount": "50",
+  "reason": "Recipient is on the denylist (denylist takes precedence over allowlist)"
+}
+```
+
+## Running & Testing
+
+### Start server:
+```sh
+node route.mjs
+# transfer-list-suite route server listening on http://localhost:4104
+```
+
+### Execute test suite:
+```sh
+node route.test.mjs
+```

--- a/contrib/routes/issue-104-transfer-list-suite/route.mjs
+++ b/contrib/routes/issue-104-transfer-list-suite/route.mjs
@@ -1,0 +1,161 @@
+import http from "node:http";
+
+// In-memory data store for allowlists and denylists per account:
+// Map<accountAddress, { allowlist: Set<recipientAddress>, denylist: Set<recipientAddress> }>
+const accountLists = new Map();
+
+function getOrCreateAccountLists(account) {
+  if (!accountLists.has(account)) {
+    accountLists.set(account, {
+      allowlist: new Set(),
+      denylist: new Set(),
+    });
+  }
+  return accountLists.get(account);
+}
+
+export function addToList(body) {
+  const { account, listType, recipient } = body || {};
+  if (!account || !listType || !recipient) {
+    return { status: 400, body: { error: "account, listType, and recipient are required" } };
+  }
+
+  const normalizedType = String(listType).toLowerCase();
+  if (normalizedType !== "allowlist" && normalizedType !== "denylist") {
+    return { status: 400, body: { error: "listType must be 'allowlist' or 'denylist'" } };
+  }
+
+  const lists = getOrCreateAccountLists(account);
+  lists[normalizedType].add(recipient);
+
+  return {
+    status: 200,
+    body: {
+      success: true,
+      account,
+      listType: normalizedType,
+      recipient,
+      message: `Successfully added ${recipient} to ${normalizedType} for account ${account}`,
+    },
+  };
+}
+
+export function removeFromList(body) {
+  const { account, listType, recipient } = body || {};
+  if (!account || !listType || !recipient) {
+    return { status: 400, body: { error: "account, listType, and recipient are required" } };
+  }
+
+  const normalizedType = String(listType).toLowerCase();
+  if (normalizedType !== "allowlist" && normalizedType !== "denylist") {
+    return { status: 400, body: { error: "listType must be 'allowlist' or 'denylist'" } };
+  }
+
+  const lists = accountLists.get(account);
+  if (!lists || !lists[normalizedType].has(recipient)) {
+    return { status: 404, body: { error: `Recipient ${recipient} not found on ${normalizedType} for account ${account}` } };
+  }
+
+  lists[normalizedType].delete(recipient);
+
+  return {
+    status: 200,
+    body: {
+      success: true,
+      account,
+      listType: normalizedType,
+      recipient,
+      message: `Successfully removed ${recipient} from ${normalizedType} for account ${account}`,
+    },
+  };
+}
+
+export function checkTransfer(data) {
+  const { account, recipient, amount } = data || {};
+  if (!account || !recipient) {
+    return { status: 400, body: { error: "account and recipient are required" } };
+  }
+
+  const lists = accountLists.get(account) || { allowlist: new Set(), denylist: new Set() };
+
+  // Rule 1: Denylist ALWAYS takes precedence. If recipient is on denylist, reject.
+  if (lists.denylist.has(recipient)) {
+    return {
+      status: 200,
+      body: {
+        allowed: false,
+        account,
+        recipient,
+        amount: amount || null,
+        reason: "Recipient is on the denylist (denylist takes precedence over allowlist)",
+      },
+    };
+  }
+
+  // Rule 2: If allowlist is configured and non-empty, recipient MUST be on allowlist.
+  if (lists.allowlist.size > 0 && !lists.allowlist.has(recipient)) {
+    return {
+      status: 200,
+      body: {
+        allowed: false,
+        account,
+        recipient,
+        amount: amount || null,
+        reason: "Recipient is not on the allowlist",
+      },
+    };
+  }
+
+  // Otherwise, transfer is allowed.
+  return {
+    status: 200,
+    body: {
+      allowed: true,
+      account,
+      recipient,
+      amount: amount || null,
+      reason: null,
+    },
+  };
+}
+
+export function clearLists() {
+  accountLists.clear();
+}
+
+export function handleRequest(method, urlPath, body, query) {
+  if (method === "POST" && urlPath === "/add-to-list") return addToList(body);
+  if (method === "POST" && urlPath === "/remove-from-list") return removeFromList(body);
+  if (method === "POST" && urlPath === "/check-transfer") return checkTransfer(body);
+  if (method === "GET" && urlPath === "/check-transfer") return checkTransfer(query);
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let bodyData = "";
+    req.on("data", (chunk) => (bodyData += chunk));
+    req.on("end", () => {
+      let parsedBody;
+      try {
+        parsedBody = bodyData ? JSON.parse(bodyData) : undefined;
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "invalid_json" }));
+      }
+
+      const urlObj = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+      const queryParams = Object.fromEntries(urlObj.searchParams);
+      const { status, body: responseBody } = handleRequest(req.method, urlObj.pathname, parsedBody, queryParams);
+
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(responseBody));
+    });
+  });
+
+  const port = process.env.PORT || 4104;
+  server.listen(port, () => {
+    console.log(`transfer-list-suite route server listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-104-transfer-list-suite/route.test.mjs
+++ b/contrib/routes/issue-104-transfer-list-suite/route.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { handleRequest, clearLists } from "./route.mjs";
+
+clearLists();
+
+const ACCOUNT_A = "GBXACCOUNT11111111111111111111111111111111111111111111";
+const RECIPIENT_ALLOWED = "GCXRECIPIENT222222222222222222222222222222222222222";
+const RECIPIENT_DENIED = "GCXRECIPIENT333333333333333333333333333333333333333";
+const RECIPIENT_CONFLICT = "GCXRECIPIENT444444444444444444444444444444444444444";
+
+// 1. Add RECIPIENT_ALLOWED to allowlist
+let res = handleRequest("POST", "/add-to-list", {
+  account: ACCOUNT_A,
+  listType: "allowlist",
+  recipient: RECIPIENT_ALLOWED,
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.success, true);
+assert.equal(res.body.listType, "allowlist");
+
+// 2. Add RECIPIENT_DENIED to denylist
+res = handleRequest("POST", "/add-to-list", {
+  account: ACCOUNT_A,
+  listType: "denylist",
+  recipient: RECIPIENT_DENIED,
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.success, true);
+
+// 3. Test ALLOWED transfer (recipient on allowlist, not on denylist)
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: RECIPIENT_ALLOWED,
+  amount: "100",
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+assert.equal(res.body.reason, null);
+
+// 4. Test DENIED transfer (recipient on denylist)
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: RECIPIENT_DENIED,
+  amount: "50",
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.ok(res.body.reason.includes("denylist"));
+
+// 5. Test DENIED transfer (recipient not on allowlist when allowlist is active)
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: "GCUNLISTED99999999999999999999999999999999999999999",
+  amount: "25",
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.ok(res.body.reason.includes("allowlist"));
+
+// 6. Test CONFLICTING LIST PRECEDENCE CASE:
+// Add RECIPIENT_CONFLICT to BOTH allowlist AND denylist
+handleRequest("POST", "/add-to-list", {
+  account: ACCOUNT_A,
+  listType: "allowlist",
+  recipient: RECIPIENT_CONFLICT,
+});
+handleRequest("POST", "/add-to-list", {
+  account: ACCOUNT_A,
+  listType: "denylist",
+  recipient: RECIPIENT_CONFLICT,
+});
+
+// Check transfer for conflicting recipient: MUST BE REJECTED because denylist overrides allowlist
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: RECIPIENT_CONFLICT,
+  amount: "500",
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.ok(res.body.reason.includes("denylist"));
+
+// 7. Test remove-from-list
+res = handleRequest("POST", "/remove-from-list", {
+  account: ACCOUNT_A,
+  listType: "denylist",
+  recipient: RECIPIENT_CONFLICT,
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.success, true);
+
+// Now RECIPIENT_CONFLICT is only on allowlist -> should be ALLOWED
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: RECIPIENT_CONFLICT,
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+
+// 8. Test Input Validation & 400 Bad Request
+res = handleRequest("POST", "/add-to-list", { account: ACCOUNT_A });
+assert.equal(res.status, 400);
+
+res = handleRequest("POST", "/check-transfer", {});
+assert.equal(res.status, 400);
+
+console.log("PASS: transfer-list-suite — allowed transfer, denied transfer, and conflicting list precedence case verified successfully!");

--- a/contrib/routes/transfer-list-suite/README.md
+++ b/contrib/routes/transfer-list-suite/README.md
@@ -1,0 +1,91 @@
+# Mock route: transfer list suite (Issue #104)
+
+Simulates per-account allowlist and denylist checks for proposed payment recipient transfers.
+
+## Features & Rules
+- Allowlists and denylists are maintained per sending account.
+- **Denylist Precedence**: A denylisted recipient is **always rejected**, even if also present on the allowlist.
+- **Clear Failure Reason**: `/check-transfer` returns `allowed: false` along with a human-readable `reason` field when a transfer is rejected.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/add-to-list` | Add a recipient to account's `allowlist` or `denylist`. |
+| POST | `/remove-from-list` | Remove a recipient from account's `allowlist` or `denylist`. |
+| POST / GET | `/check-transfer` | Check if proposed transfer from account to recipient is allowed. |
+
+## Endpoints Detail
+
+### 1. `POST /add-to-list`
+Request body:
+```json
+{
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "listType": "allowlist", // or "denylist"
+  "recipient": "GCXRECIPIENT222222222222222222222222222222222222222"
+}
+```
+Response:
+```json
+{
+  "success": true,
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "listType": "allowlist",
+  "recipient": "GCXRECIPIENT222222222222222222222222222222222222222",
+  "message": "Successfully added GCXRECIPIENT222222222222222222222222222222222222222 to allowlist for account GBXACCOUNT11111111111111111111111111111111111111111111"
+}
+```
+
+### 2. `POST /remove-from-list`
+Request body:
+```json
+{
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "listType": "denylist",
+  "recipient": "GCXRECIPIENT333333333333333333333333333333333333333"
+}
+```
+
+### 3. `POST /check-transfer`
+Request body:
+```json
+{
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "recipient": "GCXRECIPIENT222222222222222222222222222222222222222",
+  "amount": "100"
+}
+```
+Allowed response:
+```json
+{
+  "allowed": true,
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "recipient": "GCXRECIPIENT222222222222222222222222222222222222222",
+  "amount": "100",
+  "reason": null
+}
+```
+Denied response:
+```json
+{
+  "allowed": false,
+  "account": "GBXACCOUNT11111111111111111111111111111111111111111111",
+  "recipient": "GCXRECIPIENT333333333333333333333333333333333333333",
+  "amount": "50",
+  "reason": "Recipient is on the denylist (denylist takes precedence over allowlist)"
+}
+```
+
+## Running & Testing
+
+### Start server:
+```sh
+node route.mjs
+# transfer-list-suite route server listening on http://localhost:4104
+```
+
+### Execute test suite:
+```sh
+node route.test.mjs
+```

--- a/contrib/routes/transfer-list-suite/route.mjs
+++ b/contrib/routes/transfer-list-suite/route.mjs
@@ -1,0 +1,161 @@
+import http from "node:http";
+
+// In-memory data store for allowlists and denylists per account:
+// Map<accountAddress, { allowlist: Set<recipientAddress>, denylist: Set<recipientAddress> }>
+const accountLists = new Map();
+
+function getOrCreateAccountLists(account) {
+  if (!accountLists.has(account)) {
+    accountLists.set(account, {
+      allowlist: new Set(),
+      denylist: new Set(),
+    });
+  }
+  return accountLists.get(account);
+}
+
+export function addToList(body) {
+  const { account, listType, recipient } = body || {};
+  if (!account || !listType || !recipient) {
+    return { status: 400, body: { error: "account, listType, and recipient are required" } };
+  }
+
+  const normalizedType = String(listType).toLowerCase();
+  if (normalizedType !== "allowlist" && normalizedType !== "denylist") {
+    return { status: 400, body: { error: "listType must be 'allowlist' or 'denylist'" } };
+  }
+
+  const lists = getOrCreateAccountLists(account);
+  lists[normalizedType].add(recipient);
+
+  return {
+    status: 200,
+    body: {
+      success: true,
+      account,
+      listType: normalizedType,
+      recipient,
+      message: `Successfully added ${recipient} to ${normalizedType} for account ${account}`,
+    },
+  };
+}
+
+export function removeFromList(body) {
+  const { account, listType, recipient } = body || {};
+  if (!account || !listType || !recipient) {
+    return { status: 400, body: { error: "account, listType, and recipient are required" } };
+  }
+
+  const normalizedType = String(listType).toLowerCase();
+  if (normalizedType !== "allowlist" && normalizedType !== "denylist") {
+    return { status: 400, body: { error: "listType must be 'allowlist' or 'denylist'" } };
+  }
+
+  const lists = accountLists.get(account);
+  if (!lists || !lists[normalizedType].has(recipient)) {
+    return { status: 404, body: { error: `Recipient ${recipient} not found on ${normalizedType} for account ${account}` } };
+  }
+
+  lists[normalizedType].delete(recipient);
+
+  return {
+    status: 200,
+    body: {
+      success: true,
+      account,
+      listType: normalizedType,
+      recipient,
+      message: `Successfully removed ${recipient} from ${normalizedType} for account ${account}`,
+    },
+  };
+}
+
+export function checkTransfer(data) {
+  const { account, recipient, amount } = data || {};
+  if (!account || !recipient) {
+    return { status: 400, body: { error: "account and recipient are required" } };
+  }
+
+  const lists = accountLists.get(account) || { allowlist: new Set(), denylist: new Set() };
+
+  // Rule 1: Denylist ALWAYS takes precedence. If recipient is on denylist, reject.
+  if (lists.denylist.has(recipient)) {
+    return {
+      status: 200,
+      body: {
+        allowed: false,
+        account,
+        recipient,
+        amount: amount || null,
+        reason: "Recipient is on the denylist (denylist takes precedence over allowlist)",
+      },
+    };
+  }
+
+  // Rule 2: If allowlist is configured and non-empty, recipient MUST be on allowlist.
+  if (lists.allowlist.size > 0 && !lists.allowlist.has(recipient)) {
+    return {
+      status: 200,
+      body: {
+        allowed: false,
+        account,
+        recipient,
+        amount: amount || null,
+        reason: "Recipient is not on the allowlist",
+      },
+    };
+  }
+
+  // Otherwise, transfer is allowed.
+  return {
+    status: 200,
+    body: {
+      allowed: true,
+      account,
+      recipient,
+      amount: amount || null,
+      reason: null,
+    },
+  };
+}
+
+export function clearLists() {
+  accountLists.clear();
+}
+
+export function handleRequest(method, urlPath, body, query) {
+  if (method === "POST" && urlPath === "/add-to-list") return addToList(body);
+  if (method === "POST" && urlPath === "/remove-from-list") return removeFromList(body);
+  if (method === "POST" && urlPath === "/check-transfer") return checkTransfer(body);
+  if (method === "GET" && urlPath === "/check-transfer") return checkTransfer(query);
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let bodyData = "";
+    req.on("data", (chunk) => (bodyData += chunk));
+    req.on("end", () => {
+      let parsedBody;
+      try {
+        parsedBody = bodyData ? JSON.parse(bodyData) : undefined;
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "invalid_json" }));
+      }
+
+      const urlObj = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+      const queryParams = Object.fromEntries(urlObj.searchParams);
+      const { status, body: responseBody } = handleRequest(req.method, urlObj.pathname, parsedBody, queryParams);
+
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(responseBody));
+    });
+  });
+
+  const port = process.env.PORT || 4104;
+  server.listen(port, () => {
+    console.log(`transfer-list-suite route server listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/transfer-list-suite/route.test.mjs
+++ b/contrib/routes/transfer-list-suite/route.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { handleRequest, clearLists } from "./route.mjs";
+
+clearLists();
+
+const ACCOUNT_A = "GBXACCOUNT11111111111111111111111111111111111111111111";
+const RECIPIENT_ALLOWED = "GCXRECIPIENT222222222222222222222222222222222222222";
+const RECIPIENT_DENIED = "GCXRECIPIENT333333333333333333333333333333333333333";
+const RECIPIENT_CONFLICT = "GCXRECIPIENT444444444444444444444444444444444444444";
+
+// 1. Add RECIPIENT_ALLOWED to allowlist
+let res = handleRequest("POST", "/add-to-list", {
+  account: ACCOUNT_A,
+  listType: "allowlist",
+  recipient: RECIPIENT_ALLOWED,
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.success, true);
+assert.equal(res.body.listType, "allowlist");
+
+// 2. Add RECIPIENT_DENIED to denylist
+res = handleRequest("POST", "/add-to-list", {
+  account: ACCOUNT_A,
+  listType: "denylist",
+  recipient: RECIPIENT_DENIED,
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.success, true);
+
+// 3. Test ALLOWED transfer (recipient on allowlist, not on denylist)
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: RECIPIENT_ALLOWED,
+  amount: "100",
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+assert.equal(res.body.reason, null);
+
+// 4. Test DENIED transfer (recipient on denylist)
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: RECIPIENT_DENIED,
+  amount: "50",
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.ok(res.body.reason.includes("denylist"));
+
+// 5. Test DENIED transfer (recipient not on allowlist when allowlist is active)
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: "GCUNLISTED99999999999999999999999999999999999999999",
+  amount: "25",
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.ok(res.body.reason.includes("allowlist"));
+
+// 6. Test CONFLICTING LIST PRECEDENCE CASE:
+// Add RECIPIENT_CONFLICT to BOTH allowlist AND denylist
+handleRequest("POST", "/add-to-list", {
+  account: ACCOUNT_A,
+  listType: "allowlist",
+  recipient: RECIPIENT_CONFLICT,
+});
+handleRequest("POST", "/add-to-list", {
+  account: ACCOUNT_A,
+  listType: "denylist",
+  recipient: RECIPIENT_CONFLICT,
+});
+
+// Check transfer for conflicting recipient: MUST BE REJECTED because denylist overrides allowlist
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: RECIPIENT_CONFLICT,
+  amount: "500",
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.ok(res.body.reason.includes("denylist"));
+
+// 7. Test remove-from-list
+res = handleRequest("POST", "/remove-from-list", {
+  account: ACCOUNT_A,
+  listType: "denylist",
+  recipient: RECIPIENT_CONFLICT,
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.success, true);
+
+// Now RECIPIENT_CONFLICT is only on allowlist -> should be ALLOWED
+res = handleRequest("POST", "/check-transfer", {
+  account: ACCOUNT_A,
+  recipient: RECIPIENT_CONFLICT,
+});
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+
+// 8. Test Input Validation & 400 Bad Request
+res = handleRequest("POST", "/add-to-list", { account: ACCOUNT_A });
+assert.equal(res.status, 400);
+
+res = handleRequest("POST", "/check-transfer", {});
+assert.equal(res.status, 400);
+
+console.log("PASS: transfer-list-suite — allowed transfer, denied transfer, and conflicting list precedence case verified successfully!");


### PR DESCRIPTION
### Summary
Add a self-contained mock route suite under `contrib/routes/` that maintains per-account allowlists and denylists and evaluates recipient transfer checks.

### Requirements & Behavior
- **Endpoints**:
  - `POST /add-to-list`: Adds recipient to account's `allowlist` or `denylist`.
  - `POST /remove-from-list`: Removes recipient from account's `allowlist` or `denylist`.
  - `POST /check-transfer` (and `GET /check-transfer`): Evaluates recipient against account's lists.
- **Denylist Precedence**: A denylisted recipient is **always rejected**, even if present on the allowlist.
- **Clear Reason Field**: Returns `allowed: false` with a human-readable `reason` field describing rejection reasons.
- **Testing**: Includes `route.test.mjs` verifying allowed transfers, denied transfers, and conflicting list precedence (recipient on both allowlist and denylist).

### Constraints Compliance
- Created from base branch `drips`.
- All changes are strictly inside `contrib/`.
- PR targets `drips` branch.

Closes #104