### PR TITLE
feat(permission-service): make origin permission cache TTL configurable

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.23.1)
 
   services/policy-service:
     dependencies:
@@ -3953,6 +3956,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   promise-toolbox@0.21.0:
     resolution: {integrity: sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==}

--- a/railway.json
+++ b/railway.json
@@ -10,5 +10,8 @@
     "healthcheckTimeout": 120,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3
+  },
+  "variables": {
+    "PERMISSION_CACHE_TTL_MS": "300000"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -49,6 +49,9 @@ services:
       # Allow the deployed frontend origin (update to the real vellar.xyz once live).
       - key: CORS_ORIGIN
         value: "https://vellar.xyz"
+      # Origin permission cache lifetime: 5 minutes (valid range: 1 second to 24 hours).
+      - key: PERMISSION_CACHE_TTL_MS
+        value: "300000"
       # Wire the Postgres created below.
       - key: DATABASE_URL
         fromDatabase:

--- a/services/permission-service/README.md
+++ b/services/permission-service/README.md
@@ -1,3 +1,10 @@
 # @vellar/permission-service
 
 dApp origin permissions, extension connection records, revocation state
+
+## Configuration
+
+`PERMISSION_CACHE_TTL_MS` controls how long origin permissions remain in the
+in-memory cache. It defaults to `300000` (5 minutes). Values must be between
+`1000` (1 second) and `86400000` (24 hours), inclusive; invalid values use the
+default.

--- a/services/permission-service/package.json
+++ b/services/permission-service/package.json
@@ -8,9 +8,11 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.0"
   }
 }

--- a/services/permission-service/src/config.test.ts
+++ b/services/permission-service/src/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { configFromEnv, DEFAULTS } from "./config";
+import { OriginPermissionCache } from "./origin-permission-cache";
+
+describe("permission-service cache configuration", () => {
+  it("uses the default TTL when it is not configured", () => {
+    expect(configFromEnv({}).originPermissionCacheTtlMs).toBe(DEFAULTS.originPermissionCacheTtlMs);
+  });
+
+  it("respects the configured TTL", () => {
+    let now = 10_000;
+    const config = configFromEnv({ PERMISSION_CACHE_TTL_MS: "2500" });
+    const cache = new OriginPermissionCache({
+      ttlMs: config.originPermissionCacheTtlMs,
+      now: () => now,
+    });
+
+    cache.set("https://example.test", true);
+    now += 2499;
+    expect(cache.get("https://example.test")).toBe(true);
+    now += 1;
+    expect(cache.get("https://example.test")).toBeUndefined();
+  });
+
+  it("falls back for values outside the documented range", () => {
+    expect(configFromEnv({ PERMISSION_CACHE_TTL_MS: "500" }).originPermissionCacheTtlMs).toBe(
+      DEFAULTS.originPermissionCacheTtlMs,
+    );
+    expect(configFromEnv({ PERMISSION_CACHE_TTL_MS: "86400001" }).originPermissionCacheTtlMs).toBe(
+      DEFAULTS.originPermissionCacheTtlMs,
+    );
+  });
+});

--- a/services/permission-service/src/config.ts
+++ b/services/permission-service/src/config.ts
@@ -1,0 +1,27 @@
+export interface PermissionServiceRuntimeConfig {
+  originPermissionCacheTtlMs: number;
+}
+
+const DEFAULT_ORIGIN_PERMISSION_CACHE_TTL_MS = 5 * 60 * 1000;
+const MIN_ORIGIN_PERMISSION_CACHE_TTL_MS = 1000;
+const MAX_ORIGIN_PERMISSION_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export const DEFAULTS = {
+  originPermissionCacheTtlMs: DEFAULT_ORIGIN_PERMISSION_CACHE_TTL_MS,
+  minOriginPermissionCacheTtlMs: MIN_ORIGIN_PERMISSION_CACHE_TTL_MS,
+  maxOriginPermissionCacheTtlMs: MAX_ORIGIN_PERMISSION_CACHE_TTL_MS,
+} as const;
+
+export function configFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): PermissionServiceRuntimeConfig {
+  const configuredTtl = Number(env.PERMISSION_CACHE_TTL_MS);
+  const originPermissionCacheTtlMs =
+    Number.isFinite(configuredTtl) &&
+    configuredTtl >= MIN_ORIGIN_PERMISSION_CACHE_TTL_MS &&
+    configuredTtl <= MAX_ORIGIN_PERMISSION_CACHE_TTL_MS
+      ? configuredTtl
+      : DEFAULT_ORIGIN_PERMISSION_CACHE_TTL_MS;
+
+  return { originPermissionCacheTtlMs };
+}

--- a/services/permission-service/src/index.ts
+++ b/services/permission-service/src/index.ts
@@ -1,3 +1,2 @@
-// @vellar/permission-service — dApp origin permissions, extension connection records, revocation state
-// See CLAUDE.md and BUILD-PLAN.md before implementing.
-export {};
+export { configFromEnv, DEFAULTS, type PermissionServiceRuntimeConfig } from "./config";
+export { OriginPermissionCache } from "./origin-permission-cache";

--- a/services/permission-service/src/origin-permission-cache.ts
+++ b/services/permission-service/src/origin-permission-cache.ts
@@ -1,0 +1,42 @@
+interface CacheEntry<Value> {
+  value: Value;
+  expiresAt: number;
+}
+
+export interface OriginPermissionCacheOptions {
+  ttlMs: number;
+  now?: () => number;
+}
+
+export class OriginPermissionCache<Value> {
+  private readonly entries = new Map<string, CacheEntry<Value>>();
+  private readonly now: () => number;
+
+  constructor({ ttlMs, now = Date.now }: OriginPermissionCacheOptions) {
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+      throw new RangeError("Origin permission cache TTL must be greater than zero");
+    }
+    this.ttlMs = ttlMs;
+    this.now = now;
+  }
+
+  private readonly ttlMs: number;
+
+  get(origin: string): Value | undefined {
+    const entry = this.entries.get(origin);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(origin);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(origin: string, value: Value): void {
+    this.entries.set(origin, { value, expiresAt: this.now() + this.ttlMs });
+  }
+
+  delete(origin: string): boolean {
+    return this.entries.delete(origin);
+  }
+}


### PR DESCRIPTION
Closes #288 