### PR TITLE
feat: deploy health gate, canary error budget, staging config, policy builder rollout flag

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -3,3 +3,23 @@
 Primary product surface (technical-doc.md §4.1, §12): onboarding, passkey registration/recovery, wallet dashboard, advanced transaction review, policy builder, verification console, cleanup wizard, device/session management.
 
 Stack (idea.md §7): Next.js, React, TypeScript, Tailwind, Zustand, React Hook Form + Zod, TanStack Query.
+
+## Feature flags
+
+`lib/feature-flags.ts` gates a UI behind a gradual rollout — an allowlist of
+`accountId`s that always see it, plus a percentage rollout bucketed by a
+stable hash of `accountId` (so the same account always gets the same
+experience across page loads). Configured via `NEXT_PUBLIC_FLAG_*` env vars,
+inlined at build time like every other client config value in
+`lib/config.ts`. Currently gates the policy builder (`app/policies/page.tsx`,
+flag name `policyBuilderV2`):
+
+```
+NEXT_PUBLIC_FLAG_POLICY_BUILDER_V2_ROLLOUT_PERCENT=25   # 0-100, default 0
+NEXT_PUBLIC_FLAG_POLICY_BUILDER_V2_ALLOWLIST=GACCT1,GACCT2
+```
+
+See `docs/decisions.md` (gitignored — private strategy doc, see repo root
+`.gitignore`) for the full rollout plan and reasoning; the mechanism itself
+is documented in `lib/feature-flags.ts` and tested in
+`lib/feature-flags.test.ts` / `app/policies/page.flag-gating.test.tsx`.

--- a/apps/web/app/policies/page.flag-gating.test.tsx
+++ b/apps/web/app/policies/page.flag-gating.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WalletProvider } from "@/lib/wallet-context";
+import Policies from "./page";
+
+// Issue #335 acceptance criterion: "a test verifying flagged and unflagged
+// users see the correct UI". Deliberately a separate file from
+// page.test.tsx, which mocks the flag on (always true) so its own
+// assertions exercise the real builder — this file leaves the flag's real
+// evaluation in place and drives it via env vars instead, the way it's
+// actually configured in production.
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/policies",
+}));
+
+vi.mock("@/lib/policy", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/policy")>("@/lib/policy");
+  return { ...actual, listTemplates: vi.fn().mockResolvedValue([]) };
+});
+
+const SESSION = {
+  accountId: "CWALLET1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDE",
+  network: "testnet",
+  connected: true,
+  authMethod: "passkey",
+  createdAt: "2026-07-16T10:00:00.000Z",
+  lastActiveAt: "2026-07-16T10:00:00.000Z",
+};
+
+function renderPage() {
+  window.localStorage.setItem("vellar.session", JSON.stringify(SESSION));
+  render(
+    <WalletProvider>
+      <Policies />
+    </WalletProvider>,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  delete process.env.NEXT_PUBLIC_FLAG_POLICY_BUILDER_V2_ROLLOUT_PERCENT;
+  delete process.env.NEXT_PUBLIC_FLAG_POLICY_BUILDER_V2_ALLOWLIST;
+});
+
+describe("Policy builder — feature flag gating (#335)", () => {
+  it("shows the not-yet-available fallback for an unflagged connected session (default: 0% rollout)", async () => {
+    renderPage();
+    expect(await screen.findByText(/rolling out gradually/i)).toBeDefined();
+    // The real builder's template picker must NOT render (note: the
+    // fallback copy itself mentions "spending limits" in prose, so assert
+    // against the picker's own loading state instead of a text match that
+    // would also match the fallback's wording).
+    expect(screen.queryByText(/loading templates/i)).toBeNull();
+  });
+
+  it("does not show the flag-gated builder content when no wallet is connected (AppShell's own auth redirect takes over first)", async () => {
+    render(
+      <WalletProvider>
+        <Policies />
+      </WalletProvider>,
+    );
+    // AppShell redirects an unauthenticated visitor before any policy-builder
+    // content (flagged or not) would render — see components/app-shell.tsx.
+    // This asserts policyBuilderVisibleFor's null-accountId branch doesn't
+    // somehow leak the real builder through in that state, not that a
+    // specific fallback message appears (AppShell owns that UI).
+    expect(await screen.findByText(/redirecting/i)).toBeDefined();
+    expect(screen.queryByText("Account policies")).toBeNull();
+  });
+
+  it("shows the real builder for an allowlisted account, even at 0% rollout", async () => {
+    process.env.NEXT_PUBLIC_FLAG_POLICY_BUILDER_V2_ALLOWLIST = SESSION.accountId;
+    // Re-import BOTH the page and WalletProvider from a fresh module
+    // registry so the page's module-level readFlagConfig() call (which
+    // picks up the env var set just above — it's read once at module load,
+    // matching how a real Next.js build inlines NEXT_PUBLIC_* at build
+    // time) and WalletProvider's React context are the same module
+    // instances; mixing a freshly-imported page with the already-imported
+    // WalletProvider from the top of this file throws "must be used inside
+    // <WalletProvider>" because they'd hold two distinct Context objects.
+    vi.resetModules();
+    const { default: FlaggedPolicies } = await import("./page");
+    const { WalletProvider: FreshWalletProvider } = await import("@/lib/wallet-context");
+
+    window.localStorage.setItem("vellar.session", JSON.stringify(SESSION));
+    render(
+      <FreshWalletProvider>
+        <FlaggedPolicies />
+      </FreshWalletProvider>,
+    );
+
+    expect(await screen.findByText("Account policies")).toBeDefined();
+    expect(screen.queryByText(/rolling out gradually/i)).toBeNull();
+  });
+});

--- a/apps/web/app/policies/page.test.tsx
+++ b/apps/web/app/policies/page.test.tsx
@@ -33,6 +33,18 @@ vi.mock("@/lib/connector-factory", async (importOriginal) => {
   return { ...actual, getWalletRuntime: runtimeMock };
 });
 
+// #335: the policy builder is gated behind a gradual-rollout feature flag,
+// which defaults OFF for any session with no rollout configured. This suite
+// tests the builder's own behavior (templates, validation, deploy), not the
+// flag gate itself (see lib/feature-flags.test.ts and the "flag gating"
+// describe block below for that) — force the flag on here so the existing
+// assertions keep exercising the real UI rather than the "not yet available"
+// fallback.
+vi.mock("@/lib/feature-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/feature-flags")>();
+  return { ...actual, isFlagEnabled: () => true };
+});
+
 const SESSION = {
   accountId: "CWALLET1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDE",
   network: "testnet",

--- a/apps/web/app/policies/page.tsx
+++ b/apps/web/app/policies/page.tsx
@@ -6,6 +6,7 @@ import { AppShell } from "@/components/app-shell";
 import { Eyebrow, LpActionButton } from "@/app/landing/ui";
 import { getWalletRuntime } from "@/lib/connector-factory";
 import { useWalletSession } from "@/lib/wallet-context";
+import { isFlagEnabled, readFlagConfig } from "@/lib/feature-flags";
 import {
   deployPolicy,
   detachPolicy,
@@ -30,8 +31,54 @@ type Stage =
   | { name: "configure"; template: PolicyTemplateInfo }
   | { name: "review"; template: PolicyTemplateInfo; policy: GeneratedPolicy };
 
+// Feature flag gating the policy builder's gradual rollout (#335 —
+// docs/decisions.md records the flag name and rollout plan). Read once at
+// module load: the env vars it's built from are inlined at Next.js build
+// time (NEXT_PUBLIC_*), so there's no benefit to re-reading them per render,
+// and reading it here (not inside the component) keeps
+// PolicyBuilderFlagged's gating logic testable without rendering the whole
+// page tree.
+const POLICY_BUILDER_FLAG = readFlagConfig("policyBuilderV2");
+
+/** Exported for tests — the gating decision as a pure function of session. */
+export function policyBuilderVisibleFor(accountId: string | null): boolean {
+  return isFlagEnabled(POLICY_BUILDER_FLAG, accountId);
+}
+
 export default function Policies() {
   const session = useWalletSession();
+
+  if (!policyBuilderVisibleFor(session?.accountId ?? null)) {
+    return <PolicyBuilderNotYetAvailable />;
+  }
+
+  return <PolicyBuilder session={session} />;
+}
+
+/**
+ * Shown to a connected wallet not yet in the policy-builder rollout, and to
+ * anyone with no wallet connected yet (accountId unavailable — see
+ * isFlagEnabled's doc: there is no stable identity to bucket against yet).
+ * A flagged-out user gets an honest "not yet" state rather than either a
+ * broken partial UI or a silently missing page.
+ */
+function PolicyBuilderNotYetAvailable() {
+  return (
+    <AppShell>
+      <div className="flex max-w-[720px] flex-col gap-5">
+        <header>
+          <h1>Account policies</h1>
+          <p className="mt-3! max-w-[560px] text-[15px] leading-relaxed text-[var(--lp-ink-soft)]">
+            Programmable account policies — spending limits, multisig, contract allowlists — are
+            rolling out gradually. This account isn't in the rollout yet; check back soon.
+          </p>
+        </header>
+      </div>
+    </AppShell>
+  );
+}
+
+function PolicyBuilder({ session }: { session: WalletSession | null }) {
   const [templates, setTemplates] = useState<PolicyTemplateInfo[] | null>(null);
   const [stage, setStage] = useState<Stage>({ name: "pick" });
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/lib/feature-flags.test.ts
+++ b/apps/web/lib/feature-flags.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { bucketFor, isFlagEnabled, readFlagConfig } from "./feature-flags";
+
+describe("readFlagConfig (#335)", () => {
+  it("defaults to 0% rollout and an empty allowlist when unconfigured", () => {
+    const cfg = readFlagConfig("policyBuilderV2", {});
+    expect(cfg.rolloutPercent).toBe(0);
+    expect(cfg.allowlist).toEqual([]);
+  });
+
+  it("reads rolloutPercent and allowlist from the camelCase-derived env var names", () => {
+    const cfg = readFlagConfig("policyBuilderV2", {
+      NEXT_PUBLIC_FLAG_POLICY_BUILDER_V2_ROLLOUT_PERCENT: "25",
+      NEXT_PUBLIC_FLAG_POLICY_BUILDER_V2_ALLOWLIST: "GACCT1,GACCT2",
+    });
+    expect(cfg.rolloutPercent).toBe(25);
+    expect(cfg.allowlist).toEqual(["GACCT1", "GACCT2"]);
+  });
+
+  it("also accepts the SCREAMING_SNAKE_CASE form directly", () => {
+    const cfg = readFlagConfig("POLICY_BUILDER_V2", {
+      NEXT_PUBLIC_FLAG_POLICY_BUILDER_V2_ROLLOUT_PERCENT: "50",
+    });
+    expect(cfg.rolloutPercent).toBe(50);
+  });
+
+  it("trims whitespace and drops empty entries from the allowlist", () => {
+    const cfg = readFlagConfig("f", {
+      NEXT_PUBLIC_FLAG_F_ALLOWLIST: " GACCT1 , , GACCT2,",
+    });
+    expect(cfg.allowlist).toEqual(["GACCT1", "GACCT2"]);
+  });
+
+  it("fails closed (0%) on a non-numeric rolloutPercent rather than throwing", () => {
+    const cfg = readFlagConfig("f", { NEXT_PUBLIC_FLAG_F_ROLLOUT_PERCENT: "not-a-number" });
+    expect(cfg.rolloutPercent).toBe(0);
+  });
+
+  it("clamps a rolloutPercent above 100 down to 100", () => {
+    const cfg = readFlagConfig("f", { NEXT_PUBLIC_FLAG_F_ROLLOUT_PERCENT: "500" });
+    expect(cfg.rolloutPercent).toBe(100);
+  });
+
+  it("clamps a negative rolloutPercent up to 0", () => {
+    const cfg = readFlagConfig("f", { NEXT_PUBLIC_FLAG_F_ROLLOUT_PERCENT: "-10" });
+    expect(cfg.rolloutPercent).toBe(0);
+  });
+});
+
+describe("bucketFor (#335)", () => {
+  it("is deterministic — the same accountId always produces the same bucket", () => {
+    const id = "GACCOUNTIDEXAMPLE1234567890";
+    const first = bucketFor(id);
+    for (let i = 0; i < 20; i++) {
+      expect(bucketFor(id)).toBe(first);
+    }
+  });
+
+  it("stays within [0, 100) for a range of inputs", () => {
+    for (let i = 0; i < 200; i++) {
+      const bucket = bucketFor(`GACCOUNT${i}`);
+      expect(bucket).toBeGreaterThanOrEqual(0);
+      expect(bucket).toBeLessThan(100);
+    }
+  });
+
+  it("distributes across the range rather than collapsing to one value", () => {
+    const buckets = new Set<number>();
+    for (let i = 0; i < 500; i++) {
+      buckets.add(bucketFor(`GACCOUNT${i}`));
+    }
+    // Not asserting a specific distribution shape — just that 500 distinct
+    // inputs don't all collide into a handful of buckets, which would make
+    // "percentage rollout" meaningless.
+    expect(buckets.size).toBeGreaterThan(50);
+  });
+
+  it("produces different buckets for different accountIds (not a constant function)", () => {
+    const a = bucketFor("GACCOUNTAAAAAAAAAAAAAAAAAAAA");
+    const b = bucketFor("GACCOUNTBBBBBBBBBBBBBBBBBBBB");
+    // Extremely unlikely to collide for two arbitrary distinct strings;
+    // if this ever flakes, the hash function itself has a real bug.
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("isFlagEnabled (#335)", () => {
+  it("returns false when accountId is null (no connected wallet yet)", () => {
+    expect(isFlagEnabled({ rolloutPercent: 100, allowlist: [] }, null)).toBe(false);
+  });
+
+  it("returns false at 0% rollout for an account not on the allowlist", () => {
+    expect(isFlagEnabled({ rolloutPercent: 0, allowlist: [] }, "GANYACCOUNT")).toBe(false);
+  });
+
+  it("returns true at 100% rollout for any account", () => {
+    for (let i = 0; i < 20; i++) {
+      expect(isFlagEnabled({ rolloutPercent: 100, allowlist: [] }, `GACCOUNT${i}`)).toBe(true);
+    }
+  });
+
+  it("an allowlisted account sees the flag even at 0% rollout", () => {
+    const cfg = { rolloutPercent: 0, allowlist: ["GBETATESTER"] };
+    expect(isFlagEnabled(cfg, "GBETATESTER")).toBe(true);
+  });
+
+  it("a non-allowlisted account respects the percentage rollout, not the allowlist", () => {
+    const account = "GNOTONLIST";
+    const bucket = bucketFor(account);
+    const cfgJustBelow = { rolloutPercent: bucket, allowlist: [] }; // bucket < rolloutPercent is false when equal
+    const cfgJustAbove = { rolloutPercent: bucket + 1, allowlist: [] };
+    expect(isFlagEnabled(cfgJustBelow, account)).toBe(false);
+    expect(isFlagEnabled(cfgJustAbove, account)).toBe(true);
+  });
+
+  it("the same account consistently sees the same flagged/unflagged UI across repeated calls", () => {
+    const cfg = { rolloutPercent: 50, allowlist: [] };
+    const account = "GSTABLEUSER";
+    const first = isFlagEnabled(cfg, account);
+    for (let i = 0; i < 10; i++) {
+      expect(isFlagEnabled(cfg, account)).toBe(first);
+    }
+  });
+});

--- a/apps/web/lib/feature-flags.ts
+++ b/apps/web/lib/feature-flags.ts
@@ -1,0 +1,93 @@
+// Feature flags — gradual rollout gating (issue #335).
+//
+// The policy builder UI (app/policies/page.tsx) needs a gradual rollout
+// mechanism rather than a hard cutover for all users. This module provides
+// two gating strategies that combine into one decision:
+//
+//   1. Allowlist — a fixed set of account IDs (e.g. internal/beta testers)
+//      always see the flagged UI, regardless of the percentage rollout.
+//   2. Percentage rollout — a stable hash of the account's own accountId
+//      buckets it into [0, 100). The same account ALWAYS lands in the same
+//      bucket (the hash is deterministic, not randomized per page load), so
+//      a user's experience doesn't flicker between the old and new UI on
+//      every refresh — the property a gradual rollout actually needs.
+//
+// Configured via NEXT_PUBLIC_* env vars, matching every other client
+// config value in lib/config.ts (NEXT_PUBLIC_* vars are inlined at build
+// time by Next.js).
+
+export interface FeatureFlagConfig {
+  /** 0-100. Percentage of accounts (by stable hash) that see the flagged UI. */
+  rolloutPercent: number;
+  /** Account IDs that always see the flagged UI, independent of rolloutPercent. */
+  allowlist: string[];
+}
+
+const FLAG_ENV_PREFIX = "NEXT_PUBLIC_FLAG_";
+
+/**
+ * Reads a flag's config from env vars:
+ *   NEXT_PUBLIC_FLAG_<NAME>_ROLLOUT_PERCENT  (default 0 — off unless configured)
+ *   NEXT_PUBLIC_FLAG_<NAME>_ALLOWLIST        (comma-separated account IDs)
+ *
+ * `name` is upper-snake-cased internally, so callers can pass either form
+ * ("policyBuilderV2" or "POLICY_BUILDER_V2") and get the same env var names.
+ */
+export function readFlagConfig(name: string, env: Record<string, string | undefined> = process.env): FeatureFlagConfig {
+  const key = toEnvKey(name);
+  const rolloutRaw = env[`${FLAG_ENV_PREFIX}${key}_ROLLOUT_PERCENT`];
+  const allowlistRaw = env[`${FLAG_ENV_PREFIX}${key}_ALLOWLIST`];
+
+  let rolloutPercent = 0;
+  if (rolloutRaw !== undefined && rolloutRaw !== "") {
+    const parsed = Number(rolloutRaw);
+    // clamp: a misconfigured value (negative, >100, NaN) must fail closed
+    // toward "fewer people see it" rather than silently rolling out to
+    // everyone or crashing the page.
+    rolloutPercent = Number.isFinite(parsed) ? Math.min(100, Math.max(0, parsed)) : 0;
+  }
+
+  const allowlist = (allowlistRaw ?? "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+
+  return { rolloutPercent, allowlist };
+}
+
+function toEnvKey(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toUpperCase();
+}
+
+/**
+ * Stable, deterministic bucket in [0, 100) for `accountId`. Same accountId
+ * always produces the same bucket — this is NOT cryptographic, just a
+ * simple, fast, deterministic string hash (FNV-1a), which is exactly what a
+ * rollout bucket needs and nothing more.
+ */
+export function bucketFor(accountId: string): number {
+  let hash = 0x811c9dc5; // FNV-1a 32-bit offset basis
+  for (let i = 0; i < accountId.length; i++) {
+    hash ^= accountId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193); // FNV prime
+  }
+  // >>> 0 converts to unsigned before the modulo, so the bucket is always
+  // non-negative regardless of hash's sign after Math.imul.
+  return (hash >>> 0) % 100;
+}
+
+/**
+ * Whether `accountId` should see the flagged UI, given `config`.
+ * Allowlist wins outright; otherwise the account's stable bucket must fall
+ * inside the configured rollout percentage. `accountId` of `null` (no
+ * connected wallet — e.g. before wallet connect completes) never sees the
+ * flagged UI: a rollout decision requires an identity to be stable against,
+ * and there is none yet.
+ */
+export function isFlagEnabled(config: FeatureFlagConfig, accountId: string | null): boolean {
+  if (!accountId) return false;
+  if (config.allowlist.includes(accountId)) return true;
+  return bucketFor(accountId) < config.rolloutPercent;
+}


### PR DESCRIPTION
## Summary

Four deploy/rollout-hardening issues. A note up front: this repo deploys as a single combined process to Railway/Render with no orchestrator (`infra/README.md`'s k8s section is aspirational, not yet built), so a literal blue/green traffic cutover (#334) or percentage-based canary routing (#336) aren't buildable against the actual infra today. Each issue below is scoped down to what IS real and shippable given that constraint, stated explicitly rather than faked.

- **#334 — blue/green for wallet-service.** `scripts/deploy-health-gate.ts`: polls `/health` until it reports healthy for N consecutive checks (not just once) or times out — the automatable pre-cutover verification step for a blue/green promotion or rollback decision on Render/Railway's native rollback-to-prior-build mechanism. Documented rollback runbook in `services/wallet-service/README.md`.
- **#336 — canary stage for api-gateway.** `scripts/canary-error-budget-gate.ts`: scrapes a service's real `/metrics` (`vela_http_requests_total`, from `@vellar/service-kit`'s `registerMetrics`) twice, a window apart, and computes the 5xx rate within that window — the automatable promotion gate. Documented canary stage, rollback trigger, and staging rehearsal in `services/api-gateway/README.md`.
- **#338 — staging config for verification-service.** `services/verification-service/.env.staging.example` (isolated port, Stellar TESTNET RPC as the 'third-party lookup' target, isolated DB slot) plus `src/config.staging.test.ts`, which resolves it via `configFromEnv` AND boots a real server against it — not just an unverified env file.
- **#335 — feature flag for the policy builder UI.** `lib/feature-flags.ts`: an allowlist combined with a percentage rollout bucketed by a stable hash of the account's own `accountId`, so a user's experience doesn't flicker across page loads. Gates `app/policies/page.tsx` — an unflagged connected wallet sees an honest 'rolling out gradually' message rather than a broken partial UI (there's no separate 'old' builder to fall back to). Documented in `docs/decisions.md` per the issue's instruction — but that path is gitignored in this repo as a private strategy doc, so also added a real, shipped 'Feature flags' section to `apps/web/README.md`.

`scripts/` is a new pnpm workspace package (own `package.json`/`tsconfig`/vitest) so the two gate scripts are unit-tested with injectable fetch/sleep/clock — no real network calls or timers in the test suite.

## Testing

```
cd scripts && npx vitest run                                          # 15/15
cd services/verification-service && npx vitest run src/config.staging.test.ts   # 4/4
cd apps/web && npm test                                                # 14 files, 82/82
cd apps/web && npx next build                                          # real production build, succeeds
cd scripts && npx tsc --noEmit                                         # clean
cd apps/web && npx tsc --noEmit                                        # clean
```

Closes #334
Closes #336
Closes #338
Closes #335