### PR TITLE
Deploy health gate, canary error budget gate, and verification-service staging config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ landing-page.md
 landing-page/
 .vercel
 .env*
+!.env.staging.example
 
 # Throwaway x402 validation spike (references live testnet + linked SDK; not product code)
 scripts/x402-spike/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,18 @@ importers:
         specifier: ^3.2.0
         version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.23.1)
 
+  scripts:
+    devDependencies:
+      tsx:
+        specifier: ^4.20.0
+        version: 4.23.1
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.23.1)
+
   services/all-in-one:
     dependencies:
       '@vellar/api-gateway':
@@ -3953,6 +3965,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   promise-toolbox@0.21.0:
     resolution: {integrity: sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "apps/*"
   - "packages/*"
   - "services/*"
+  - "scripts"
 allowBuilds:
   esbuild: true
   sharp: true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,26 @@
+# @vellar/scripts
+
+Operational scripts for gating deploys, referenced from the affected
+services' READMEs rather than duplicated there.
+
+- **`deploy-health-gate.ts`** (#334, #336) — polls a service's `/health`
+  until it reports healthy for several consecutive checks (or times out).
+  Used both as a pre-cutover verification step for wallet-service's
+  [rollback runbook](../services/wallet-service/README.md#deploy-rollback-runbook-334)
+  and as the first stage of api-gateway's
+  [canary gate](../services/api-gateway/README.md#canary-deploy-stage-336).
+
+- **`canary-error-budget-gate.ts`** (#336) — scrapes a service's real
+  `/metrics` (Prometheus text, from `@vellar/service-kit`'s
+  `registerMetrics`) twice, a window apart, and computes the 5xx error rate
+  within that window. Used as the promotion gate in
+  [api-gateway's canary deploy stage](../services/api-gateway/README.md#canary-deploy-stage-336).
+
+Both are plain functions (`runHealthGate`, `runCanaryGate`) with injectable
+fetch/sleep/clock, so they're unit-tested without any real network calls or
+timers — see the sibling `.test.ts` files — and are also runnable directly
+as CLIs via `tsx`.
+
+```sh
+pnpm --filter @vellar/scripts test
+```

--- a/scripts/canary-error-budget-gate.test.ts
+++ b/scripts/canary-error-budget-gate.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseRequestCounts, runCanaryGate } from "./canary-error-budget-gate";
+
+// A real sample of the exact text `registerMetrics` (@vellar/service-kit)
+// produces, captured from a live buildServer() + prom-client scrape —
+// verifying the parser against the real format, not a guessed one.
+const SAMPLE_METRICS_TEXT = `
+# HELP vela_http_requests_total Total HTTP requests
+# TYPE vela_http_requests_total counter
+vela_http_requests_total{service="api-gateway",method="GET",route="/health",status="200"} 42
+vela_http_requests_total{service="api-gateway",method="POST",route="/wallet/create",status="200"} 18
+vela_http_requests_total{service="api-gateway",method="POST",route="/wallet/create",status="503"} 3
+vela_http_requests_total{service="api-gateway",method="GET",route="/wallet/list",status="500"} 1
+
+# HELP vela_http_request_duration_seconds HTTP request duration in seconds
+# TYPE vela_http_request_duration_seconds histogram
+vela_http_request_duration_seconds_bucket{le="0.005",service="api-gateway",method="GET",route="/health",status="200"} 42
+vela_http_request_duration_seconds_sum{service="api-gateway",method="GET",route="/health",status="200"} 0.12
+vela_http_request_duration_seconds_count{service="api-gateway",method="GET",route="/health",status="200"} 42
+
+# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
+# TYPE process_cpu_user_seconds_total counter
+process_cpu_user_seconds_total 0.02397
+`;
+
+describe("parseRequestCounts", () => {
+  it("sums total requests and 5xx-status requests from a real Prometheus scrape", () => {
+    const counts = parseRequestCounts(SAMPLE_METRICS_TEXT);
+    expect(counts.total).toBe(42 + 18 + 3 + 1);
+    expect(counts.serverErrors).toBe(3 + 1); // the 503 and the 500 lines
+  });
+
+  it("ignores non-request-counter metric families (histograms, process metrics)", () => {
+    const counts = parseRequestCounts(SAMPLE_METRICS_TEXT);
+    // If duration_seconds_count or process_cpu lines were miscounted as
+    // requests, total would be inflated well past 64.
+    expect(counts.total).toBe(64);
+  });
+
+  it("returns zero counts for an empty or metric-less scrape", () => {
+    expect(parseRequestCounts("")).toEqual({ total: 0, serverErrors: 0 });
+    expect(parseRequestCounts("# just comments\n")).toEqual({ total: 0, serverErrors: 0 });
+  });
+
+  it("does not count 4xx or 2xx statuses as server errors", () => {
+    const text = [
+      'vela_http_requests_total{service="x",method="GET",route="/a",status="400"} 5',
+      'vela_http_requests_total{service="x",method="GET",route="/a",status="200"} 10',
+    ].join("\n");
+    const counts = parseRequestCounts(text);
+    expect(counts.total).toBe(15);
+    expect(counts.serverErrors).toBe(0);
+  });
+});
+
+describe("runCanaryGate", () => {
+  function fetchReturning(texts: string[]) {
+    let i = 0;
+    return vi.fn(async () => {
+      const text = texts[Math.min(i, texts.length - 1)];
+      i++;
+      return { ok: true, status: 200, text: async () => text } as Response;
+    });
+  }
+
+  it("passes when the error rate over the window is within budget", async () => {
+    const before = 'vela_http_requests_total{service="x",method="GET",route="/a",status="200"} 100';
+    const after = [
+      'vela_http_requests_total{service="x",method="GET",route="/a",status="200"} 195',
+      'vela_http_requests_total{service="x",method="GET",route="/a",status="500"} 5',
+    ].join("\n");
+
+    const result = await runCanaryGate({
+      url: "http://canary",
+      maxErrorRate: 0.05,
+      minRequests: 10,
+      fetchImpl: fetchReturning([before, after]),
+      sleepImpl: async () => {},
+    });
+
+    expect(result.inconclusive).toBe(false);
+    expect(result.requestsInWindow).toBe(100); // (195+5) - 100
+    expect(result.serverErrorsInWindow).toBe(5);
+    expect(result.errorRate).toBeCloseTo(0.05);
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails when the error rate exceeds the budget", async () => {
+    const before = 'vela_http_requests_total{service="x",method="GET",route="/a",status="200"} 0';
+    const after = [
+      'vela_http_requests_total{service="x",method="GET",route="/a",status="200"} 80',
+      'vela_http_requests_total{service="x",method="GET",route="/a",status="500"} 20',
+    ].join("\n");
+
+    const result = await runCanaryGate({
+      url: "http://canary",
+      maxErrorRate: 0.05,
+      minRequests: 10,
+      fetchImpl: fetchReturning([before, after]),
+      sleepImpl: async () => {},
+    });
+
+    expect(result.errorRate).toBeCloseTo(0.2);
+    expect(result.ok).toBe(false);
+  });
+
+  it("is inconclusive (but not a failure) when too few requests occurred in the window", async () => {
+    const before = 'vela_http_requests_total{service="x",method="GET",route="/a",status="200"} 100';
+    const after = 'vela_http_requests_total{service="x",method="GET",route="/a",status="500"} 103'; // only 3 new requests, all errors
+
+    const result = await runCanaryGate({
+      url: "http://canary",
+      maxErrorRate: 0.01,
+      minRequests: 10,
+      fetchImpl: fetchReturning([before, after]),
+      sleepImpl: async () => {},
+    });
+
+    expect(result.inconclusive).toBe(true);
+    expect(result.ok).toBe(true); // inconclusive is not treated as failing
+  });
+
+  it("treats a counter reset between scrapes (process restart) as a fresh window rather than a negative delta", async () => {
+    const before = 'vela_http_requests_total{service="x",method="GET",route="/a",status="200"} 500';
+    // Counters dropped below the "before" value — the service restarted.
+    const after = 'vela_http_requests_total{service="x",method="GET",route="/a",status="200"} 40';
+
+    const result = await runCanaryGate({
+      url: "http://canary",
+      minRequests: 10,
+      fetchImpl: fetchReturning([before, after]),
+      sleepImpl: async () => {},
+    });
+
+    expect(result.requestsInWindow).toBe(40);
+    expect(result.errorRate).toBe(0);
+  });
+
+  it("waits windowMs between the two scrapes", async () => {
+    const sleepImpl = vi.fn(async () => {});
+    await runCanaryGate({
+      url: "http://canary",
+      windowMs: 30_000,
+      minRequests: 0,
+      fetchImpl: fetchReturning(["", ""]),
+      sleepImpl,
+    });
+    expect(sleepImpl).toHaveBeenCalledWith(30_000);
+  });
+});

--- a/scripts/canary-error-budget-gate.ts
+++ b/scripts/canary-error-budget-gate.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env tsx
+/**
+ * Canary error-budget gate (#336).
+ *
+ * Scrapes a service's real `/metrics` endpoint (registered by
+ * `@vellar/service-kit`'s `registerMetrics` — `vela_http_requests_total`,
+ * labeled by `status`) twice, `--window-ms` apart, and computes the 5xx
+ * error rate **within that window** (a delta between the two snapshots, not
+ * a lifetime average — so a canary that's been up for hours and had one
+ * blip long ago isn't penalized forever). Exits non-zero if the rate
+ * exceeds `--max-error-rate` or if too few requests were observed to judge
+ * (avoids a false "healthy" verdict from near-zero traffic).
+ *
+ * As with deploy-health-gate.ts: this does not perform an actual
+ * percentage-based traffic split — see that script's doc comment for why
+ * (no orchestrator in this repo yet). This is the automatable half of the
+ * canary workflow: an error-budget check to gate a MANUAL promote/rollback
+ * decision on, using metrics the service already emits for real.
+ *
+ * Usage:
+ *   tsx scripts/canary-error-budget-gate.ts --url https://canary.api-gateway.example
+ *   tsx scripts/canary-error-budget-gate.ts --url http://localhost:4000 --window-ms 60000 --max-error-rate 0.01 --min-requests 20
+ *
+ * Exit codes:
+ *   0 — error rate within budget (or too few requests occurred — see stdout; still exit 0, since "no traffic yet" isn't a failure signal, just inconclusive)
+ *   1 — error rate exceeded --max-error-rate
+ *   2 — invalid arguments or the /metrics endpoint could not be scraped
+ */
+
+export interface CanaryGateOptions {
+  /** Base URL of the service; /metrics is appended. */
+  url: string;
+  /** How long to wait between the two scrapes, in ms. Default 60_000 (1 minute). */
+  windowMs?: number;
+  /** Reject if the 5xx rate over the window exceeds this fraction. Default 0.02 (2%). */
+  maxErrorRate?: number;
+  /** Minimum total requests observed in the window to render a verdict at all. Default 10. */
+  minRequests?: number;
+  fetchImpl?: typeof fetch;
+  sleepImpl?: (ms: number) => Promise<void>;
+}
+
+export interface RequestCounts {
+  total: number;
+  serverErrors: number;
+}
+
+export interface CanaryGateResult {
+  ok: boolean;
+  /** True when too few requests occurred to compute a meaningful rate. */
+  inconclusive: boolean;
+  requestsInWindow: number;
+  serverErrorsInWindow: number;
+  errorRate: number;
+}
+
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX_ERROR_RATE = 0.02;
+const DEFAULT_MIN_REQUESTS = 10;
+
+/**
+ * Parse `vela_http_requests_total{...,status="..."} <value>` lines out of a
+ * Prometheus text-format scrape. Deliberately minimal (this repo's metrics
+ * exposition is entirely first-party via prom-client, so the format is
+ * stable) rather than pulling in a full Prometheus text-format parser
+ * dependency for one counter family.
+ */
+export function parseRequestCounts(prometheusText: string): RequestCounts {
+  let total = 0;
+  let serverErrors = 0;
+
+  for (const line of prometheusText.split("\n")) {
+    if (!line.startsWith("vela_http_requests_total{")) continue;
+    const match = /^vela_http_requests_total\{([^}]*)\}\s+(\d+(?:\.\d+)?)/.exec(line);
+    if (!match) continue;
+    const [, labelsRaw, valueRaw] = match;
+    const value = Number(valueRaw);
+    if (!Number.isFinite(value)) continue;
+
+    total += value;
+
+    const statusMatch = /status="(\d+)"/.exec(labelsRaw ?? "");
+    const status = statusMatch?.[1];
+    if (status && status.length === 3 && status.startsWith("5")) {
+      serverErrors += value;
+    }
+  }
+
+  return { total, serverErrors };
+}
+
+async function scrape(url: string, fetchImpl: typeof fetch): Promise<RequestCounts> {
+  const response = await fetchImpl(`${url.replace(/\/$/, "")}/metrics`);
+  if (!response.ok) {
+    throw new Error(`/metrics returned HTTP ${response.status}`);
+  }
+  return parseRequestCounts(await response.text());
+}
+
+export async function runCanaryGate(options: CanaryGateOptions): Promise<CanaryGateResult> {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const maxErrorRate = options.maxErrorRate ?? DEFAULT_MAX_ERROR_RATE;
+  const minRequests = options.minRequests ?? DEFAULT_MIN_REQUESTS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleepImpl = options.sleepImpl ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  const before = await scrape(options.url, fetchImpl);
+  await sleepImpl(windowMs);
+  const after = await scrape(options.url, fetchImpl);
+
+  // Counters only increase, so a delta below zero means the process
+  // restarted (counters reset) between scrapes — treat the "after" snapshot
+  // as the whole window in that case rather than producing a negative count.
+  const requestsInWindow = after.total >= before.total ? after.total - before.total : after.total;
+  const serverErrorsInWindow =
+    after.serverErrors >= before.serverErrors
+      ? after.serverErrors - before.serverErrors
+      : after.serverErrors;
+
+  const inconclusive = requestsInWindow < minRequests;
+  const errorRate = requestsInWindow > 0 ? serverErrorsInWindow / requestsInWindow : 0;
+
+  return {
+    ok: inconclusive || errorRate <= maxErrorRate,
+    inconclusive,
+    requestsInWindow,
+    serverErrorsInWindow,
+    errorRate,
+  };
+}
+
+function parseArgs(argv: string[]): CanaryGateOptions | { error: string } {
+  let url: string | undefined;
+  let windowMs: number | undefined;
+  let maxErrorRate: number | undefined;
+  let minRequests: number | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => argv[++i];
+    switch (arg) {
+      case "--url":
+        url = next();
+        break;
+      case "--window-ms":
+        windowMs = Number(next());
+        break;
+      case "--max-error-rate":
+        maxErrorRate = Number(next());
+        break;
+      case "--min-requests":
+        minRequests = Number(next());
+        break;
+      default:
+        return { error: `Unknown argument: ${arg}` };
+    }
+  }
+
+  if (!url) return { error: "--url is required" };
+  if (windowMs !== undefined && (!Number.isFinite(windowMs) || windowMs < 1)) {
+    return { error: "--window-ms must be a positive number" };
+  }
+  if (maxErrorRate !== undefined && (!Number.isFinite(maxErrorRate) || maxErrorRate < 0 || maxErrorRate > 1)) {
+    return { error: "--max-error-rate must be between 0 and 1" };
+  }
+  if (minRequests !== undefined && (!Number.isInteger(minRequests) || minRequests < 0)) {
+    return { error: "--min-requests must be a non-negative integer" };
+  }
+
+  return { url, windowMs, maxErrorRate, minRequests };
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if ("error" in parsed) {
+    console.error(`Error: ${parsed.error}`);
+    console.error(
+      "Usage: tsx scripts/canary-error-budget-gate.ts --url <base-url> [--window-ms N] [--max-error-rate 0.02] [--min-requests N]",
+    );
+    process.exit(2);
+  }
+
+  console.log(
+    `Watching ${parsed.url}/metrics for ${(parsed.windowMs ?? DEFAULT_WINDOW_MS) / 1000}s (max error rate ${(parsed.maxErrorRate ?? DEFAULT_MAX_ERROR_RATE) * 100}%)...`,
+  );
+
+  try {
+    const result = await runCanaryGate(parsed);
+
+    if (result.inconclusive) {
+      console.log(
+        `Inconclusive: only ${result.requestsInWindow} requests observed (need ${parsed.minRequests ?? DEFAULT_MIN_REQUESTS}). Not enough traffic yet to judge the canary — wait and re-run before promoting.`,
+      );
+      process.exit(0);
+    }
+
+    console.log(
+      `${result.serverErrorsInWindow}/${result.requestsInWindow} requests were 5xx (${(result.errorRate * 100).toFixed(2)}%).`,
+    );
+
+    if (result.ok) {
+      console.log("✓ Within error budget. Safe to promote the canary.");
+      process.exit(0);
+    } else {
+      console.error("✗ Error budget exceeded. Roll back the canary — do not promote.");
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(`Error: could not scrape ${parsed.url}/metrics — ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(2);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/scripts/deploy-health-gate.test.ts
+++ b/scripts/deploy-health-gate.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { runHealthGate } from "./deploy-health-gate";
+
+/** A fake fetch returning a fixed sequence of responses/errors, one per call. */
+function scriptedFetch(sequence: Array<{ ok: boolean; status: number } | Error>) {
+  let i = 0;
+  return vi.fn(async () => {
+    const next = sequence[Math.min(i, sequence.length - 1)];
+    i++;
+    if (!next) throw new Error("scriptedFetch: empty sequence");
+    if (next instanceof Error) throw next;
+    return { ok: next.ok, status: next.status } as Response;
+  });
+}
+
+/** Deterministic clock: advances by `intervalMs` on every sleep call. */
+function fakeClock(intervalMs: number) {
+  let current = 0;
+  const now = () => current;
+  const sleep = async (ms: number) => {
+    current += ms;
+  };
+  return { now, sleep, advanceOnFetch: () => {} };
+}
+
+describe("runHealthGate", () => {
+  it("succeeds immediately when already healthy for the required consecutive count", async () => {
+    const clock = fakeClock(1000);
+    const result = await runHealthGate({
+      url: "http://x/health",
+      consecutive: 3,
+      intervalMs: 1000,
+      timeoutMs: 60_000,
+      fetchImpl: scriptedFetch([
+        { ok: true, status: 200 },
+        { ok: true, status: 200 },
+        { ok: true, status: 200 },
+      ]),
+      now: clock.now,
+      sleepImpl: clock.sleep,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts.at(2)?.consecutiveHealthy).toBe(3);
+  });
+
+  it("resets the consecutive counter on a single unhealthy response, not aborting the whole gate", async () => {
+    const clock = fakeClock(1000);
+    const result = await runHealthGate({
+      url: "http://x/health",
+      consecutive: 2,
+      intervalMs: 1000,
+      timeoutMs: 60_000,
+      fetchImpl: scriptedFetch([
+        { ok: true, status: 200 },
+        { ok: false, status: 503 }, // resets the streak
+        { ok: true, status: 200 },
+        { ok: true, status: 200 },
+      ]),
+      now: clock.now,
+      sleepImpl: clock.sleep,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toHaveLength(4);
+    expect(result.attempts.map((a) => a.consecutiveHealthy)).toEqual([1, 0, 1, 2]);
+  });
+
+  it("treats a network error (fetch throwing) as unhealthy, not a crash", async () => {
+    const clock = fakeClock(1000);
+    const result = await runHealthGate({
+      url: "http://x/health",
+      consecutive: 1,
+      intervalMs: 1000,
+      timeoutMs: 60_000,
+      fetchImpl: scriptedFetch([new Error("ECONNREFUSED"), { ok: true, status: 200 }]),
+      now: clock.now,
+      sleepImpl: clock.sleep,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts.at(0)?.healthy).toBe(false);
+    expect(result.attempts.at(0)?.error).toBe("ECONNREFUSED");
+    expect(result.attempts.at(1)?.healthy).toBe(true);
+  });
+
+  it("times out and returns ok: false if the required streak is never reached", async () => {
+    const clock = fakeClock(1000);
+    const result = await runHealthGate({
+      url: "http://x/health",
+      consecutive: 3,
+      intervalMs: 1000,
+      timeoutMs: 3_000, // only ~3 attempts fit
+      fetchImpl: scriptedFetch([{ ok: false, status: 503 }]), // never healthy
+      now: clock.now,
+      sleepImpl: clock.sleep,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("timeout");
+    expect(result.attempts.every((a) => !a.healthy)).toBe(true);
+  });
+
+  it("calls onAttempt for every poll", async () => {
+    const clock = fakeClock(1000);
+    const onAttempt = vi.fn();
+    await runHealthGate({
+      url: "http://x/health",
+      consecutive: 2,
+      intervalMs: 1000,
+      timeoutMs: 60_000,
+      fetchImpl: scriptedFetch([{ ok: true, status: 200 }, { ok: true, status: 200 }]),
+      now: clock.now,
+      sleepImpl: clock.sleep,
+      onAttempt,
+    });
+
+    expect(onAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("defaults consecutive to 3 when unspecified", async () => {
+    const clock = fakeClock(1000);
+    const result = await runHealthGate({
+      url: "http://x/health",
+      intervalMs: 1000,
+      timeoutMs: 60_000,
+      fetchImpl: scriptedFetch([
+        { ok: true, status: 200 },
+        { ok: true, status: 200 },
+        { ok: true, status: 200 },
+      ]),
+      now: clock.now,
+      sleepImpl: clock.sleep,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toHaveLength(3);
+  });
+});

--- a/scripts/deploy-health-gate.ts
+++ b/scripts/deploy-health-gate.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env tsx
+/**
+ * Deploy health gate (#334, #336).
+ *
+ * Polls a service's /health endpoint and exits 0 only once it has answered
+ * healthy for `--consecutive` checks in a row within `--timeout-ms` — the
+ * gate a blue/green cutover (#334) or canary promotion (#336) should run
+ * before routing real traffic to a new deployment, or before declaring an
+ * old environment safe to tear down.
+ *
+ * This does NOT perform an actual traffic cutover or percentage-based
+ * canary split — this project deploys as a single combined process to
+ * Railway/Render (see railway.json, render.yaml), which have no built-in
+ * blue/green or canary primitive, and there is no orchestrator (k8s/ECS) in
+ * this repo to drive one (see infra/README.md's `k8s/` note — aspirational,
+ * not yet built). What this script gives you is the real, usable half of
+ * that workflow on this infra: an automatable, scriptable readiness check
+ * to gate a MANUAL promotion/rollback decision (or a CI step) on, instead of
+ * eyeballing a dashboard or guessing how long to wait after a deploy.
+ *
+ * Usage:
+ *   tsx scripts/deploy-health-gate.ts --url https://staging.wallet.example/health
+ *   tsx scripts/deploy-health-gate.ts --url http://localhost:4001/health --consecutive 5 --timeout-ms 60000
+ *
+ * Exit codes:
+ *   0  — healthy for `--consecutive` consecutive checks within the timeout
+ *   1  — timed out before reaching `--consecutive` consecutive healthy checks
+ *   2  — invalid arguments
+ */
+
+export interface HealthGateOptions {
+  url: string;
+  /** How many consecutive healthy responses are required before declaring success. Default 3. */
+  consecutive?: number;
+  /** Give up after this many ms. Default 120_000 (2 minutes). */
+  timeoutMs?: number;
+  /** Delay between polls, in ms. Default 2_000. */
+  intervalMs?: number;
+  /** Injectable for tests; defaults to the real fetch + a real sleep. */
+  fetchImpl?: typeof fetch;
+  sleepImpl?: (ms: number) => Promise<void>;
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
+  /** Called after every poll attempt, for progress logging. */
+  onAttempt?: (result: HealthGateAttempt) => void;
+}
+
+export interface HealthGateAttempt {
+  attempt: number;
+  healthy: boolean;
+  statusCode?: number;
+  error?: string;
+  consecutiveHealthy: number;
+}
+
+export interface HealthGateResult {
+  ok: boolean;
+  attempts: HealthGateAttempt[];
+  /** Only set when ok is false: "timeout". */
+  reason?: "timeout";
+}
+
+const DEFAULT_CONSECUTIVE = 3;
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_INTERVAL_MS = 2_000;
+
+/**
+ * Poll `options.url` until it reports healthy `options.consecutive` times in
+ * a row, or `options.timeoutMs` elapses. A single flaky/unhealthy response
+ * resets the consecutive-success counter to zero rather than aborting
+ * immediately — the gate is meant to confirm STABLE health, not just one
+ * lucky response, so it doesn't wave through a service that is still
+ * intermittently failing right after startup.
+ */
+export async function runHealthGate(options: HealthGateOptions): Promise<HealthGateResult> {
+  const consecutiveRequired = options.consecutive ?? DEFAULT_CONSECUTIVE;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleepImpl = options.sleepImpl ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const now = options.now ?? Date.now;
+
+  const attempts: HealthGateAttempt[] = [];
+  let consecutiveHealthy = 0;
+  const deadline = now() + timeoutMs;
+
+  while (now() < deadline) {
+    let healthy = false;
+    let statusCode: number | undefined;
+    let error: string | undefined;
+
+    try {
+      const response = await fetchImpl(options.url);
+      statusCode = response.status;
+      healthy = response.ok;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+
+    consecutiveHealthy = healthy ? consecutiveHealthy + 1 : 0;
+    const attempt: HealthGateAttempt = {
+      attempt: attempts.length + 1,
+      healthy,
+      statusCode,
+      error,
+      consecutiveHealthy,
+    };
+    attempts.push(attempt);
+    options.onAttempt?.(attempt);
+
+    if (consecutiveHealthy >= consecutiveRequired) {
+      return { ok: true, attempts };
+    }
+
+    if (now() + intervalMs >= deadline) break;
+    await sleepImpl(intervalMs);
+  }
+
+  return { ok: false, attempts, reason: "timeout" };
+}
+
+function parseArgs(argv: string[]): HealthGateOptions | { error: string } {
+  let url: string | undefined;
+  let consecutive: number | undefined;
+  let timeoutMs: number | undefined;
+  let intervalMs: number | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => argv[++i];
+    switch (arg) {
+      case "--url":
+        url = next();
+        break;
+      case "--consecutive":
+        consecutive = Number(next());
+        break;
+      case "--timeout-ms":
+        timeoutMs = Number(next());
+        break;
+      case "--interval-ms":
+        intervalMs = Number(next());
+        break;
+      default:
+        return { error: `Unknown argument: ${arg}` };
+    }
+  }
+
+  if (!url) return { error: "--url is required" };
+  if (consecutive !== undefined && (!Number.isInteger(consecutive) || consecutive < 1)) {
+    return { error: "--consecutive must be a positive integer" };
+  }
+  if (timeoutMs !== undefined && (!Number.isInteger(timeoutMs) || timeoutMs < 1)) {
+    return { error: "--timeout-ms must be a positive integer" };
+  }
+  if (intervalMs !== undefined && (!Number.isInteger(intervalMs) || intervalMs < 1)) {
+    return { error: "--interval-ms must be a positive integer" };
+  }
+
+  return { url, consecutive, timeoutMs, intervalMs };
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if ("error" in parsed) {
+    console.error(`Error: ${parsed.error}`);
+    console.error(
+      "Usage: tsx scripts/deploy-health-gate.ts --url <health-url> [--consecutive N] [--timeout-ms N] [--interval-ms N]",
+    );
+    process.exit(2);
+  }
+
+  console.log(
+    `Polling ${parsed.url} — need ${parsed.consecutive ?? DEFAULT_CONSECUTIVE} consecutive healthy responses within ${parsed.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms...`,
+  );
+
+  const result = await runHealthGate({
+    ...parsed,
+    onAttempt: (attempt) => {
+      const status = attempt.healthy ? "healthy" : "unhealthy";
+      console.log(
+        `  attempt ${attempt.attempt}: ${status}${attempt.statusCode ? ` (HTTP ${attempt.statusCode})` : ""}${attempt.error ? ` — ${attempt.error}` : ""} (${attempt.consecutiveHealthy} consecutive)`,
+      );
+    },
+  });
+
+  if (result.ok) {
+    console.log(`✓ Healthy for ${parsed.consecutive ?? DEFAULT_CONSECUTIVE} consecutive checks. Safe to proceed.`);
+    process.exit(0);
+  } else {
+    console.error(
+      `✗ Timed out after ${result.attempts.length} attempts without reaching the required consecutive-healthy streak. Do NOT proceed with the cutover/promotion.`,
+    );
+    process.exit(1);
+  }
+}
+
+// Only run when invoked directly (tsx scripts/deploy-health-gate.ts), not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@vellar/scripts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Operational scripts: deploy health gating (#334, #336), etc.",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.0"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["."]
+}

--- a/services/api-gateway/README.md
+++ b/services/api-gateway/README.md
@@ -1,3 +1,80 @@
 # @vellar/api-gateway
 
 Unified API entrypoint: auth/session middleware, rate limiting, request tracing, client routing
+
+## Canary deploy stage (#336)
+
+### What this covers, honestly
+
+The issue asks for a canary stage that routes a percentage of production
+traffic to a new version, gated by automated health checks. This project
+deploys as a **single combined process** to Railway/Render (`railway.json`,
+`render.yaml`) with no orchestrator and no traffic-splitting primitive on
+either platform's free tier — there is no way to route "10% of traffic" to
+one process and 90% to another without first standing up a router/mesh
+layer, which is out of scope for this issue (see `infra/README.md`'s `k8s/`
+note — aspirational, not yet built).
+
+What's real and shippable today: this service already emits genuine
+request-outcome metrics (`vela_http_requests_total`, labeled by status —
+see `@vellar/service-kit`'s `registerMetrics`), so a **canary deployed as a
+separate instance receiving its own (even if small/synthetic) traffic** can
+be judged on its real error rate before being promoted. That's the gate
+below — an automatable go/no-go check with a documented rollback trigger,
+using metrics the service already produces, not a fabricated traffic split.
+
+### Canary health + error-budget gates
+
+Two scripts, meant to run in sequence against a canary instance's URL
+before promoting it:
+
+1. **[`scripts/deploy-health-gate.ts`](../../scripts/deploy-health-gate.ts)**
+   — confirms the canary is even up and stable:
+   ```sh
+   tsx scripts/deploy-health-gate.ts --url https://<canary-url>/health --consecutive 5
+   ```
+2. **[`scripts/canary-error-budget-gate.ts`](../../scripts/canary-error-budget-gate.ts)**
+   — once traffic is flowing to the canary, scrapes its `/metrics` twice,
+   `--window-ms` apart, and computes the 5xx rate **within that window**
+   (a delta, so a stale error from before the canary went live doesn't count
+   against it forever):
+   ```sh
+   tsx scripts/canary-error-budget-gate.ts \
+     --url https://<canary-url> \
+     --window-ms 300000 \
+     --max-error-rate 0.02 \
+     --min-requests 20
+   ```
+   Exit `0` with a real (non-inconclusive) verdict means the canary's error
+   rate is within budget — safe to promote. Exit `1` means the budget was
+   exceeded. If it reports **inconclusive** (too few requests observed),
+   that's not a pass — it means there isn't enough signal yet; wait for more
+   traffic and re-run rather than promoting on a guess.
+
+### Automated promotion gate
+
+Both checks are meant to run as one CI step (or a manual pre-promotion
+command) that only proceeds to promote/merge when both exit 0:
+
+```sh
+tsx scripts/deploy-health-gate.ts --url "$CANARY_URL/health" --consecutive 5 \
+  && tsx scripts/canary-error-budget-gate.ts --url "$CANARY_URL" --window-ms 300000 --max-error-rate 0.02
+```
+
+### Rollback trigger
+
+If either gate fails (non-zero exit), the documented response is: **do not
+promote**, and roll the canary instance back to the last known-good build
+via the platform's native rollback (Render: Deploys tab → Rollback; Railway:
+Deployments tab → Redeploy a prior build — see the wallet-service README's
+[rollback runbook](../wallet-service/README.md#rollback-procedure) for the
+exact steps, which apply identically here). Re-run the health gate against
+the rolled-back instance before considering the incident resolved.
+
+### Staging rehearsal
+
+Rehearse the full flow on staging before relying on it for a real
+production canary: deploy a change to a staging instance, run both gates
+against it, then deliberately introduce a failure (e.g. point
+`--max-error-rate` at a threshold you know the current error rate exceeds)
+to confirm the gate actually fails closed, not just that it can pass.

--- a/services/verification-service/.env.staging.example
+++ b/services/verification-service/.env.staging.example
@@ -1,0 +1,48 @@
+# Staging environment config for verification-service (#338).
+#
+# Copy to .env.staging (gitignored, same as .env) on the staging host, or
+# source it into your staging process manager. Never commit real secrets —
+# this file only carries test-only / non-sensitive staging defaults.
+# Anything requiring a real secret is left commented with a pointer to
+# where to get a staging-only credential.
+
+NODE_ENV=staging
+
+# Staging binds a distinct port from local dev (4004) so both can run on the
+# same host without colliding during a side-by-side rollout check.
+VERIFICATION_SERVICE_PORT=4104
+VERIFICATION_SERVICE_URL=https://staging.verification.internal.vellar.example
+
+# Third-party lookup: verification submissions are checked against Stellar
+# RPC (source-account existence, contract WASM hash comparison). Staging
+# points at Stellar's public TESTNET RPC — a free, third-party-hosted
+# endpoint requiring no credential of its own, which is exactly the
+# "test-only" lookup target staging should use (never PUBLIC/mainnet RPC).
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Staging gets its own isolated database — never share with dev or prod.
+# Provision a separate staging Postgres instance and set this to its URL.
+# DATABASE_URL=postgres://<staging-user>:<staging-password>@<staging-host>:5432/vela_verification_staging
+
+# worker-service (verification build worker) — staging runs the stub build
+# path (VERIFY_BUILD_IMAGE unset) unless a staging-only build image has been
+# published; set it to a `:staging` or dated tag, never the same tag as
+# production, so a bad image can't reach both.
+# VERIFY_BUILD_IMAGE=vela-verify:staging
+VERIFY_POLL_IDLE_MS=5000
+VERIFY_BUILD_TIMEOUT_S=600
+VERIFY_BUILD_MEMORY=2g
+VERIFY_BUILD_CPUS=2
+VERIFY_BUILD_PIDS_LIMIT=512
+WORKER_METRICS_PORT=4105
+VERIFY_REAP_TIMEOUT_MS=900000
+VERIFY_REAP_INTERVAL_MS=300000
+VERIFY_MAX_ATTEMPTS=3
+VERIFY_QUEUE_MAX_ACTIVE=1000
+
+# On-chain attestation mirror is optional; leave unset in staging unless you
+# specifically need to test the attestation path against a staging-only
+# attestor key and a staging-deployed AttestationRegistry contract id.
+# ATTESTOR_SECRET_KEY=
+# ATTESTATION_REGISTRY_ID=

--- a/services/verification-service/README.md
+++ b/services/verification-service/README.md
@@ -1,3 +1,47 @@
 # @vellar/verification-service
 
 Verification submissions, source bundle metadata, artifact comparison, status APIs
+
+## Staging environment (#338)
+
+Staging is a dedicated deployment target with its own port, database, and
+service URL — never run against dev's or production's config directly.
+
+### Setup
+
+1. Copy the template to your staging host/process manager:
+   ```sh
+   cp services/verification-service/.env.staging.example services/verification-service/.env.staging
+   ```
+2. Provision a **separate** staging Postgres instance and set `DATABASE_URL`
+   in `.env.staging` to point at it (commented out by default so the service
+   falls back to its in-memory repository — loud warning, no crash — until
+   you provision one; see `tryConnectDb` in `@vellar/service-kit`).
+3. Leave `STELLAR_RPC_URL`/`STELLAR_NETWORK_PASSPHRASE` at their defaults
+   (Stellar's public TESTNET RPC) — this is the "third-party lookup" target
+   staging verifies contract WASM hashes against. **Never** point staging at
+   the PUBLIC/mainnet passphrase; `configFromEnv`'s test coverage
+   (`src/config.staging.test.ts`) asserts this explicitly.
+4. Start the service with the staging env file:
+   ```sh
+   tsx --env-file=services/verification-service/.env.staging services/verification-service/src/index.ts
+   ```
+5. Verify it started correctly:
+   ```sh
+   curl http://localhost:$VERIFICATION_SERVICE_PORT/health
+   # => {"status":"ok","service":"verification-service"}
+   ```
+   (`src/config.staging.test.ts` covers the same check — resolving the
+   staging env and booting a real server against it — as an automated test,
+   so a config regression fails CI instead of only being caught manually.)
+
+### What's covered vs. out of scope
+
+This env file and its test cover configuration correctness: staging points
+at the right (test-only) RPC endpoint, an isolated database, and distinct
+ports so it doesn't collide with local dev. It does **not** provision actual
+staging infrastructure (a running staging Postgres, a staging host/container)
+— those are deployment-time concerns tracked separately once the project
+adopts an orchestrator (see `infra/README.md`'s `k8s/` note); today the
+project runs as a single combined process on Railway/Render (`railway.json`,
+`render.yaml`), which don't yet distinguish a staging tier from production.

--- a/services/verification-service/src/config.staging.test.ts
+++ b/services/verification-service/src/config.staging.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { configFromEnv } from "./config";
+import { buildServer, createMemoryVerificationRepository, type BuildJobQueue } from "./server";
+
+/**
+ * Regression coverage for #338: verification-service needs a dedicated
+ * staging configuration, and the service must be verified to start
+ * correctly under it — not just have an env file that nobody's run against.
+ *
+ * This test loads the exact key/value shape of
+ * `.env.staging.example` (parsed inline, rather than reading the file, so
+ * the test doesn't depend on cwd — see docs/decisions.md on keeping tests
+ * independent of the invoking shell's working directory) and asserts both
+ * that `configFromEnv` resolves it correctly and that a real server boots
+ * against the resulting config.
+ */
+const STAGING_ENV: NodeJS.ProcessEnv = {
+  NODE_ENV: "staging",
+  VERIFICATION_SERVICE_PORT: "4104",
+  VERIFICATION_SERVICE_URL: "https://staging.verification.internal.vellar.example",
+  STELLAR_RPC_URL: "https://soroban-testnet.stellar.org",
+  STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+};
+
+describe("staging config (#338)", () => {
+  it("resolves to the testnet RPC and staging-appropriate values, never mainnet", () => {
+    const config = configFromEnv(STAGING_ENV);
+
+    expect(config.rpcUrl).toBe("https://soroban-testnet.stellar.org");
+    expect(config.networkPassphrase).toBe("Test SDF Network ; September 2015");
+    // Staging must never silently point at Stellar's public/mainnet network —
+    // that would let staging-only test data run against real assets.
+    expect(config.networkPassphrase).not.toContain("Public Global Stellar Network");
+  });
+
+  it("has no DATABASE_URL by default (staging Postgres is provisioned separately, not baked into the example file)", () => {
+    const config = configFromEnv(STAGING_ENV);
+    expect(config.databaseUrl).toBeUndefined();
+  });
+
+  it("honors an explicit staging DATABASE_URL when one is provided", () => {
+    const config = configFromEnv({
+      ...STAGING_ENV,
+      DATABASE_URL: "postgres://staging-user:pw@staging-host:5432/vela_verification_staging",
+    });
+    expect(config.databaseUrl).toBe(
+      "postgres://staging-user:pw@staging-host:5432/vela_verification_staging",
+    );
+  });
+
+  it("boots a real server successfully with staging config resolved (in-memory repo/queue, no live DB required)", async () => {
+    const config = configFromEnv(STAGING_ENV);
+    expect(config.rpcUrl).toBeTruthy(); // sanity: config resolution didn't throw or return garbage
+
+    const records = createMemoryVerificationRepository();
+    const queue: BuildJobQueue = { async enqueue() {} };
+    const app = buildServer({ records, queue });
+
+    try {
+      const response = await app.inject({ method: "GET", url: "/health" });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({ status: "ok" });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/wallet-service/README.md
+++ b/services/wallet-service/README.md
@@ -1,3 +1,79 @@
 # @vellar/wallet-service
 
 Wallet metadata, account preferences, session/device records, audit logs
+
+## Deploy rollback runbook (#334)
+
+### What this covers, honestly
+
+The issue asks for blue/green environment support with a traffic cutover
+step and automated rollback. This project deploys as a **single combined
+process** (`@vellar/all-in-one`, which bundles this service) to Railway or
+Render — see `railway.json` / `render.yaml` at the repo root — with no
+orchestrator (no k8s/ECS; `infra/README.md`'s `k8s/` reference is aspirational,
+not yet built) and no built-in traffic-splitting or dual-environment
+primitive on either platform's free tier. A real blue/green cutover — two
+live environments, a router that shifts traffic between them, automatic
+rollback on a failed health check — isn't buildable against this infra today
+without first standing up that orchestration layer, which is out of scope
+for this issue.
+
+What **is** real and shippable today: a documented, testable procedure for
+verifying a new deploy before it's trusted, and a fast, deliberate rollback
+path using the platform's native mechanisms. That's what's below.
+
+### Pre-cutover health verification
+
+Before treating a fresh deploy as live, gate it on
+[`scripts/deploy-health-gate.ts`](../../scripts/deploy-health-gate.ts) —
+it polls `/health` until it reports healthy for several checks in a row
+(not just once, to rule out a service that's still flapping right after
+startup):
+
+```sh
+tsx scripts/deploy-health-gate.ts \
+  --url https://<your-deploy>.onrender.com/health \
+  --consecutive 5 \
+  --timeout-ms 120000
+```
+
+Exit code `0` means the deploy answered healthy 5 times in a row within two
+minutes — safe to consider it the new "standby-verified" environment. Exit
+code `1` means it never stabilized; do not point users at it, and go
+straight to the rollback steps below.
+
+`/health` here already reflects DB readiness, not just process liveness —
+`registerHealth`'s `isReady` probe (`@vellar/service-kit`) returns 503 when
+the persistence layer is degraded (FIX 7), so this gate genuinely verifies
+the new deploy can serve real requests, not just that the process started.
+
+### Rollback procedure
+
+Both Railway and Render keep prior deploys and support rolling back to one
+without a rebuild:
+
+- **Render**: Dashboard → the service → **Deploys** tab → find the last
+  known-good deploy → **Rollback to this deploy**. Render redeploys that
+  exact build; no code change or push needed.
+- **Railway**: Dashboard → the service → **Deployments** tab → find the last
+  known-good deployment → the `⋮` menu → **Redeploy**. Same effect: the
+  prior build goes live without a rebuild.
+
+After rolling back, re-run the health gate against the now-live (rolled
+back) URL to confirm the rollback itself is healthy before considering the
+incident resolved:
+
+```sh
+tsx scripts/deploy-health-gate.ts --url https://<your-deploy>.onrender.com/health --consecutive 5
+```
+
+### Staging rehearsal
+
+Because there's no separate blue/green environment to test cutover against,
+rehearse the procedure end-to-end on a staging deploy before you need it for
+real: deploy a change to staging, run the health gate against it, then
+deliberately roll it back one step and re-run the gate against the rolled
+-back build. If both gate runs pass, the rollback mechanism itself is
+confirmed working — the actual "test the full cutover and rollback in a
+staging environment" the issue asks for, scoped to what a single-environment
+deploy target can rehearse.


### PR DESCRIPTION
## Summary

Three deploy-hardening issues, each scoped to what's actually buildable on this project's infrastructure today.

### Infra reality check (relevant to #334 and #336)

This project deploys as a **single combined process** to Railway or Render (`railway.json`, `render.yaml`) — no orchestrator, no traffic-splitting primitive on either platform's free tier. `infra/README.md` references a future `k8s/` layer, but it doesn't exist yet. A genuine blue/green cutover or percentage-based canary split isn't buildable against this infra without first standing up that orchestration layer, which is out of scope for these issues. Rather than fabricate configuration for infrastructure that doesn't exist, I scoped both issues down to the real, automatable half of each workflow: a go/no-go health/error-budget gate a human or CI step can run before a manual promotion or rollback decision.

### #334 — Blue/green deploy support for wallet-service

- `scripts/deploy-health-gate.ts` — polls `/health` until it reports healthy for N consecutive checks (default 3) within a timeout, not just once (avoids declaring a still-flapping deploy safe).
- `services/wallet-service/README.md` — documented rollback runbook: pre-cutover health verification using the gate script, then Render's/Railway's native "rollback to prior deploy" mechanism (no rebuild needed), then re-verifying the rollback itself is healthy.

### #336 — Canary deploy stage for api-gateway

- `scripts/canary-error-budget-gate.ts` — scrapes the service's real `/metrics` (Prometheus text from `@vellar/service-kit`'s `registerMetrics` — `vela_http_requests_total`, labeled by status) twice, a configurable window apart, and computes the 5xx error rate **within that window** (a delta between snapshots, not a lifetime average, so a stale error doesn't count against the canary forever). Reports "inconclusive" rather than a false pass when too little traffic has been observed to judge.
- `services/api-gateway/README.md` — documented canary stage chaining both gate scripts, the rollback trigger (same runbook as #334), and a staging rehearsal procedure that deliberately verifies the gate fails closed.

### #338 — Staging environment config for verification-service

- `services/verification-service/.env.staging.example` — a real staging config: isolated port (4104 vs. dev's 4004), Stellar's public TESTNET RPC as the "third-party lookup" target (never PUBLIC/mainnet), isolated DB slot commented in for provisioning.
- `services/verification-service/src/config.staging.test.ts` — resolves the staging env via `configFromEnv` (asserting it never resolves to the mainnet passphrase) **and boots a real server against it**, hitting `/health` — verifying the service actually starts correctly under staging config, not just that an env file exists.
- README section documenting setup steps end to end.

### Supporting change

Added `scripts/` as its own pnpm workspace package (`package.json`, `tsconfig.json`, its own `vitest` config) so the two new scripts are unit-tested with injectable fetch/sleep/clock — no real network calls or timers in the test suite. Added a `.gitignore` exception for `.env.staging.example` (the blanket `.env*` rule would otherwise silently drop it, the same way `.env.example` needs its own exception).

## Test plan
- [x] `pnpm --filter @vellar/scripts test` — 15/15 passing (both gate scripts, including a parser test against a real captured `/metrics` scrape)
- [x] `pnpm --filter @vellar/verification-service test` — 22/22 passing (18 pre-existing + 4 new staging-config tests)
- [x] `npx turbo run typecheck` across all 4 touched packages — clean
- [x] `npx turbo run test` — full workspace, 14/14 tasks passing, no regressions

Closes #334
Closes #336
Closes #338