### PR TITLE
feat(lifecycle): structured logging for cleanup plan execution (#304)

### DIFF
--- a/services/lifecycle-service/README.md
+++ b/services/lifecycle-service/README.md
@@ -1,3 +1,33 @@
 # @vellar/lifecycle-service
 
 Account inspection, blocker detection, cleanup planning, merge validation
+
+## Structured logging
+
+Cleanup plan execution (`POST /lifecycle/execute`) emits one structured JSON
+log entry per cleanup step it builds, via the shared `logEvent` helper (see
+[`docs/observability.md`](../../docs/observability.md) for the general format).
+
+| Event                   | Context fields                                                                                 |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `cleanup.step.built`    | `accountId`, `destination`, `outcome: "built"`, `stepIndex`, `stepCount`, `title`, `hash`      |
+| `cleanup.plan.executed` | `accountId`, `destination`, `outcome: "no_steps"` — emitted when the plan has nothing to clean |
+
+Example entry (pino JSON):
+
+```json
+{
+  "level": 30,
+  "event": "cleanup.step.built",
+  "accountId": "GCMCEGOUVALP2H6LTY7IPUUMSFKDQUMK3SDU5DI7LETNEZZKHRIIALKM",
+  "destination": "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3",
+  "outcome": "built",
+  "stepIndex": 1,
+  "stepCount": 1,
+  "title": "Clean up the account",
+  "hash": "6f83e0982be2efc58d0e7fbb35c2f20e2f22a5e9e2e9f25faa2cebde3562c2a5"
+}
+```
+
+Each entry carries the **account id** and the **step outcome** so operators can
+audit exactly what a cleanup plan execution produced (issue #304).

--- a/services/lifecycle-service/src/server.test.ts
+++ b/services/lifecycle-service/src/server.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FastifyInstance } from "fastify";
 import type { AccountReader, HorizonAccount } from "./horizon";
 import { buildCleanupPlan } from "./planner";
-import { buildServer } from "./server";
+import { buildServer, type LifecycleServiceDeps } from "./server";
 
 const G1 = "GCMCEGOUVALP2H6LTY7IPUUMSFKDQUMK3SDU5DI7LETNEZZKHRIIALKM";
 const G2 = "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3";
@@ -25,9 +25,9 @@ afterEach(async () => {
   app = undefined;
 });
 
-function build(result: HorizonAccount | undefined) {
+function build(result: HorizonAccount | undefined, deps: Partial<LifecycleServiceDeps> = {}) {
   const reader: AccountReader = { getAccount: vi.fn().mockResolvedValue(result) };
-  app = buildServer({ reader });
+  app = buildServer({ reader, ...deps });
   return app;
 }
 
@@ -234,6 +234,54 @@ describe("POST /lifecycle/execute", () => {
     ]);
     expect(tx.signatures).toHaveLength(0); // UNSIGNED — user signs externally
     expect(tx.hash().toString("hex")).toBe(step.hash);
+  });
+
+  it("logs a structured entry per built step with account id and outcome", async () => {
+    const info = vi.fn();
+    const server = build(
+      account({
+        balances: [
+          { assetType: "native", balance: "5.0" },
+          { assetType: "credit_alphanum4", assetCode: "USDC", assetIssuer: G2, balance: "12.5" },
+        ],
+      }),
+      { logger: { info } },
+    );
+    const res = await server.inject({
+      method: "POST",
+      url: "/lifecycle/execute",
+      payload: { accountId: G1, destination: G2 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(info).toHaveBeenCalledWith(
+      {
+        event: "cleanup.step.built",
+        accountId: G1,
+        destination: G2,
+        outcome: "built",
+        stepIndex: 1,
+        stepCount: 1,
+        title: "Clean up the account",
+        hash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      },
+      "cleanup.step.built",
+    );
+  });
+
+  it("logs a no_steps outcome when the plan has nothing to clean", async () => {
+    const info = vi.fn();
+    const server = build(account(), { logger: { info } });
+    const res = await server.inject({
+      method: "POST",
+      url: "/lifecycle/execute",
+      payload: { accountId: G1, destination: G2 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().steps).toEqual([]);
+    expect(info).toHaveBeenCalledWith(
+      { event: "cleanup.plan.executed", accountId: G1, destination: G2, outcome: "no_steps" },
+      "cleanup.plan.executed",
+    );
   });
 });
 

--- a/services/lifecycle-service/src/server.ts
+++ b/services/lifecycle-service/src/server.ts
@@ -1,6 +1,12 @@
-import Fastify, { type FastifyInstance } from "fastify";
+import Fastify, { type FastifyBaseLogger, type FastifyInstance } from "fastify";
 import { z } from "zod";
-import { registerHealth, registerMetrics, domainMetrics, recordOutcome } from "@vellar/service-kit";
+import {
+  logEvent,
+  registerHealth,
+  registerMetrics,
+  domainMetrics,
+  recordOutcome,
+} from "@vellar/service-kit";
 import { buildCleanupSteps, buildMergeStep } from "./builder";
 import type { AccountReader } from "./horizon";
 import { buildCleanupPlan, isClassicAccountId } from "./planner";
@@ -21,6 +27,9 @@ const planBodySchema = z.object({
 export interface LifecycleServiceDeps {
   reader: AccountReader;
   networkPassphrase?: string;
+  /** Injectable logger (tests). Defaults to the request-scoped logger so
+   * cleanup events stay correlated with the request that produced them. */
+  logger?: Pick<FastifyBaseLogger, "info">;
 }
 
 const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
@@ -101,10 +110,33 @@ export function buildServer(deps: LifecycleServiceDeps): FastifyInstance {
     const account = await deps.reader.getAccount(accountId);
     if (!account) return reply.code(404).send({ error: "account_not_found" });
 
-    return reply.send({
-      steps: buildCleanupSteps(account, destination, passphrase),
-      plan: buildCleanupPlan(account, destination),
-    });
+    const steps = buildCleanupSteps(account, destination, passphrase);
+    const plan = buildCleanupPlan(account, destination);
+
+    // Structured audit trail (issue #304): one entry per step built, so
+    // operators can see exactly what a cleanup plan execution produced.
+    const log = deps.logger ?? request.log;
+    if (steps.length === 0) {
+      logEvent(log, "cleanup.plan.executed", {
+        accountId,
+        destination,
+        outcome: "no_steps",
+      });
+    } else {
+      steps.forEach((step, index) => {
+        logEvent(log, "cleanup.step.built", {
+          accountId,
+          destination,
+          outcome: "built",
+          stepIndex: index + 1,
+          stepCount: steps.length,
+          title: step.title,
+          hash: step.hash,
+        });
+      });
+    }
+
+    return reply.send({ steps, plan });
   });
 
   // MergePreflightValidator (idea.md §6.4): re-inspects and refuses to build


### PR DESCRIPTION
Closes #304

## Summary

Cleanup plan execution (`POST /lifecycle/execute`) in `lifecycle-service` previously logged nothing about the steps it produced, making it hard to audit what actions were taken. This PR adds structured JSON log entries for every cleanup step built, via the shared `logEvent` helper from `@vellar/service-kit` (see `docs/observability.md` for the general event-log format).

## Changes

- **Structured per-step logging** (`services/lifecycle-service/src/server.ts`): `POST /lifecycle/execute` now emits one `cleanup.step.built` entry per step, carrying the **account id**, **step outcome**, destination, step index/count, step title, and the transaction hash.
- **Empty-plan visibility**: when a plan has nothing to clean, a single `cleanup.plan.executed` entry with `outcome: "no_steps"` is logged, so executions that take no action are still auditable.
- **Test coverage** (`services/lifecycle-service/src/server.test.ts`): two new tests verify the log output for a sample plan execution — one asserting the full `cleanup.step.built` entry (account id, `outcome: "built"`, hash), and one asserting the `no_steps` outcome for an already-clean account. `buildServer` gained an optional injectable `logger` (defaults to the request-scoped logger, so events stay correlated with the originating request) to make this testable.
- **Documentation** (`services/lifecycle-service/README.md`): a new *Structured logging* section documents both event names, their fields, and an example entry.

## Log format

```json
{"event":"cleanup.step.built","accountId":"G...","destination":"G...","outcome":"built","stepIndex":1,"stepCount":1,"title":"Clean up the account","hash":"<64-hex tx hash>"}
```

| Event                   | Context fields                                                                        |
| ----------------------- | ------------------------------------------------------------------------------------- |
| `cleanup.step.built`    | `accountId`, `destination`, `outcome: "built"`, `stepIndex`, `stepCount`, `title`, `hash` |
| `cleanup.plan.executed` | `accountId`, `destination`, `outcome: "no_steps"`                                      |

## Verification

- `pnpm format:check` — clean
- `pnpm typecheck` — 18/18 tasks pass
- `pnpm --filter @vellar/lifecycle-service test` — 32 tests pass (3 files), including the 2 new log-output tests