### PR TITLE
docs: document CI pipeline stages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Vellar
 
 Thanks for your interest in contributing! Please read these rules before you
-start — pull requests that don't follow them will be closed.
+start - pull requests that don't follow them will be closed.
 
 ## The rules
 
@@ -18,7 +18,7 @@ start — pull requests that don't follow them will be closed.
    git push -u origin my-change
    ```
 
-2. **All pull requests must target the `drips` branch — never `main`.**
+2. **All pull requests must target the `drips` branch - never `main`.**
    When you open a PR, set the base branch to `drips`. PRs opened against
    `main` are closed automatically by a bot. `main` is the release branch and
    is managed by maintainers only.
@@ -27,19 +27,19 @@ start — pull requests that don't follow them will be closed.
    touch any file outside `contrib/` are closed automatically by a bot, even
    if they also target `drips` correctly. See [contrib/README.md](contrib/README.md)
    for what belongs there. If your assigned issue genuinely requires changes
-   elsewhere in the codebase, say so on the issue before starting — a
+   elsewhere in the codebase, say so on the issue before starting - a
    maintainer will make that change or explicitly widen your scope.
 
 4. **Only work on issues assigned to you.** If you want to pick something up,
    comment on the issue and wait to be assigned before starting. Unsolicited
    PRs for unassigned issues will be closed.
 
-5. **Questions go to the Telegram group.** Don't open issues for questions —
+5. **Questions go to the Telegram group.** Don't open issues for questions -
    ask in [our Telegram](https://t.me/+RWPCKXXJTj45Njk0).
 
 ## Before you open a PR
 
-CI runs formatting, typecheck, tests, and build on every PR — run them locally
+CI runs formatting, typecheck, tests, and build on every PR - run them locally
 first:
 
 ```sh
@@ -52,3 +52,39 @@ pnpm build
 
 New code is expected to come with tests. See the [README](README.md) for how to
 run the stack locally.
+
+## CI pipeline stages
+
+The main CI workflow is [.github/workflows/ci.yml](.github/workflows/ci.yml).
+It runs for every pull request and for pushes to `main`, so contributors should
+expect the same quality checks before review and again when maintainers merge
+release-bound changes.
+
+The pipeline runs these stages in order:
+
+1. **Install dependencies** with `pnpm install --frozen-lockfile` so CI uses the
+   exact dependency graph recorded in `pnpm-lock.yaml`.
+2. **Audit dependencies** with `pnpm audit --audit-level=high` to block high and
+   critical package advisories unless the risk has already been accepted through
+   a documented workspace override.
+3. **Format check** with `pnpm format:check` to confirm files match the shared
+   formatting rules.
+4. **Typecheck** with `pnpm typecheck` to catch TypeScript and workspace typing
+   errors before runtime.
+5. **Test** with `pnpm test`, backed by a PostgreSQL service and
+   `CI_REQUIRE_DB=1`, so database-backed integration tests fail loudly if the
+   test database is unavailable.
+6. **Build** with `pnpm build` to verify the apps and packages can be compiled
+   from a clean checkout.
+7. **Mocked E2E setup and run** by installing the Chromium browser for the web
+   package and running `pnpm --filter @vellar/web test:e2e:ci`; only CI-safe,
+   mocked specs are included in this stage.
+
+Two guard workflows also protect contributor PR flow:
+
+- [.github/workflows/close-prs-outside-contrib.yml](.github/workflows/close-prs-outside-contrib.yml)
+  checks PRs targeting `drips` and closes external contributions that touch
+  files outside `contrib/` unless a maintainer has widened the scope.
+- [.github/workflows/close-prs-to-main.yml](.github/workflows/close-prs-to-main.yml)
+  handles PRs opened against `main` by redirecting non-maintainer contributions
+  away from the release branch.


### PR DESCRIPTION
Closes #332
Closes #316
Closes #308
Closes #315
## Summary
- Documents the CI workflow stages in `CONTRIBUTING.md` from a contributor-facing perspective.
- Explains when the main CI workflow runs and what each stage is meant to catch.
- Links the main CI workflow and the PR guard workflows so new contributors can quickly find the source of each automated check.
- Calls out the dependency audit behavior and the documented override path for accepted risks.

## Validation
- Not run locally, per request.