### PR TITLE
feat(contrib): session retention job, smoke test script, rollback + queue backlog runbooks

### DIFF
--- a/contrib/routes/issue-337-queue-backlog-runbook/README.md
+++ b/contrib/routes/issue-337-queue-backlog-runbook/README.md
@@ -1,0 +1,189 @@
+# Issue 337 — Runbook: worker-service Queue Backlog Incident
+
+Sandboxed operational runbook (per `contrib/README.md` — this repo has no
+runbooks directory yet at all, confirmed by grep; see the PR description for
+why this can't be added at, say, `docs/runbooks/` directly today) for a
+`verification_records` queue backlog on `services/worker-service`.
+
+## Background: what the "queue" actually is here
+
+`worker-service` has **no message broker** — no Redis, no BullMQ, confirmed
+by grep across `services/` and `packages/` (zero hits for
+`redis`/`ioredis`/`bullmq`). The queue is the `verification_records` Postgres
+table itself: rows move through the status enum
+`unverified → submitted → building → verified | failed | dead_letter`
+(`packages/types/src/index.ts`). The worker loop
+(`services/worker-service/src/loop.ts`, wired from `src/index.ts`) polls that
+table, atomically claims a `submitted` row (moves it to `building`), builds
+it, and writes the result. A "backlog" here specifically means: rows are
+piling up in `submitted` (or stuck in `building`) faster than the worker
+process can drain them.
+
+This matters for the runbook because the mitigation options are different
+from a broker-backed queue: there's no separate broker to inspect, no
+consumer group to rebalance — "scaling consumers" means running more
+`worker-service` processes against the same Postgres table (each claims rows
+atomically, so concurrent workers don't double-process), and "pausing
+producers" means throttling or rejecting new `POST /verification/submit`
+calls at the gateway/verification-service layer, not pausing a broker.
+
+## 1. Detection signals
+
+- **Primary metric** (already defined in `docs/observability.md`):
+  `vela_verification_turnaround_seconds` — the histogram the worker emits via
+  `WorkerMetrics.verificationResult()` (`services/worker-service/src/index.ts`).
+  The existing alert `VerificationSlow` (p95 > 300s for 15m, per
+  `docs/observability.md`'s "Recommended alert rules") is the closest existing
+  precedent — a backlog manifests as this p95 climbing, since a row sitting in
+  `submitted` waiting for a free worker adds directly to its own eventual
+  turnaround time.
+- **Queue depth**: count of rows in `submitted` + `building` status in
+  `verification_records`. Not currently exposed as its own metric — until it
+  is, the operational proxy is:
+  ```sql
+  SELECT status, count(*) FROM verification_records
+  WHERE status IN ('submitted', 'building')
+  GROUP BY status;
+  ```
+  run against the shared `DATABASE_URL` worker-service and
+  verification-service both connect to.
+- **The built-in backlog valve firing**: root `.env.example` already documents
+  `VERIFY_QUEUE_MAX_ACTIVE` (default 1000) — "`/verification/submit` 429s past
+  this many active records." A spike in `429` responses from
+  `POST /verification/submit` at the gateway **is itself a backlog signal**:
+  it means the active-record count already hit the configured ceiling before
+  any human noticed. Watch gateway access logs / `domainMetrics` for a rise in
+  429s on that route.
+- **Reaper log noise**: `services/worker-service/src/index.ts`'s reaper
+  (`runReaper`, on `VERIFY_REAP_INTERVAL_MS`, default 5m) logs
+  `reaper: reclaimed X, dead-lettered Y` whenever it reclaims stranded
+  `building` rows (past `VERIFY_REAP_TIMEOUT_MS`, default 15m) or dead-letters
+  them after `VERIFY_MAX_ATTEMPTS` (default 3). A rising rate of reclaims is a
+  symptom of workers dying or hanging mid-build (crash-looping, OOM,
+  Docker/timeout issues) rather than simple under-capacity — worth
+  distinguishing from "just needs more workers" (see Mitigation, below).
+- **worker-service `/health`** (`WORKER_METRICS_PORT`, default 4005): the
+  worker is still "healthy" per this endpoint even while backlogged — `/health`
+  only reflects that the metrics Fastify app is up, not queue depth. **Don't
+  rely on worker-service's own `/health` as a backlog signal** — it will stay
+  green through an entire backlog incident. Use the metric/valve/SQL signals
+  above instead.
+
+## 2. Mitigation
+
+### 2a. Scale consumers (the primary lever)
+Run additional `worker-service` processes pointed at the same
+`DATABASE_URL`. Because the job store claims rows via an atomic Postgres
+update (`services/worker-service/src/pg-job-store.ts`), multiple worker
+processes are safe to run concurrently against the same table without extra
+coordination — this is the intended scale-out path, not a workaround.
+```sh
+# example: run two additional worker processes locally/in an environment
+# that supports it (each just needs the same DATABASE_URL + build image config)
+DATABASE_URL=$SHARED_DB_URL VERIFY_BUILD_IMAGE=vela-verify:1.94.0 \
+  pnpm --filter @vellar/worker-service start &
+DATABASE_URL=$SHARED_DB_URL VERIFY_BUILD_IMAGE=vela-verify:1.94.0 \
+  pnpm --filter @vellar/worker-service start &
+```
+In a container/orchestrated deployment (this repo currently ships
+`render.yaml`/`railway.json` for the combined `all-in-one` process — see
+`infra/README.md` for the stated future direction toward `k8s/` manifests),
+this is simply increasing the worker-service replica count.
+**Caveat**: each worker runs real Docker builds under resource caps
+(`VERIFY_BUILD_MEMORY`/`VERIFY_BUILD_CPUS`/`VERIFY_BUILD_PIDS_LIMIT`, default
+`2g`/`2`/`512`, per `services/worker-service/README.md`) — scaling worker
+*count* on a single host multiplies that resource footprint; make sure the
+host actually has capacity before adding replicas, or backlog mitigation
+becomes a new host-resource incident.
+
+### 2b. Pause / throttle producers
+Since there's no broker to pause, this means reducing inbound
+`POST /verification/submit` load at the source:
+- **Lower `VERIFY_QUEUE_MAX_ACTIVE`** temporarily (env var on
+  verification-service/gateway) so the existing 429 valve engages sooner,
+  shedding load before the backlog gets worse, buying the scaled-up workers
+  (2a) time to drain the existing backlog.
+- If the backlog is driven by a specific abusive/misbehaving caller (e.g. a
+  script retrying submissions in a loop), tighten the rate limit at the
+  `api-gateway` layer: `services/api-gateway/src/server.ts` already registers
+  `@fastify/rate-limit` gateway-wide (`RATE_LIMIT_MAX` / `RATE_LIMIT_WINDOW_MS`
+  env vars, default 120 req/60s, with `/health` explicitly exempted via its
+  `allowList`). This incident is exactly the case for lowering
+  `RATE_LIMIT_MAX` temporarily, or adding a route-specific limit on
+  `/verification/submit` if the existing gateway-wide limit isn't tight
+  enough to shed the specific abusive load.
+- Communicate to callers (internal or external, depending on how
+  `/verification/submit` is exposed) that submissions are being throttled,
+  so retries don't compound the backlog further.
+
+### 2c. Investigate and fix a stuck-worker root cause (if reaper reclaims are high)
+If detection signals point to workers dying/hanging (high reaper reclaim
+rate) rather than simple under-capacity, scaling consumers alone won't help —
+more workers just means more workers eventually hanging too. Check:
+- Docker build logs for the specific failing submissions (a SIGKILL exit
+  specifically means the build hit `VERIFY_BUILD_TIMEOUT_S` — default 600s —
+  or a memory/pids cap, not a code error).
+- Whether a specific repo/commit submitted for verification is pathological
+  (e.g. genuinely needs more than the default resource caps, or its
+  dependencies aren't vendored and fail hard against the build's
+  `--network=none` sandbox).
+- `VERIFY_MAX_ATTEMPTS` (default 3): if many rows are landing in
+  `dead_letter`, that's the reaper doing its job correctly (per
+  `services/worker-service/src/index.ts`'s comment: "so a mid-build crash
+  can't strand a job forever") — those rows need resubmission after the root
+  cause is fixed, not further worker scaling.
+
+## 3. Escalation
+
+This repo has no formal on-call rotation documented today (confirmed:
+no `CODEOWNERS`, no on-call config found). Until one exists:
+- **Primary escalation**: the repo maintainer, `davedumto` (the only account
+  exempted from the `main`-targeting and `contrib/`-only PR guards per
+  `.github/workflows/close-prs-to-main.yml` and
+  `.github/workflows/close-prs-outside-contrib.yml` — i.e., the de facto
+  owner/operator of this codebase).
+- **Community channel**: the Telegram group linked from `CONTRIBUTING.md` and
+  `contrib/README.md` (`https://t.me/+RWPCKXXJTj45Njk0`) is this project's
+  documented communication channel for anything that isn't a GitHub issue.
+- **Escalate when**: `VERIFY_QUEUE_MAX_ACTIVE`'s 429 valve has been engaged
+  for more than ~15 minutes (matching the existing `VerificationSlow` alert's
+  15-minute window in `docs/observability.md`, for consistency with an
+  established threshold in this repo) without the backlog visibly draining
+  after mitigation steps 2a/2b have been applied, or if 2c reveals a
+  potential security concern (e.g. a submission designed to exhaust build
+  resources) rather than an ordinary capacity issue.
+
+## 4. Rollback steps
+
+"Rollback" here means: once the backlog is drained and root cause addressed,
+undo any temporary mitigation so the system returns to its normal operating
+configuration — don't leave throttled settings in place indefinitely:
+
+- [ ] **Restore `VERIFY_QUEUE_MAX_ACTIVE`** to its normal value if it was
+      lowered in step 2b — confirm the queue depth (§1's SQL query) has been
+      stable near zero for a reasonable window first (e.g. 30+ minutes) before
+      relaxing the valve back.
+- [ ] **Scale worker-service replica count back down** to its normal steady
+      state if it was scaled up in 2a purely to drain a one-off backlog spike
+      (as opposed to a durable increase in submission volume, in which case
+      the new replica count should become the new baseline, not a rollback
+      target).
+- [ ] **Undo any emergency rate-limit/block** applied at the gateway in 2b
+      once the misbehaving caller (if any) has been confirmed fixed/blocked
+      properly, rather than leaving an ad hoc rule in place.
+- [ ] **Resubmit dead-lettered rows** (status `dead_letter`) that failed only
+      because of the backlog/root-cause condition, once it's confirmed fixed —
+      dead-lettering is terminal (the reaper never retries a `dead_letter`
+      row on its own; see `services/worker-service/src/index.ts`), so this
+      needs an explicit resubmission via `POST /verification/submit` for each
+      affected `contractId`.
+- [ ] **Re-run the pre-deploy smoke test** (issue #339's
+      `contrib/routes/issue-339-predeploy-smoke-test/`) against the recovered
+      environment to confirm all services (including worker-service's own
+      `/health` on `WORKER_METRICS_PORT`) are reporting healthy before closing
+      the incident.
+- [ ] **Note the incident** for future reference (see issue #340's runbook for
+      the same caveat about `docs/decisions.md` being gitignored on `main`) —
+      capture the peak queue depth, what mitigation actually resolved it, and
+      whether it revealed a genuine capacity gap (permanent fix: raise steady-
+      state worker replica count) vs. a one-off (e.g. a single bad submission).

--- a/contrib/routes/issue-339-predeploy-smoke-test/README.md
+++ b/contrib/routes/issue-339-predeploy-smoke-test/README.md
@@ -1,0 +1,122 @@
+# Issue 339 — Pre-Deploy Smoke Test Script for the Services Workspace
+
+Sandboxed reference implementation (per `contrib/README.md` — this cannot add
+a script to the real `services/` workspace or root `package.json` directly;
+see the PR description) of a CI-friendly smoke test that hits every service's
+`/health` endpoint and runs a basic wallet-creation e2e check, exiting
+non-zero on any failure.
+
+## What it checks, and why those checks
+
+Grounded in the real workspace layout (`services/*`, root `.env.example`,
+`packages/service-kit/src/index.ts`):
+
+1. **Health checks for every service that has one.** All real services except
+   `permission-service` (currently an empty stub — `export {};`, nothing to
+   check) expose `GET /health` via the shared `registerHealth()` helper in
+   `packages/service-kit/src/index.ts`, which returns
+   `{ status: "ok", service: <name> }` (200) or
+   `{ status: "unavailable", service: <name> }` (503) when a DB-aware
+   readiness probe fails. Default ports, from root `.env.example`:
+
+   | Service | Port env var | Default port |
+   | --- | --- | --- |
+   | api-gateway | `PORT` | 4000 |
+   | wallet-service | `WALLET_SERVICE_PORT` | 4001 |
+   | lifecycle-service | `LIFECYCLE_SERVICE_PORT` | 4002 |
+   | policy-service | `POLICY_SERVICE_PORT` | 4003 |
+   | verification-service | `VERIFICATION_SERVICE_PORT` | 4004 |
+   | worker-service | `WORKER_METRICS_PORT` | 4005 (metrics-only Fastify app, not the main worker loop) |
+
+   `permission-service` is intentionally excluded from the default target
+   list — it has no server, no port, no `/health` route today. The script
+   still accepts it via `SMOKE_TARGETS` if/when it grows one (see below), so
+   this doesn't silently stay stale.
+
+2. **A basic e2e check: wallet creation.** Mirrors the real contract
+   confirmed in `services/wallet-service/src/server.test.ts`:
+   `POST /wallet/create` with `{ keyId, contractId, network, signedTx }`
+   returns `201` with `{ contractId, txHash, sessionId }`. The smoke script
+   posts a synthetic payload and asserts a `201` with those three fields
+   present — this is a shape/liveness check (is the route wired end to end
+   and responding correctly), not a real on-chain deploy.
+
+3. **CI-friendly exit code.** Exits `0` only if every configured target
+   passes; exits `1` (non-zero) the moment anything fails or times out, after
+   printing a summary of every check (pass/fail per target), so a CI log
+   shows the full picture in one run rather than stopping at the first
+   failure.
+
+## Files
+
+- `route.mjs` — the smoke-test engine (`checkHealth`, `checkWalletCreate`,
+  `runSmokeTest`) plus a CLI entrypoint that reads `SMOKE_TARGETS`/`SMOKE_BASE_URL`
+  from the environment, runs all checks, prints a summary, and calls
+  `process.exit(1)` on any failure. Uses `fetch` (Node 22+, matching this
+  repo's `engines.node: ">=22"` in the root `package.json`) against
+  **mocked** service responses in this sandbox (see "Running standalone"
+  below) — the request/assertion logic itself is real and portable to a real
+  deployment.
+- `route.test.mjs` — unit tests for `checkHealth`/`checkWalletCreate`/
+  `runSmokeTest` against an in-process mock HTTP server, covering: all
+  services healthy → pass; one service down/503 → fail + non-zero exit code;
+  wallet-create e2e failure → fail; a slow/hanging service → timeout → fail
+  (not an infinite hang); mixed pass/fail → summary reports all of them, not
+  just the first.
+
+## How to run it manually
+
+Against a locally running stack (e.g. `pnpm --filter @vellar/all-in-one start`,
+or each service started individually per its own README):
+
+```sh
+SMOKE_BASE_URL=http://localhost node contrib/routes/issue-339-predeploy-smoke-test/route.mjs
+```
+
+Override the target list/ports if your local setup differs from the
+`.env.example` defaults:
+
+```sh
+SMOKE_TARGETS='[{"name":"api-gateway","port":4000},{"name":"wallet-service","port":4001,"walletCreateCheck":true}]' \
+  node contrib/routes/issue-339-predeploy-smoke-test/route.mjs
+```
+
+Exit code: `0` = all checks passed, safe to deploy; non-zero = at least one
+check failed — the summary printed to stdout shows exactly which one(s).
+
+## How to run it in CI
+
+Add a step after the stack is up (e.g. after `docker compose up -d` /
+starting `all-in-one`) and before a deploy step:
+
+```yaml
+- name: Pre-deploy smoke test
+  run: node contrib/routes/issue-339-predeploy-smoke-test/route.mjs
+  env:
+    SMOKE_BASE_URL: http://localhost
+```
+
+Because the script's own `process.exit(1)` on failure, no extra `if` /
+`continue-on-error` handling is needed — a failed smoke test fails the job
+the normal way, blocking the deploy step that would follow it. A real
+integration would move `route.mjs`'s logic into
+`services/*/package.json`'s workspace (e.g. a root `pnpm smoke` script) so it
+runs against the actually-started services rather than the mocks used here
+in the sandbox.
+
+## Running standalone (mocked responses)
+
+```sh
+node contrib/routes/issue-339-predeploy-smoke-test/route.mjs --demo
+```
+
+`--demo` starts an in-process mock server that answers `/health` for every
+service and `/wallet/create` for wallet-service, then runs the real smoke
+test against it — a self-contained way to see the script's output shape
+without a real stack running.
+
+## Tests
+
+```sh
+node contrib/routes/issue-339-predeploy-smoke-test/route.test.mjs
+```

--- a/contrib/routes/issue-339-predeploy-smoke-test/route.mjs
+++ b/contrib/routes/issue-339-predeploy-smoke-test/route.mjs
@@ -1,0 +1,196 @@
+import http from "node:http";
+
+// Sandboxed reference implementation of issue #339 (pre-deploy smoke test
+// script for the services workspace). See README.md for how the target list
+// maps onto the real services/* ports and health/wallet-create contracts.
+
+/** Default targets, matching root .env.example's documented ports.
+ * permission-service is deliberately omitted — it's an empty stub with no
+ * server today (services/permission-service/src/index.ts is `export {};`). */
+export const DEFAULT_TARGETS = [
+  { name: "api-gateway", port: 4000 },
+  { name: "wallet-service", port: 4001, walletCreateCheck: true },
+  { name: "lifecycle-service", port: 4002 },
+  { name: "policy-service", port: 4003 },
+  { name: "verification-service", port: 4004 },
+  { name: "worker-service", port: 4005 },
+];
+
+export function targetsFromEnv(env = process.env) {
+  if (env.SMOKE_TARGETS) {
+    try {
+      const parsed = JSON.parse(env.SMOKE_TARGETS);
+      if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+    } catch {
+      // fall through to defaults on malformed override — never silently
+      // run zero checks because of a typo'd env var.
+    }
+  }
+  return DEFAULT_TARGETS;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+async function fetchWithTimeout(url, options, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * GET {baseUrl}:{port}/health and assert the shared registerHealth() shape
+ * (packages/service-kit/src/index.ts): 200 + { status: "ok", service }.
+ * A 503 ({ status: "unavailable" }) is a real, meaningful failure — it means
+ * the service is up but its readiness probe (e.g. DB connectivity) failed.
+ */
+export async function checkHealth(baseUrl, target, { timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = fetchWithTimeout } = {}) {
+  const url = `${baseUrl}:${target.port}/health`;
+  try {
+    const res = await fetchImpl(url, { method: "GET" }, timeoutMs);
+    let body;
+    try {
+      body = await res.json();
+    } catch {
+      body = undefined;
+    }
+    if (res.status !== 200 || body?.status !== "ok") {
+      return {
+        name: target.name,
+        check: "health",
+        ok: false,
+        detail: `expected 200 {status:"ok"}, got ${res.status} ${JSON.stringify(body)}`,
+      };
+    }
+    return { name: target.name, check: "health", ok: true, detail: `${res.status} ${body.status}` };
+  } catch (err) {
+    const reason = err?.name === "AbortError" ? `timed out after ${timeoutMs}ms` : (err?.message ?? String(err));
+    return { name: target.name, check: "health", ok: false, detail: reason };
+  }
+}
+
+/**
+ * POST {baseUrl}:{port}/wallet/create with a synthetic payload and assert the
+ * real contract confirmed in services/wallet-service/src/server.test.ts:
+ * 201 + { contractId, txHash, sessionId }. This is a shape/liveness e2e
+ * check, not a real on-chain deploy.
+ */
+export async function checkWalletCreate(baseUrl, target, { timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = fetchWithTimeout } = {}) {
+  const url = `${baseUrl}:${target.port}/wallet/create`;
+  const payload = {
+    keyId: "smoke-test-key",
+    contractId: "CSMOKETESTACCOUNT00000000000000000000000000000000000000",
+    network: "testnet",
+    signedTx: "smoke-test-xdr",
+  };
+  try {
+    const res = await fetchImpl(
+      url,
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(payload) },
+      timeoutMs,
+    );
+    let body;
+    try {
+      body = await res.json();
+    } catch {
+      body = undefined;
+    }
+    const hasRequiredFields = body && "contractId" in body && "txHash" in body && "sessionId" in body;
+    if (res.status !== 201 || !hasRequiredFields) {
+      return {
+        name: target.name,
+        check: "wallet-create-e2e",
+        ok: false,
+        detail: `expected 201 {contractId,txHash,sessionId}, got ${res.status} ${JSON.stringify(body)}`,
+      };
+    }
+    return { name: target.name, check: "wallet-create-e2e", ok: true, detail: `201, sessionId=${body.sessionId}` };
+  } catch (err) {
+    const reason = err?.name === "AbortError" ? `timed out after ${timeoutMs}ms` : (err?.message ?? String(err));
+    return { name: target.name, check: "wallet-create-e2e", ok: false, detail: reason };
+  }
+}
+
+/**
+ * Runs health checks for every target, plus the wallet-create e2e check for
+ * any target flagged `walletCreateCheck: true`. Never stops at the first
+ * failure — collects every result so the summary shows the full picture,
+ * matching how a real CI smoke test should behave (one failing service
+ * shouldn't hide a second, unrelated failure).
+ */
+export async function runSmokeTest({ baseUrl, targets, timeoutMs, fetchImpl } = {}) {
+  const effectiveTargets = targets ?? DEFAULT_TARGETS;
+  const effectiveBaseUrl = baseUrl ?? "http://localhost";
+
+  const checks = [];
+  for (const target of effectiveTargets) {
+    checks.push(checkHealth(effectiveBaseUrl, target, { timeoutMs, fetchImpl }));
+    if (target.walletCreateCheck) {
+      checks.push(checkWalletCreate(effectiveBaseUrl, target, { timeoutMs, fetchImpl }));
+    }
+  }
+  const results = await Promise.all(checks);
+  const failed = results.filter((r) => !r.ok);
+  return { results, passed: failed.length === 0, failedCount: failed.length };
+}
+
+function printSummary(results) {
+  for (const r of results) {
+    const mark = r.ok ? "PASS" : "FAIL";
+    console.log(`[${mark}] ${r.name} (${r.check}) — ${r.detail}`);
+  }
+}
+
+// --- CLI entrypoint ---------------------------------------------------
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  if (process.argv.includes("--demo")) {
+    // Self-contained demo: spin up a mock server answering every target's
+    // /health and wallet-service's /wallet/create, then run the real smoke
+    // test against it end to end.
+    const port = 4339;
+    const server = http.createServer((req, res) => {
+      let bodyStr = "";
+      req.on("data", (chunk) => (bodyStr += chunk));
+      req.on("end", () => {
+        if (req.url === "/health") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ status: "ok", service: "demo" }));
+          return;
+        }
+        if (req.url === "/wallet/create" && req.method === "POST") {
+          res.writeHead(201, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ contractId: "CDEMO", txHash: "demo-hash", sessionId: "demo-session" }));
+          return;
+        }
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "not_found" }));
+      });
+    });
+    await new Promise((resolve) => server.listen(port, resolve));
+    console.log(`[demo] mock services listening on :${port} for every target\n`);
+
+    const demoTargets = DEFAULT_TARGETS.map((t) => ({ ...t, port }));
+    const { results, passed } = await runSmokeTest({ baseUrl: "http://localhost", targets: demoTargets });
+    printSummary(results);
+    server.close();
+    process.exit(passed ? 0 : 1);
+  }
+
+  const baseUrl = process.env.SMOKE_BASE_URL || "http://localhost";
+  const targets = targetsFromEnv(process.env);
+  const timeoutMs = process.env.SMOKE_TIMEOUT_MS ? Number(process.env.SMOKE_TIMEOUT_MS) : DEFAULT_TIMEOUT_MS;
+
+  const { results, passed, failedCount } = await runSmokeTest({ baseUrl, targets, timeoutMs });
+  printSummary(results);
+  if (!passed) {
+    console.error(`\n${failedCount} check(s) failed — deploy should NOT proceed.`);
+    process.exit(1);
+  }
+  console.log(`\nAll ${results.length} checks passed.`);
+  process.exit(0);
+}

--- a/contrib/routes/issue-339-predeploy-smoke-test/route.test.mjs
+++ b/contrib/routes/issue-339-predeploy-smoke-test/route.test.mjs
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { checkHealth, checkWalletCreate, runSmokeTest, targetsFromEnv, DEFAULT_TARGETS } from "./route.mjs";
+
+// Spins up a real in-process HTTP server per test so checkHealth/checkWalletCreate/
+// runSmokeTest exercise their actual fetch + timeout logic against a real
+// socket, not a hand-rolled fake fetch.
+function startMockServer(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, port, baseUrl: "http://127.0.0.1" });
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    let data = "";
+    req.on("data", (c) => (data += c));
+    req.on("end", () => resolve(data));
+  });
+}
+
+// --- targetsFromEnv --------------------------------------------------------
+
+{
+  assert.deepEqual(targetsFromEnv({}), DEFAULT_TARGETS);
+  assert.deepEqual(
+    targetsFromEnv({ SMOKE_TARGETS: JSON.stringify([{ name: "x", port: 9999 }]) }),
+    [{ name: "x", port: 9999 }],
+  );
+  // Malformed override falls back to defaults rather than silently running
+  // zero checks.
+  assert.deepEqual(targetsFromEnv({ SMOKE_TARGETS: "{not valid json" }), DEFAULT_TARGETS);
+  assert.deepEqual(targetsFromEnv({ SMOKE_TARGETS: "[]" }), DEFAULT_TARGETS);
+}
+
+// --- checkHealth: healthy service --------------------------------------
+
+{
+  const { server, port, baseUrl } = await startMockServer((req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok", service: "test-svc" }));
+  });
+  const result = await checkHealth(baseUrl, { name: "test-svc", port });
+  assert.equal(result.ok, true);
+  assert.equal(result.check, "health");
+  await closeServer(server);
+}
+
+// --- checkHealth: 503 unavailable (matches registerHealth's readiness-fail shape) -
+
+{
+  const { server, port, baseUrl } = await startMockServer((req, res) => {
+    res.writeHead(503, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "unavailable", service: "test-svc" }));
+  });
+  const result = await checkHealth(baseUrl, { name: "test-svc", port });
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /503/);
+  await closeServer(server);
+}
+
+// --- checkHealth: connection refused (service not running at all) --------
+
+{
+  // Nothing listening on this port.
+  const result = await checkHealth("http://127.0.0.1", { name: "down-svc", port: 1 }, { timeoutMs: 1000 });
+  assert.equal(result.ok, false);
+}
+
+// --- checkHealth: timeout on a hanging service --------------------------
+
+{
+  const { server, port, baseUrl } = await startMockServer((_req, _res) => {
+    // Never respond — simulates a hung service.
+  });
+  const start = Date.now();
+  const result = await checkHealth(baseUrl, { name: "hung-svc", port }, { timeoutMs: 100 });
+  const elapsed = Date.now() - start;
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /timed out/);
+  assert.ok(elapsed < 2000, "must fail fast via timeout, not hang indefinitely");
+  await closeServer(server);
+}
+
+// --- checkWalletCreate: success shape matches server.test.ts's real contract -
+
+{
+  const { server, port, baseUrl } = await startMockServer(async (req, res) => {
+    const body = JSON.parse(await readBody(req));
+    assert.equal(body.keyId, "smoke-test-key");
+    assert.equal(body.network, "testnet");
+    res.writeHead(201, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ contractId: "C123", txHash: "h1", sessionId: "s1" }));
+  });
+  const result = await checkWalletCreate(baseUrl, { name: "wallet-service", port });
+  assert.equal(result.ok, true);
+  assert.match(result.detail, /s1/);
+  await closeServer(server);
+}
+
+// --- checkWalletCreate: missing required fields fails ---------------------
+
+{
+  const { server, port, baseUrl } = await startMockServer((req, res) => {
+    res.writeHead(201, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ contractId: "C123" })); // missing txHash, sessionId
+  });
+  const result = await checkWalletCreate(baseUrl, { name: "wallet-service", port });
+  assert.equal(result.ok, false);
+  await closeServer(server);
+}
+
+// --- checkWalletCreate: non-201 status fails even with a well-shaped body -
+
+{
+  const { server, port, baseUrl } = await startMockServer((req, res) => {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ contractId: "C123", txHash: "h1", sessionId: "s1" }));
+  });
+  const result = await checkWalletCreate(baseUrl, { name: "wallet-service", port });
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /500/);
+  await closeServer(server);
+}
+
+// --- runSmokeTest: all services healthy -> passed, exit-worthy 0 ----------
+
+{
+  const { server, port, baseUrl } = await startMockServer(async (req, res) => {
+    if (req.url === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok", service: "svc" }));
+      return;
+    }
+    if (req.url === "/wallet/create") {
+      await readBody(req);
+      res.writeHead(201, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ contractId: "C1", txHash: "h", sessionId: "s" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  const targets = [
+    { name: "api-gateway", port },
+    { name: "wallet-service", port, walletCreateCheck: true },
+  ];
+  const { passed, results, failedCount } = await runSmokeTest({ baseUrl, targets });
+  assert.equal(passed, true);
+  assert.equal(failedCount, 0);
+  // health for both targets + wallet-create for the flagged one = 3 checks
+  assert.equal(results.length, 3);
+  await closeServer(server);
+}
+
+// --- runSmokeTest: one service down -> fails, but ALL results still reported -
+
+{
+  const { server: upServer, port: upPort, baseUrl } = await startMockServer((req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok", service: "up" }));
+  });
+
+  const targets = [
+    { name: "healthy-svc", port: upPort },
+    { name: "down-svc", port: 1 }, // nothing listening
+  ];
+  const { passed, results, failedCount } = await runSmokeTest({ baseUrl, targets, timeoutMs: 1000 });
+  assert.equal(passed, false);
+  assert.equal(failedCount, 1);
+  // Both results present — a failure doesn't short-circuit the rest of the run.
+  assert.equal(results.length, 2);
+  assert.equal(results.find((r) => r.name === "healthy-svc").ok, true);
+  assert.equal(results.find((r) => r.name === "down-svc").ok, false);
+  await closeServer(upServer);
+}
+
+// --- runSmokeTest: wallet-create e2e failure fails the whole run ----------
+
+{
+  const { server, port, baseUrl } = await startMockServer(async (req, res) => {
+    if (req.url === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok", service: "svc" }));
+      return;
+    }
+    await readBody(req);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "relayer not configured" }));
+  });
+
+  const targets = [{ name: "wallet-service", port, walletCreateCheck: true }];
+  const { passed, failedCount } = await runSmokeTest({ baseUrl, targets });
+  assert.equal(passed, false);
+  assert.equal(failedCount, 1);
+  await closeServer(server);
+}
+
+// --- runSmokeTest: mixed pass/fail across multiple targets summarizes all -
+
+{
+  const { server: healthyServer, port: healthyPort, baseUrl } = await startMockServer((req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok", service: "healthy" }));
+  });
+  const { server: unhealthyServer, port: unhealthyPort } = await startMockServer((req, res) => {
+    res.writeHead(503, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "unavailable", service: "unhealthy" }));
+  });
+
+  const targets = [
+    { name: "svc-a", port: healthyPort },
+    { name: "svc-b", port: unhealthyPort },
+    { name: "svc-c", port: 1 }, // down
+  ];
+  const { passed, failedCount, results } = await runSmokeTest({ baseUrl, targets, timeoutMs: 1000 });
+  assert.equal(passed, false);
+  assert.equal(failedCount, 2);
+  assert.equal(results.length, 3);
+  await closeServer(healthyServer);
+  await closeServer(unhealthyServer);
+}
+
+console.log("PASS: Issue 339 pre-deploy smoke test tests passed cleanly!");

--- a/contrib/routes/issue-340-contract-rollback-runbook/README.md
+++ b/contrib/routes/issue-340-contract-rollback-runbook/README.md
@@ -1,0 +1,221 @@
+# Issue 340 — Rollback Procedure for Failed Soroban Contract Deployments
+
+Sandboxed doc (per `contrib/README.md` — this cannot live at
+`contracts/ROLLBACK.md` directly; see the PR description) documenting how to
+detect a failed Soroban contract deployment on Vellar, the recovery options,
+and a post-rollback consistency checklist. Written to be dropped in next to
+`contracts/README.md` once a maintainer accepts it.
+
+This is grounded in the real deploy tooling and reproducibility model already
+documented in `services/worker-service/README.md` and `contracts/README.md` —
+this repo has no scripted `deploy.sh`; deploys are the manual `stellar
+contract build` / `stellar contract upload` / `stellar contract deploy` flow
+described there, run against the canonical Docker build image
+(`vela-verify:1.94.0`, pinned in `contracts/rust-toolchain.toml` and built
+from `infra/docker/verification-builder.Dockerfile`).
+
+## Where this fits in `contracts/`
+
+Per `contracts/README.md`, the workspace currently holds:
+
+- `contracts/attestation-registry/` — on-chain attestation mirror contract
+  (`packages/service-kit`/`services/worker-service` write to it via
+  `createRegistrySubmitter`, see `services/worker-service/src/registry-submitter.ts`).
+- `contracts/policy-templates/` — `spending-limit/`, `token-spending-limit/`,
+  `verified-recipient/` policy contracts (deployed per-account by
+  `policy-service`, per `docs/design-provenance-gated-spending.md`).
+
+Both are Soroban/Rust contracts built with the same pinned toolchain
+(`contracts/rust-toolchain.toml`) and deployed with the Stellar CLI. This doc
+applies to a failed deployment of either.
+
+## 1. Detecting a failed deployment
+
+A Soroban deploy is really three steps that can each fail independently —
+detect failure at the step it actually happened, not just "something broke":
+
+### 1a. Build step fails
+`stellar contract build` (inside the canonical image, per
+`services/worker-service/README.md` §"Reproducibility model") exits non-zero.
+**Signal**: the CI/deploy job itself fails before any network call — check the
+build log for a Rust compile error, a toolchain/target mismatch (compare
+against `contracts/rust-toolchain.toml`'s pinned `1.94.0` + `wasm32v1-none`),
+or a dependency that couldn't be vendored/pre-fetched (the build runs
+`--network=none`, so an unvendored dependency fails here, not later).
+**Nothing was ever uploaded or deployed — no on-chain state changed.**
+Recovery is just "fix the build and retry"; skip straight to redeploy below.
+
+### 1b. Upload step fails (`stellar contract upload`)
+**Signal**: the CLI returns a non-zero exit and/or the RPC response includes
+an error (insufficient balance on `--source-account`, a malformed/re-optimized
+wasm — remember `--optimize=false` is required per the worker-service README,
+since `stellar contract build` already optimizes and re-optimizing on upload
+changes the hash and breaks verification), or an RPC timeout/5xx from the
+configured `--rpc-url`.
+**Signal to distinguish from 1c**: no wasm hash was returned, or the returned
+hash doesn't match what a **local** `sha256sum` of the built `.wasm` file
+produces. Nothing is deployed yet — the wasm may or may not be on the ledger
+depending on exactly where the call failed.
+**Recovery**: retry the upload with the SAME already-built wasm bytes (don't
+rebuild — rebuilding on a non-hermetic host can silently produce
+byte-different output per the reproducibility note in
+`services/worker-service/README.md`). If upload keeps failing, check
+`--source-account` funding and RPC health before retrying again.
+
+### 1c. Deploy/instantiate step fails (`stellar contract deploy` /
+the constructor/`__constructor` invocation)
+**Signal**: the wasm uploaded successfully (hash confirmed) but the
+`deploy`/instantiate transaction itself failed — insufficient fee, a failed
+constructor precondition (e.g. a policy contract's constructor rejecting bad
+initial parameters), or the transaction simply never got included (check the
+tx hash on a Horizon/Explorer lookup — this repo already links an explorer
+per `docs/link-explorer` conventions).
+**Signal to distinguish from a genuinely "half-deployed" contract**: Soroban
+contract creation is atomic per Stellar's transaction model — either the
+`CreateContract`/instantiate operation lands in a **successful** transaction,
+in which case the contract address exists and is initialized, or it doesn't
+land at all. There is no persistent "wasm uploaded but contract-instance
+half-created" on-chain state to reconcile — check the transaction result
+(`SUCCESS` vs any non-success result code), not the contract address's mere
+existence, since a failed tx never produces a live contract ID to begin with.
+
+### General signals across all three steps
+- CI job for the deploy step is red.
+- The Docker build's exit code and stdout/stderr log (per the sandbox
+  described in `services/worker-service/README.md` §"Build sandbox" —
+  `--network=none`, resource caps, a SIGKILL on timeout) — a SIGKILL exit
+  code specifically means the build hit its timeout/memory/pids cap, not a
+  code error.
+- For a policy-service-initiated deploy specifically: `policy-service`'s own
+  spend-budget ledger (`FIX 3`, mirrored in `services/wallet-service/src/index.ts`'s
+  `budgetLimitsFromEnv` pattern) would show the deploy attempt debited against
+  the `deploy` budget line even if the on-chain tx failed — a budget-vs-chain
+  mismatch itself is a signal worth checking (see the consistency checklist
+  below).
+
+## 2. Recovery options
+
+### Option A — Redeploy (default path for 1a/1b, and most of 1c)
+Since a failed build/upload/deploy leaves no live contract behind (see the
+atomicity note above), the default recovery is simply: **fix the root cause,
+then rerun the deploy from the failed step onward** using the exact commands
+in `services/worker-service/README.md` §"Reproducibility model":
+
+```sh
+# 1. rebuild in the canonical image (deterministic — only needed if 1a failed,
+#    or if you're not certain the previously-built wasm bytes are still valid)
+docker run --rm -v "$(pwd)/contracts:/work" -w /work vela-verify:1.94.0 \
+  stellar contract build
+
+# 2. upload — REQUIRED --optimize=false (build already optimized; see above)
+stellar contract upload \
+  --wasm contracts/target/wasm32v1-none/release/<name>.wasm \
+  --optimize=false \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015" \
+  --source-account <funded-identity>
+
+# 3. deploy/instantiate using the confirmed wasm hash from step 2
+stellar contract deploy \
+  --wasm-hash <hash-from-upload> \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015" \
+  --source-account <funded-identity> \
+  -- <constructor-args-if-any>
+```
+
+If a **different** contract address is produced on redeploy (expected — a new
+deploy always gets a new contract ID unless using a deterministic
+salt/CREATE2-style deploy), every place that referenced the old
+(nonexistent) address must be updated. For this repo that's:
+- `ATTESTATION_REGISTRY_ID` env var (`services/worker-service/src/config.ts`)
+  if redeploying `attestation-registry`.
+- Any policy-instance address `policy-service` recorded for an account, if
+  redeploying a `policy-templates/*` contract instance.
+
+### Option B — State reconciliation (only relevant for an already-LIVE contract
+being upgraded, not a from-scratch failed deploy)
+If the "deployment" in question was actually a contract **upgrade**
+(`stellar contract upgrade` swapping the wasm on an existing, already-live
+contract address) and that upgrade transaction failed, the existing contract
+instance and its on-chain storage/state are untouched — Soroban's upgrade
+model doesn't mutate storage as part of a wasm swap, and a failed upgrade tx
+never lands, so the previous wasm keeps serving the contract exactly as
+before. **No state reconciliation is needed on-chain** — recovery is the same
+as Option A: fix the root cause and retry the upgrade tx.
+
+The one case genuine state reconciliation applies: if this repo's
+`services/worker-service` attestation mirror (see
+`docs/design-provenance-gated-spending.md`) had already recorded an
+attestation for contract code that the deploy/upgrade never actually
+delivered — i.e., the **mirror says "attested to hash X"** but the on-chain
+contract is still running the old wasm (a failed upgrade). That's a mirror
+that needs correcting, not the chain: rerun the worker-service's own upgrade
+sweep (`services/worker-service/src/index.ts`'s `runSweep`/`attestor` — "revoke
+attestations whose contract was upgraded or deleted") or, if urgent, revoke
+the stale attestation manually via the registry submitter path before the
+sweep's next scheduled pass (`ATTESTATION_SWEEP_MS`, default 10 minutes).
+
+### Option C — Abandon and use a fresh address (last resort)
+If a partially-failed deploy left an unwanted-but-harmless contract instance
+live on-chain (e.g. step 1c's tx actually succeeded with bad constructor args,
+producing a working-but-misconfigured contract) and there's no admin/upgrade
+path to fix it in place, the pragmatic recovery is: deploy a fresh, correctly
+configured instance at a new address and update every reference to point at
+the new one (same reference-update list as Option A). The old, misconfigured
+contract instance is simply abandoned — Soroban contracts have no "delete"
+that reclaims the address for reuse, so there's no cleanup step beyond
+updating references and, if it holds any funds, sweeping them out via
+whatever admin function it exposes (dependent on the specific contract's
+`policy-templates/*` variant — check its `Cargo.toml`/source for an
+admin-withdraw entrypoint before assuming funds are stuck).
+
+## 3. Post-rollback consistency checklist
+
+Run through all of these before considering the incident closed:
+
+- [ ] **Confirm the failed transaction's actual on-chain result.** Look up
+      the tx hash (Horizon or an explorer link, per this repo's
+      `docs/link-explorer` branch conventions) and confirm it shows a
+      non-success result code — don't rely solely on the CLI's local exit
+      code, since a tx can fail on-chain for reasons the CLI surfaces
+      differently (e.g. `txFAILED` vs a client-side RPC timeout that doesn't
+      tell you whether the tx ultimately landed).
+- [ ] **Confirm no address ended up referenced by application code before
+      being live.** Grep `services/*/src` and `.env`/`.env.example` for the
+      contract address you were about to deploy — if a config change landed
+      (e.g. via a deploy PR) referencing the new address before the deploy
+      actually succeeded, revert that reference until redeploy succeeds, so
+      no service starts calling a nonexistent/misconfigured contract.
+- [ ] **If a spend budget was involved** (deploys funded through
+      `policy-service`'s or `wallet-service`'s sponsor/relayer path — see
+      `services/wallet-service/src/index.ts`'s `budgetLimits.deploy` line),
+      confirm the budget ledger's debit matches what was ACTUALLY spent
+      on-chain. A failed-but-fee-charged transaction still consumes network
+      fee even though the contract never deployed — the budget line should
+      reflect that real spend, not zero it out, but should also not double-
+      count if a retry is about to debit again for the same logical deploy.
+- [ ] **If this was an attestation-registry-relevant contract**, confirm
+      `services/worker-service`'s attestation mirror doesn't reference a
+      hash/address that was never actually deployed — see Option B above.
+- [ ] **Rerun the smoke test** (see issue #339's
+      `contrib/routes/issue-339-predeploy-smoke-test/`) against the
+      environment before considering the system healthy again — a failed
+      deploy is exactly the kind of event that should trigger a fresh
+      pre-deploy/post-incident health pass, not just a manual "looks fine"
+      check.
+- [ ] **Document the incident** in whatever this repo's decision-record
+      convention resolves to (`docs/decisions.md` is referenced repo-wide as
+      the place for this, though note it's currently gitignored in `main` —
+      see the PR description for how this was handled) — capture the root
+      cause, which step failed, and which recovery option was used, so the
+      next occurrence has a faster diagnosis path.
+
+## Explicit non-goals
+
+This doc does not cover: mainnet-specific deploy governance (see
+`docs/security-audit.md`'s mainnet-blockers material and the
+`security/mainnet-blockers` branch for that), or a scripted/automated
+rollback tool — today's deploy flow (per `services/worker-service/README.md`)
+is entirely manual CLI invocation, so this runbook is written for a human
+operator running these commands by hand, not a CI job.

--- a/contrib/routes/issue-343-session-retention-job/README.md
+++ b/contrib/routes/issue-343-session-retention-job/README.md
@@ -1,0 +1,110 @@
+# Issue 343 — Data Retention Policy Job for Expired Sessions
+
+Sandboxed reference implementation (per `contrib/README.md`, this cannot touch
+`services/wallet-service` directly — see the PR description for why) of a
+scheduled job that physically deletes `wallet_sessions` rows once they are
+past a configurable retention window, past their `expires_at`.
+
+## Why this job is needed
+
+`services/wallet-service`'s real `SessionRepository` (`src/repository.ts`,
+`src/db/pg-repository.ts`) already treats an expired session as **logically
+absent** — `find`/`listByContract` filter on `expiresAt` so an expired id
+never authorizes anything. But nothing ever **physically deletes** an expired
+row; `walletSessions` only shrinks via the single-row `delete(id)` a user
+triggers through `POST /wallet/sessions/revoke`. Expired rows accumulate
+forever, which is a real (if low-severity) storage-growth and
+data-minimization gap: session rows carry `contractId` + timestamps
+indefinitely after they've stopped being useful for anything.
+
+This module is the retention sweep that closes that gap: a scheduled job,
+matching this repo's existing scheduled-job convention, that deletes
+`wallet_sessions` rows whose `expires_at` is older than
+`now - retentionWindowMs`.
+
+## Design, matching existing repo conventions
+
+- **Scheduling pattern**: this repo has no cron library (no BullMQ, no
+  `node-cron`, no Redis anywhere — confirmed by grep). The one precedent,
+  `services/worker-service/src/index.ts`, wires scheduled work as a plain
+  `setInterval` in the service entrypoint, runs once immediately, and clears
+  the timer on `SIGINT`/`SIGTERM`:
+  ```ts
+  const reapTimer = setInterval(runReaper, config.reapIntervalMs);
+  void runReaper();
+  // ...
+  const shutdown = async () => { ...; clearInterval(reapTimer); ... };
+  ```
+  `route.mjs` in this folder follows the exact same shape:
+  `startRetentionJob()` returns `{ stop() }`, runs once immediately, then on
+  `intervalMs`, and is safe to `clearInterval` from a shutdown handler.
+
+- **Deletion query**: matches the real `createPgSessionRepository` pattern in
+  `services/wallet-service/src/db/pg-repository.ts`, which already imports
+  `and, desc, eq, gt` from `drizzle-orm` and does
+  `db.delete(walletSessions).where(eq(walletSessions.id, id))` for a
+  single-row delete. A real integration would add one bulk method to
+  `SessionRepository`:
+  ```ts
+  // services/wallet-service/src/repository.ts
+  export interface SessionRepository {
+    // ...
+    /** Physically deletes sessions whose expiresAt < cutoff. Returns count deleted. */
+    deleteExpiredBefore(cutoff: Date): Promise<number>;
+  }
+
+  // services/wallet-service/src/db/pg-repository.ts
+  async deleteExpiredBefore(cutoff) {
+    const deleted = await db
+      .delete(walletSessions)
+      .where(lt(walletSessions.expiresAt, cutoff))
+      .returning({ id: walletSessions.id });
+    return deleted.length;
+  }
+  ```
+  This module's `mockSessionStore` implements that same
+  `deleteExpiredBefore(cutoff)` contract in-memory (no real DB dependency in
+  `contrib/`), so the sweep logic under test is the real logic, not a fake.
+
+- **Configurable retention window**: `RETENTION_WINDOW_MS` env var (default
+  30 days), read the same way `worker-service/src/config.ts` reads its
+  interval env vars — `Number(env.VAR) || default`. The window is deliberately
+  **independent of and longer than** the session's own 7-day sliding
+  `expiresAt` TTL (`services/wallet-service/src/server.ts:65`,
+  `SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000`): the row goes logically-dead at
+  `expiresAt`, then stays physically queryable for `RETENTION_WINDOW_MS`
+  longer before the sweep purges it — a deliberate grace period in case an
+  expired-but-recent session is ever needed for incident investigation or
+  audit correlation (the `activityLogs`/audit-log table already reflects the
+  session's past activity independently, so deleting the session row itself
+  doesn't lose audit history).
+
+- **Cutoff, not "no rows younger than expiry"**: the job never deletes a row
+  whose `expiresAt` is in the future or within the grace window — only rows
+  where `expiresAt < now - retentionWindowMs`. This is what the test suite
+  below is built to prove.
+
+## Files
+
+- `route.mjs` — `computeExpiredCutoff`, `mockSessionStore` (the
+  `deleteExpiredBefore` contract above, in-memory), and `startRetentionJob`
+  (the `setInterval`-based scheduler, matching worker-service's shape).
+- `route.test.mjs` — asserts the sweep deletes ONLY sessions whose
+  `expiresAt` is older than the retention cutoff, and leaves active
+  (non-expired) and grace-period sessions untouched.
+
+## Running standalone
+
+```sh
+node contrib/routes/issue-343-session-retention-job/route.mjs
+```
+
+Starts an HTTP mock (`PORT`, default `4343`) exposing `POST /sweep` to trigger
+one sweep pass on demand and `GET /sessions` to inspect the in-memory store —
+useful for manually exercising the job shape without a real database.
+
+## Tests
+
+```sh
+node contrib/routes/issue-343-session-retention-job/route.test.mjs
+```

--- a/contrib/routes/issue-343-session-retention-job/route.mjs
+++ b/contrib/routes/issue-343-session-retention-job/route.mjs
@@ -1,0 +1,167 @@
+import http from "node:http";
+
+// Sandboxed reference implementation of issue #343 (data retention job for
+// expired wallet_sessions rows). See README.md for how this maps onto the
+// real services/wallet-service schema and scheduling convention.
+
+/** Default retention window: 30 days past a session's expiresAt before its
+ * row is physically deleted. Deliberately independent of, and longer than,
+ * the session's own 7-day sliding TTL (services/wallet-service/src/server.ts
+ * SESSION_TTL_MS) — expired rows get a grace period before the sweep purges
+ * them. */
+export const DEFAULT_RETENTION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Same "env var with numeric default" pattern used throughout the repo's
+ * service configs (e.g. services/worker-service/src/config.ts). */
+export function retentionWindowMsFromEnv(env = process.env) {
+  const raw = Number(env.RETENTION_WINDOW_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_RETENTION_WINDOW_MS;
+}
+
+/** A row is eligible for physical deletion once `expiresAt < cutoff`, where
+ * cutoff = now - retentionWindowMs. Exported standalone so it's trivially
+ * unit-testable without touching the store. */
+export function computeExpiredCutoff(now, retentionWindowMs) {
+  return new Date(now.getTime() - retentionWindowMs);
+}
+
+/**
+ * In-memory stand-in for services/wallet-service's real SessionRepository,
+ * extended with the one bulk method that repository doesn't have yet:
+ * deleteExpiredBefore(cutoff). Mirrors the real row shape
+ * (services/wallet-service/src/db/schema.ts walletSessions) and the real
+ * delete-by-predicate style already used in
+ * services/wallet-service/src/db/pg-repository.ts
+ * (`db.delete(walletSessions).where(...)`).
+ */
+export function mockSessionStore(initialRows = []) {
+  const rows = new Map(initialRows.map((r) => [r.id, r]));
+  return {
+    insert(row) {
+      rows.set(row.id, row);
+    },
+    get(id) {
+      return rows.get(id);
+    },
+    all() {
+      return [...rows.values()];
+    },
+    /** Physically deletes every row whose expiresAt < cutoff. Returns the
+     * deleted rows (mirrors drizzle's `.returning()` used elsewhere in this
+     * repo's pg-repository.ts, so a real port keeps the same call shape). */
+    async deleteExpiredBefore(cutoff) {
+      const deleted = [];
+      for (const row of rows.values()) {
+        if (row.expiresAt.getTime() < cutoff.getTime()) {
+          rows.delete(row.id);
+          deleted.push(row);
+        }
+      }
+      return deleted;
+    },
+  };
+}
+
+/**
+ * One sweep pass: compute the cutoff and delete everything past it. Returns
+ * a summary object so callers (the scheduler below, or a manual trigger) can
+ * log/report what happened — matching worker-service's reaper, which logs
+ * `reclaimed`/`deadLettered` counts after each pass.
+ */
+export async function runRetentionSweep(store, { now = new Date(), retentionWindowMs } = {}) {
+  const windowMs = retentionWindowMs ?? DEFAULT_RETENTION_WINDOW_MS;
+  const cutoff = computeExpiredCutoff(now, windowMs);
+  const deleted = await store.deleteExpiredBefore(cutoff);
+  return { cutoff, deletedCount: deleted.length, deletedIds: deleted.map((r) => r.id) };
+}
+
+/**
+ * Scheduled job wiring, matching services/worker-service/src/index.ts's
+ * setInterval convention exactly: run once immediately, then every
+ * intervalMs, and expose stop() so a SIGINT/SIGTERM handler can clearInterval
+ * cleanly (see e.g. worker-service's `shutdown()`).
+ */
+export function startRetentionJob(store, { intervalMs, retentionWindowMs, log, onSweep } = {}) {
+  const effectiveIntervalMs = intervalMs ?? 24 * 60 * 60 * 1000; // once/day default
+  const logger = log ?? {
+    info: (msg) => console.log(`[session-retention-job] ${msg}`),
+    error: (msg, err) => console.error(`[session-retention-job] ${msg}`, err ?? ""),
+  };
+
+  const runOnce = async () => {
+    try {
+      const result = await runRetentionSweep(store, { retentionWindowMs });
+      if (result.deletedCount > 0) {
+        logger.info(`swept ${result.deletedCount} expired session(s) past retention window`);
+      }
+      onSweep?.(result);
+      return result;
+    } catch (err) {
+      logger.error("retention sweep failed", err);
+      return undefined;
+    }
+  };
+
+  const timer = setInterval(runOnce, effectiveIntervalMs);
+  void runOnce();
+
+  return {
+    stop() {
+      clearInterval(timer);
+    },
+    runOnce,
+  };
+}
+
+// --- Optional standalone HTTP mock, matching the repo's contrib/ pattern
+// (see contrib/routes/issue-305-gateway-alerting/route.mjs) ---
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const store = mockSessionStore([
+    {
+      id: "seed-active",
+      contractId: "CACTIVE",
+      network: "testnet",
+      createdAt: new Date(),
+      lastActiveAt: new Date(),
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    },
+    {
+      id: "seed-expired-recent",
+      contractId: "CRECENT",
+      network: "testnet",
+      createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+      lastActiveAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), // expired, still in grace window
+    },
+    {
+      id: "seed-expired-old",
+      contractId: "COLD",
+      network: "testnet",
+      createdAt: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000),
+      lastActiveAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000), // past retention window, sweep target
+    },
+  ]);
+
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/sweep") {
+      runRetentionSweep(store).then((result) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
+      });
+      return;
+    }
+    if (req.method === "GET" && req.url === "/sessions") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(store.all()));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+
+  const port = process.env.PORT || 4343;
+  server.listen(port, () => console.log(`issue-343 mock listening on port ${port}`));
+}

--- a/contrib/routes/issue-343-session-retention-job/route.test.mjs
+++ b/contrib/routes/issue-343-session-retention-job/route.test.mjs
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import {
+  DEFAULT_RETENTION_WINDOW_MS,
+  computeExpiredCutoff,
+  mockSessionStore,
+  retentionWindowMsFromEnv,
+  runRetentionSweep,
+  startRetentionJob,
+} from "./route.mjs";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-08-29T00:00:00.000Z");
+
+function session(id, { createdDaysAgo, expiresDaysFromNow, network = "testnet" }) {
+  return {
+    id,
+    contractId: `C${id.toUpperCase()}`,
+    network,
+    createdAt: new Date(NOW.getTime() - createdDaysAgo * DAY_MS),
+    lastActiveAt: new Date(NOW.getTime() - createdDaysAgo * DAY_MS),
+    expiresAt: new Date(NOW.getTime() + expiresDaysFromNow * DAY_MS),
+  };
+}
+
+// --- computeExpiredCutoff -----------------------------------------------
+
+{
+  const cutoff = computeExpiredCutoff(NOW, 30 * DAY_MS);
+  assert.equal(cutoff.toISOString(), "2026-07-30T00:00:00.000Z");
+}
+
+// --- retentionWindowMsFromEnv --------------------------------------------
+
+{
+  assert.equal(retentionWindowMsFromEnv({}), DEFAULT_RETENTION_WINDOW_MS);
+  assert.equal(retentionWindowMsFromEnv({ RETENTION_WINDOW_MS: "1000" }), 1000);
+  // Invalid/garbage/negative values fall back to the default rather than
+  // silently deleting everything (0) or nothing (NaN comparisons).
+  assert.equal(retentionWindowMsFromEnv({ RETENTION_WINDOW_MS: "not-a-number" }), DEFAULT_RETENTION_WINDOW_MS);
+  assert.equal(retentionWindowMsFromEnv({ RETENTION_WINDOW_MS: "-5" }), DEFAULT_RETENTION_WINDOW_MS);
+  assert.equal(retentionWindowMsFromEnv({ RETENTION_WINDOW_MS: "0" }), DEFAULT_RETENTION_WINDOW_MS);
+}
+
+// --- runRetentionSweep: the core "only expired past the window" guarantee -
+
+{
+  const retentionWindowMs = 30 * DAY_MS;
+
+  const active = session("active", { createdDaysAgo: 1, expiresDaysFromNow: 6 }); // not expired at all
+  const expiredButInGrace = session("in-grace", { createdDaysAgo: 20, expiresDaysFromNow: -10 }); // expired 10d ago, window is 30d
+  const expiredExactlyAtCutoff = session("at-cutoff", { createdDaysAgo: 40, expiresDaysFromNow: -30 }); // expiresAt == cutoff exactly
+  const expiredPastWindow = session("past-window", { createdDaysAgo: 60, expiresDaysFromNow: -45 }); // expired 45d ago > 30d window
+  const expiredWayPastWindow = session("way-past", { createdDaysAgo: 200, expiresDaysFromNow: -180 });
+
+  const store = mockSessionStore([
+    active,
+    expiredButInGrace,
+    expiredExactlyAtCutoff,
+    expiredPastWindow,
+    expiredWayPastWindow,
+  ]);
+
+  const result = await runRetentionSweep(store, { now: NOW, retentionWindowMs });
+
+  // Only rows strictly older than the cutoff are deleted.
+  assert.deepEqual(new Set(result.deletedIds), new Set(["past-window", "way-past"]));
+  assert.equal(result.deletedCount, 2);
+
+  // Active and in-grace sessions survive untouched.
+  const remainingIds = new Set(store.all().map((r) => r.id));
+  assert.ok(remainingIds.has("active"), "active session must not be deleted");
+  assert.ok(remainingIds.has("in-grace"), "expired-but-within-grace session must not be deleted");
+  // A row whose expiresAt is EXACTLY the cutoff is not < cutoff, so it survives
+  // this pass (it becomes eligible on the next sweep once time moves forward).
+  assert.ok(remainingIds.has("at-cutoff"), "row at the exact cutoff boundary must not be deleted yet");
+
+  // Deleted rows are gone from the store entirely, not just marked.
+  assert.equal(store.get("past-window"), undefined);
+  assert.equal(store.get("way-past"), undefined);
+}
+
+// --- runRetentionSweep: no expired rows -> no-op, doesn't throw ----------
+
+{
+  const store = mockSessionStore([session("only-active", { createdDaysAgo: 1, expiresDaysFromNow: 5 })]);
+  const result = await runRetentionSweep(store, { now: NOW, retentionWindowMs: 30 * DAY_MS });
+  assert.equal(result.deletedCount, 0);
+  assert.deepEqual(result.deletedIds, []);
+  assert.equal(store.all().length, 1);
+}
+
+// --- runRetentionSweep: empty store -> no-op -------------------------------
+
+{
+  const store = mockSessionStore([]);
+  const result = await runRetentionSweep(store, { now: NOW, retentionWindowMs: 30 * DAY_MS });
+  assert.equal(result.deletedCount, 0);
+}
+
+// --- runRetentionSweep: default retention window is honored when omitted -
+
+{
+  const justOverDefault = session("default-window-target", {
+    createdDaysAgo: 40,
+    expiresDaysFromNow: -31, // expired 31 days ago; default window is 30 days
+  });
+  const justUnderDefault = session("default-window-survivor", {
+    createdDaysAgo: 40,
+    expiresDaysFromNow: -29, // expired 29 days ago; still within default 30-day window
+  });
+  const store = mockSessionStore([justOverDefault, justUnderDefault]);
+  const result = await runRetentionSweep(store, { now: NOW }); // no retentionWindowMs passed
+  assert.deepEqual(result.deletedIds, ["default-window-target"]);
+}
+
+// --- startRetentionJob: runs once immediately, then on the interval ------
+
+{
+  let sweepCount = 0;
+  const store = mockSessionStore([
+    session("immediate-target", { createdDaysAgo: 60, expiresDaysFromNow: -45 }),
+  ]);
+  const silentLog = { info: () => {}, error: () => {} };
+
+  const job = startRetentionJob(store, {
+    intervalMs: 60_000,
+    retentionWindowMs: 30 * DAY_MS,
+    log: silentLog,
+    onSweep: () => {
+      sweepCount += 1;
+    },
+  });
+
+  // The immediate run is fired via `void runOnce()` (fire-and-forget), so
+  // give the microtask queue a tick to let it settle before asserting.
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(sweepCount, 1, "job must sweep once immediately on start, matching worker-service's convention");
+  assert.equal(store.all().length, 0, "the immediate sweep must have deleted the past-window session");
+
+  job.stop();
+}
+
+// --- startRetentionJob: stop() actually clears the interval ---------------
+
+{
+  let sweepCount = 0;
+  const store = mockSessionStore([]);
+  const silentLog = { info: () => {}, error: () => {} };
+
+  const job = startRetentionJob(store, {
+    intervalMs: 5, // fast interval so we can observe ticks in a short test
+    log: silentLog,
+    onSweep: () => {
+      sweepCount += 1;
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  job.stop();
+  const countAtStop = sweepCount;
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
+  assert.ok(countAtStop >= 1, "job should have swept at least once before stop()");
+  assert.equal(sweepCount, countAtStop, "no further sweeps must fire after stop()");
+}
+
+// --- runRetentionSweep: a store failure surfaces to the caller rather than
+// silently vanishing (relevant for startRetentionJob's try/catch around it) -
+
+{
+  const throwingStore = {
+    async deleteExpiredBefore() {
+      throw new Error("connection reset");
+    },
+  };
+  await assert.rejects(
+    () => runRetentionSweep(throwingStore, { now: NOW, retentionWindowMs: 30 * DAY_MS }),
+    /connection reset/,
+  );
+}
+
+// --- startRetentionJob: a sweep failure is caught and logged, job keeps running -
+
+{
+  let errorLogged = false;
+  const throwingStore = {
+    async deleteExpiredBefore() {
+      throw new Error("boom");
+    },
+  };
+  const job = startRetentionJob(throwingStore, {
+    intervalMs: 60_000,
+    log: {
+      info: () => {},
+      error: () => {
+        errorLogged = true;
+      },
+    },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.ok(errorLogged, "a failed sweep must be logged, not thrown into the event loop");
+  job.stop();
+}
+
+console.log("PASS: Issue 343 session retention job tests passed cleanly!");


### PR DESCRIPTION
## Summary

Resolves 4 assigned issues, all scoped inside `contrib/routes/` per this
repo's contribution model (`CONTRIBUTING.md`: contributor PRs target `drips`
and may only touch `contrib/`; verified against real closed/merged PR
history — non-`contrib/` and non-`drips` PRs from non-maintainers are closed
or retargeted automatically). Two issues needed real code (a scheduled job
and a smoke-test script) and are delivered as sandboxed, fully-tested
reference implementations that mirror the actual code they'd extend if
merged into the real service; two are documentation issues, delivered as
substantive runbooks grounded in this repo's actual architecture rather than
generic filler.

## #343 — Data retention policy job for expired sessions

`contrib/routes/issue-343-session-retention-job/`

A scheduled sweep that physically deletes `wallet_sessions` rows once
they're past a configurable retention window past their `expires_at`. The
real `services/wallet-service` `SessionRepository` already treats an expired
session as logically absent (`find`/`listByContract` filter on `expiresAt`),
but nothing today physically deletes an expired row — they accumulate
forever. This closes that gap.

- Scheduling matches this repo's only existing precedent —
  `services/worker-service/src/index.ts`'s `setInterval`-based reaper (run
  once immediately, then on an interval, `stop()`/`clearInterval` on
  shutdown). There's no cron library anywhere in the repo to depend on.
- The deletion query mirrors `services/wallet-service/src/db/pg-repository.ts`'s
  real `db.delete(walletSessions).where(...)` pattern; the README documents
  the exact `SessionRepository.deleteExpiredBefore()` + drizzle
  implementation a real integration would add.
- `RETENTION_WINDOW_MS` env var (default 30 days), deliberately independent
  of and longer than the session's own 7-day sliding TTL
  (`SESSION_TTL_MS` in `services/wallet-service/src/server.ts`) — a grace
  period before physical deletion.

**Test plan**: `node contrib/routes/issue-343-session-retention-job/route.test.mjs`
— 11 assertions covering the core guarantee (deletes only sessions past the
retention cutoff; active and in-grace-period sessions are never touched),
the exact-boundary case, env-var parsing edge cases, the immediate-run +
interval scheduler lifecycle, `stop()` actually halting further sweeps, and
sweep-failure handling (logged, not thrown).

## #339 — Pre-deploy smoke test script for services workspace

`contrib/routes/issue-339-predeploy-smoke-test/`

Hits `/health` for every real services-workspace target (api-gateway,
wallet/lifecycle/policy/verification/worker-service, on their documented
`.env.example` ports 4000–4005; `permission-service` is excluded since it's
currently an empty stub with no server) plus a wallet-creation e2e check
matching the real `POST /wallet/create` contract confirmed in
`services/wallet-service/src/server.test.ts` (`201` +
`{contractId, txHash, sessionId}`). CI-friendly: exits non-zero on any
failure, times out rather than hanging on a dead/hung service, and reports
every check's result rather than stopping at the first failure.

- `route.mjs` — the real check logic (`checkHealth`, `checkWalletCreate`,
  `runSmokeTest`), a CLI entrypoint reading `SMOKE_BASE_URL`/`SMOKE_TARGETS`/
  `SMOKE_TIMEOUT_MS`, and a `--demo` mode that spins up an in-process mock
  server so the script's real request/assertion logic can be exercised
  standalone.
- README documents both manual (`node route.mjs`) and CI usage (a sample
  GitHub Actions step) — `process.exit(1)` on failure needs no extra
  `continue-on-error` handling.

**Test plan**: `node contrib/routes/issue-339-predeploy-smoke-test/route.test.mjs`
— unit tests against a real in-process HTTP server (not a fake fetch): all-
healthy pass, a 503/unavailable service, connection-refused, a hung service
timing out instead of hanging, wallet-create success/failure shapes, and
multi-target runs where one failure doesn't hide the others in the summary.
Also manually verified: `node route.mjs --demo` exits 0 against a healthy
mock; `SMOKE_TARGETS` pointed at a dead port exits 1 with a clear failure
line.

## #340 — Rollback procedure doc for failed contract deployments

`contrib/routes/issue-340-contract-rollback-runbook/`

Documents detection signals for each of the three points a Soroban deploy
can fail (build / upload / deploy-instantiate — each with a distinct
signal), recovery options (redeploy using the exact commands from
`services/worker-service/README.md`'s reproducibility section; state
reconciliation for the case where `worker-service`'s attestation mirror
references a hash the chain never actually got; abandon-and-refresh as a
last resort), and a post-rollback consistency checklist (verify the tx
result on-chain, check for premature address references in service config,
reconcile spend-budget debits, rerun the #339 smoke test).

## #337 — Runbook for worker-service queue backlog incident

`contrib/routes/issue-337-queue-backlog-runbook/`

Documents that `worker-service` has no message broker at all — the "queue"
is the `verification_records` Postgres table and its status enum
(`unverified → submitted → building → verified|failed|dead_letter`) — and
grounds detection/mitigation in that reality rather than generic
Redis/BullMQ advice: detection via the existing
`vela_verification_turnaround_seconds` p95 alert
(`docs/observability.md`), the `VERIFY_QUEUE_MAX_ACTIVE` 429 valve already in
`.env.example`, and reaper reclaim-rate as a signal of stuck workers vs.
plain under-capacity. Mitigation covers scaling `worker-service` replicas
(safe because row-claiming is an atomic Postgres update), throttling via
`api-gateway`'s real `@fastify/rate-limit` config, and root-causing stuck
workers separately from simple capacity. Escalation and rollback sections
included.

## Why these are scoped as stubs/docs in `contrib/`, not real service edits

`Ejere` has `pull`-only access to this repo (verified via the GitHub API).
Per `CONTRIBUTING.md` and the enforced `close-prs-to-main.yml` /
`close-prs-outside-contrib.yml` workflows, non-maintainer PRs must target
`drips` and may only touch files under `contrib/` — verified against real
history (e.g. PRs #251/#252 from non-maintainers touching files outside
`contrib/` were closed; only the maintainer's PRs land on `main` directly).
#343 and #339 are therefore delivered as sandboxed reference implementations
with real, tested logic (not fakes — the sweep/health-check/smoke-test logic
is genuine and directly portable into the real service, as each README's
"Design" section spells out field-by-field), rather than edits to
`services/wallet-service` or the root workspace.

## Caveats

- `docs/decisions.md`, which #343's original ask referenced as the place to
  document the retention policy, is gitignored on `main`
  (`.gitignore:47`) and doesn't exist as a tracked file — `docs/security-audit.md`
  confirms it "exist[s] only in the author's working tree." The retention
  policy is instead fully documented in
  `contrib/routes/issue-343-session-retention-job/README.md`.
- These are sandboxed reference implementations, not drop-in service code —
  each README spells out exactly what the real integration into
  `services/wallet-service` / the root workspace / `contracts/` would look
  like, but actually wiring them in is out of scope for a contributor PR
  under this repo's current contribution model.
- Did not run the full repo `pnpm test`/`pnpm typecheck` — this PR's files
  are plain, dependency-free `.mjs` under `contrib/`, untouched by the
  TypeScript/vitest workspace those commands cover. All code in this PR was
  run and verified directly via `node <file>.test.mjs`, as shown in each
  section's test plan above.

closes #343
closes #340
closes #339
closes #337
