### PR TITLE
feat(contrib): verified-only signing route suites for B9, B10, B11, B12

### DIFF
--- a/contrib/routes/issue-10-blocked-explainer-suite/README.md
+++ b/contrib/routes/issue-10-blocked-explainer-suite/README.md
@@ -1,0 +1,58 @@
+# Mock route: blocked transaction explainer suite (Issue #10 — B10)
+
+Simulates the UI behaviour when a transaction is blocked because the target
+contract is not verified. Exposes endpoints to check verification status,
+retrieve the honest explainer copy, and simulate acknowledgement of a warn
+behaviour.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/explainer/blocked` | Returns the blocked-transaction explainer copy (honest wording, no "safe" claims). |
+| POST | `/explainer/check` | Given a target contract, returns whether the transaction is allowed or blocked. |
+| POST | `/explainer/acknowledge` | Records that the user acknowledged a warn-state. |
+
+## Run
+
+```sh
+node route.mjs
+# blocked-explainer mock listening on http://localhost:4010
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example — blocked (unverified contract)
+
+```
+POST /explainer/check
+{ "targetContract": "CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67", "policyAttached": true }
+```
+
+```json
+{
+  "allowed": false,
+  "reason": "contract_not_verified",
+  "explainer": {
+    "title": "Transaction blocked",
+    "body": "The target contract's source has not been verified...",
+    "action": "You can inspect the contract on the verification explorer...",
+    "explorerUrl": "/verify?contract=CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67"
+  }
+}
+```
+
+## Example — allowed (verified contract)
+
+```
+POST /explainer/check
+{ "targetContract": "CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67", "policyAttached": true, "verifiedContracts": ["CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67"] }
+```
+
+```json
+{ "allowed": true, "reason": null }
+```

--- a/contrib/routes/issue-10-blocked-explainer-suite/route.mjs
+++ b/contrib/routes/issue-10-blocked-explainer-suite/route.mjs
@@ -1,0 +1,110 @@
+import http from "node:http";
+
+// Mock state for the blocked transaction explainer.
+const verifiedContracts = new Set();
+let acknowledgedWarns = new Set();
+
+// Honest explainer copy — never claims verified means safe.
+const BLOCKED_EXPLAINER = {
+  title: "Transaction blocked — target contract not verified",
+  body: `The target contract's published source has not been verified against the \
+deployed bytecode. Verification means the source you can read reproducibly \
+matches the code that runs on-chain — it does not mean the contract is \
+audited, benign, or safe to use.`,
+  action: `You can inspect the contract's verification status on the verification \
+explorer. If you are the contract author, submit the source for verification.`,
+  explorerLabel: "Open in verification explorer",
+};
+
+const WARN_EXPLAINER = {
+  title: "Caution — target contract is verified but not audited",
+  body: `The target contract's source has been verified: the published code \
+reproducibly matches the deployed bytecode. This does not mean the contract \
+has been audited, is free of bugs, or is safe to use. Proceed only if you \
+trust the contract author.`,
+  action: "I understand — proceed anyway",
+};
+
+function getBlockedExplainer() {
+  return { status: 200, body: { explainer: BLOCKED_EXPLAINER, warn: WARN_EXPLAINER } };
+}
+
+function checkTarget(body) {
+  if (!body || !body.targetContract) {
+    return { status: 422, body: { error: "targetContract is required" } };
+  }
+  if (!/^C[A-Z2-7]{55}$/.test(body.targetContract)) {
+    return {
+      status: 422,
+      body: { error: "targetContract must be a valid Stellar contract address (C…)" },
+    };
+  }
+
+  const policyAttached = body.policyAttached === true;
+  if (!policyAttached) {
+    return { status: 200, body: { allowed: true, reason: null } };
+  }
+
+  const isVerified = verifiedContracts.has(body.targetContract);
+  if (isVerified) {
+    return { status: 200, body: { allowed: true, reason: null } };
+  }
+
+  return {
+    status: 200,
+    body: {
+      allowed: false,
+      reason: "contract_not_verified",
+      explainer: {
+        ...BLOCKED_EXPLAINER,
+        explorerUrl: `/verify?contract=${body.targetContract}`,
+      },
+    },
+  };
+}
+
+function acknowledge(body) {
+  if (!body || !body.contractId) {
+    return { status: 422, body: { error: "contractId is required" } };
+  }
+  acknowledgedWarns.add(body.contractId);
+  return { status: 200, body: { acknowledged: true, contractId: body.contractId } };
+}
+
+// Test helpers — allow tests to register verified contracts and reset.
+export function registerVerified(contractId) {
+  verifiedContracts.add(contractId);
+}
+
+export function resetState() {
+  verifiedContracts.clear();
+  acknowledgedWarns.clear();
+}
+
+export function handleRequest(method, url, body) {
+  if (method === "GET" && url === "/explainer/blocked") return getBlockedExplainer();
+  if (method === "POST" && url === "/explainer/check") return checkTarget(body);
+  if (method === "POST" && url === "/explainer/acknowledge") return acknowledge(body);
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let bodyStr = "";
+    req.on("data", (c) => (bodyStr += c));
+    req.on("end", () => {
+      let parsed;
+      try {
+        if (bodyStr) parsed = JSON.parse(bodyStr);
+      } catch {}
+      const { status, body: resp } = handleRequest(req.method, req.url, parsed);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(resp));
+    });
+  });
+  const port = process.env.PORT || 4010;
+  server.listen(port, () => {
+    console.log(`blocked-explainer mock listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-10-blocked-explainer-suite/route.test.mjs
+++ b/contrib/routes/issue-10-blocked-explainer-suite/route.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { handleRequest, registerVerified, resetState } from "./route.mjs";
+
+const C1 = "CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67";
+const C2 = "CB" + "A".repeat(7) + "B".repeat(47);
+const G1 = "GCMCEGOUVALP2H6LTY7IPUUMSFKDQUMK3SDU5DI7LETNEZZKHRIIALKM";
+
+// Verify C1 and C2 match the contract address regex
+assert.ok(/^C[A-Z2-7]{55}$/.test(C1), "C1 must be valid");
+assert.ok(/^C[A-Z2-7]{55}$/.test(C2), "C2 must be valid");
+
+resetState();
+
+// 1. Blocked explainer returns honest copy
+let res = handleRequest("GET", "/explainer/blocked");
+assert.equal(res.status, 200);
+assert.ok(res.body.explainer.title.includes("blocked"));
+assert.ok(res.body.explainer.body.includes("does not mean"));
+// Must never claim verified means safe
+assert.ok(!res.body.explainer.body.toLowerCase().includes("verified means safe"));
+assert.ok(!res.body.explainer.body.toLowerCase().includes("guaranteed safe"));
+assert.ok(res.body.warn.body.includes("does not mean"));
+
+// 2. Check: no policy attached → allowed
+res = handleRequest("POST", "/explainer/check", { targetContract: C1, policyAttached: false });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+assert.equal(res.body.reason, null);
+
+// 3. Check: policy attached, unverified contract → blocked
+res = handleRequest("POST", "/explainer/check", { targetContract: C1, policyAttached: true });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.equal(res.body.reason, "contract_not_verified");
+assert.ok(res.body.explainer.explorerUrl.includes(C1));
+
+// 4. Check: policy attached, verified contract → allowed
+registerVerified(C1);
+res = handleRequest("POST", "/explainer/check", { targetContract: C1, policyAttached: true });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+
+// 5. Check: different unverified contract still blocked
+res = handleRequest("POST", "/explainer/check", { targetContract: C2, policyAttached: true });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.equal(res.body.reason, "contract_not_verified");
+
+// 6. Check: invalid contract address → 422
+res = handleRequest("POST", "/explainer/check", { targetContract: G1, policyAttached: true });
+assert.equal(res.status, 422);
+assert.ok(res.body.error.includes("Stellar contract address"));
+
+// 7. Check: missing targetContract → 422
+res = handleRequest("POST", "/explainer/check", {});
+assert.equal(res.status, 422);
+
+// 8. Acknowledge warn path
+res = handleRequest("POST", "/explainer/acknowledge", { contractId: C1 });
+assert.equal(res.status, 200);
+assert.equal(res.body.acknowledged, true);
+
+// 9. Acknowledge without contractId → 422
+res = handleRequest("POST", "/explainer/acknowledge", {});
+assert.equal(res.status, 422);
+
+// 10. 404 for unknown routes
+res = handleRequest("GET", "/unknown");
+assert.equal(res.status, 404);
+
+// 11. Copy never claims verification equals safety (all user-facing strings)
+res = handleRequest("GET", "/explainer/blocked");
+const explainerText = res.body.explainer.body + res.body.warn.body;
+const forbidden = ["guaranteed", "perfectly safe", "cannot be malicious", "trustworthy by default"];
+for (const phrase of forbidden) {
+  assert.ok(!explainerText.toLowerCase().includes(phrase), `copy must not contain "${phrase}"`);
+}
+
+console.log("PASS: Issue 10 blocked explainer suite — all 11 assertions passed");

--- a/contrib/routes/issue-11-recovery-path-suite/README.md
+++ b/contrib/routes/issue-11-recovery-path-suite/README.md
@@ -1,0 +1,50 @@
+# Mock route: recovery path suite (Issue #11 — B11)
+
+Simulates the verified-only signing override and recovery path. Exposes endpoints
+to remove or relax the verified-only policy, verifying that the owner can always
+remove it (the policy cannot block its own removal), and that an unauthorized
+caller cannot.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/recovery/status` | Returns whether a verified-only policy is attached and the recovery options. |
+| POST | `/recovery/remove` | Removes the verified-only policy. Requires passkey auth token from the account owner. |
+| POST | `/recovery/relax` | Relaxes from `strict` to `trusted_publishers` mode. Requires passkey auth token. |
+| GET | `/recovery/threat-model` | Returns the documented threat model for session vs passkey control. |
+
+## Run
+
+```sh
+node route.mjs
+# recovery-path mock listening on http://localhost:4011
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example — remove policy
+
+```
+POST /recovery/remove
+{ "authToken": "passkey-sig-valid" }
+```
+
+```json
+{ "removed": true }
+```
+
+## Example — unauthorized removal rejected
+
+```
+POST /recovery/remove
+{ "authToken": "wrong-token" }
+```
+
+```json
+{ "removed": false, "error": "passkey authorization required" }
+```

--- a/contrib/routes/issue-11-recovery-path-suite/route.mjs
+++ b/contrib/routes/issue-11-recovery-path-suite/route.mjs
@@ -1,0 +1,119 @@
+import http from "node:http";
+
+// Mock state for the recovery path.
+let policyState = {
+  attached: false,
+  mode: null,
+  contractId: null,
+};
+
+const VALID_AUTH_TOKEN = "passkey-sig-valid";
+
+const THREAT_MODEL = {
+  summary:
+    "A session attacker (controls the browser session but not the passkey) " +
+    "can initiate transactions but cannot sign them. The verified-only policy " +
+    "adds an additional layer: even if a session is compromised, the policy " +
+    "rejects transactions to unverified contracts.",
+  attackerCapabilities: [
+    "Can view the wallet balance and transaction history.",
+    "Can initiate transactions in the UI.",
+    "Cannot sign transactions (passkey required).",
+    "Cannot remove or relax the verified-only policy (passkey required).",
+  ],
+  ownerCapabilities: [
+    "Can always remove the verified-only policy with passkey authorization.",
+    "The removal operation itself is never blocked by the policy.",
+    "Can relax the policy from strict to trusted_publishers mode.",
+  ],
+  removalGuarantee:
+    "The verified-only policy is designed so that the removal operation is " +
+    "never rejected by the policy itself. The account owner can always " +
+    "recover by removing the policy with passkey authorization.",
+};
+
+function getStatus() {
+  return {
+    status: 200,
+    body: {
+      attached: policyState.attached,
+      mode: policyState.mode,
+      contractId: policyState.contractId,
+      recoveryOptions: policyState.attached
+        ? ["remove", "relax_to_trusted_publishers"]
+        : [],
+    },
+  };
+}
+
+function removePolicy(body) {
+  if (!body || body.authToken !== VALID_AUTH_TOKEN) {
+    return { status: 403, body: { removed: false, error: "passkey authorization required" } };
+  }
+  if (!policyState.attached) {
+    return { status: 200, body: { removed: false, reason: "no_policy_attached" } };
+  }
+
+  policyState = { attached: false, mode: null, contractId: null };
+  return { status: 200, body: { removed: true } };
+}
+
+function relaxPolicy(body) {
+  if (!body || body.authToken !== VALID_AUTH_TOKEN) {
+    return { status: 403, body: { relaxed: false, error: "passkey authorization required" } };
+  }
+  if (!policyState.attached) {
+    return { status: 200, body: { relaxed: false, reason: "no_policy_attached" } };
+  }
+  if (policyState.mode !== "strict") {
+    return {
+      status: 200,
+      body: { relaxed: false, reason: "already_not_strict", currentMode: policyState.mode },
+    };
+  }
+
+  policyState.mode = "trusted_publishers";
+  return { status: 200, body: { relaxed: true, mode: "trusted_publishers" } };
+}
+
+function getThreatModel() {
+  return { status: 200, body: THREAT_MODEL };
+}
+
+// Test helpers.
+export function setPolicyState(attached, mode = null, contractId = null) {
+  policyState = { attached, mode, contractId };
+}
+
+export function resetState() {
+  policyState = { attached: false, mode: null, contractId: null };
+}
+
+export function handleRequest(method, url, body) {
+  if (method === "GET" && url === "/recovery/status") return getStatus();
+  if (method === "POST" && url === "/recovery/remove") return removePolicy(body);
+  if (method === "POST" && url === "/recovery/relax") return relaxPolicy(body);
+  if (method === "GET" && url === "/recovery/threat-model") return getThreatModel();
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let bodyStr = "";
+    req.on("data", (c) => (bodyStr += c));
+    req.on("end", () => {
+      let parsed;
+      try {
+        if (bodyStr) parsed = JSON.parse(bodyStr);
+      } catch {}
+      const { status, body: resp } = handleRequest(req.method, req.url, parsed);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(resp));
+    });
+  });
+  const port = process.env.PORT || 4011;
+  server.listen(port, () => {
+    console.log(`recovery-path mock listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-11-recovery-path-suite/route.test.mjs
+++ b/contrib/routes/issue-11-recovery-path-suite/route.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { handleRequest, setPolicyState, resetState } from "./route.mjs";
+
+const VALID_TOKEN = "passkey-sig-valid";
+const INVALID_TOKEN = "wrong-token";
+
+// --- Tests: owner can always remove the policy ---
+
+// 1. Initial state — no policy attached
+resetState();
+let res = handleRequest("GET", "/recovery/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, false);
+assert.deepEqual(res.body.recoveryOptions, []);
+
+// 2. Attach a policy for testing
+setPolicyState(true, "strict", "CDEPLOYED123");
+res = handleRequest("GET", "/recovery/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, true);
+assert.equal(res.body.mode, "strict");
+assert.deepEqual(res.body.recoveryOptions, ["remove", "relax_to_trusted_publishers"]);
+
+// 3. Owner can remove the policy (passkey auth)
+res = handleRequest("POST", "/recovery/remove", { authToken: VALID_TOKEN });
+assert.equal(res.status, 200);
+assert.equal(res.body.removed, true);
+
+// 4. Policy is gone after removal
+res = handleRequest("GET", "/recovery/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, false);
+
+// 5. Unauthorized caller cannot remove the policy
+setPolicyState(true, "strict", "CDEPLOYED456");
+res = handleRequest("POST", "/recovery/remove", { authToken: INVALID_TOKEN });
+assert.equal(res.status, 403);
+assert.equal(res.body.removed, false);
+assert.ok(res.body.error.includes("passkey"));
+
+// 6. Policy still attached after unauthorized attempt
+res = handleRequest("GET", "/recovery/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, true);
+
+// 7. Removal without auth token is rejected
+res = handleRequest("POST", "/recovery/remove", {});
+assert.equal(res.status, 403);
+
+// 8. Removal when no policy is attached returns not-attached (not error)
+resetState();
+res = handleRequest("POST", "/recovery/remove", { authToken: VALID_TOKEN });
+assert.equal(res.status, 200);
+assert.equal(res.body.removed, false);
+assert.equal(res.body.reason, "no_policy_attached");
+
+// --- Tests: relaxation path ---
+
+// 9. Owner can relax strict → trusted_publishers
+setPolicyState(true, "strict", "CDEPLOYED789");
+res = handleRequest("POST", "/recovery/relax", { authToken: VALID_TOKEN });
+assert.equal(res.status, 200);
+assert.equal(res.body.relaxed, true);
+assert.equal(res.body.mode, "trusted_publishers");
+
+// 10. Mode is updated
+res = handleRequest("GET", "/recovery/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.mode, "trusted_publishers");
+
+// 11. Cannot relax when already not strict
+res = handleRequest("POST", "/recovery/relax", { authToken: VALID_TOKEN });
+assert.equal(res.status, 200);
+assert.equal(res.body.relaxed, false);
+assert.equal(res.body.reason, "already_not_strict");
+
+// 12. Unauthorized caller cannot relax
+setPolicyState(true, "strict", "CDEPLOYEDABC");
+res = handleRequest("POST", "/recovery/relax", { authToken: INVALID_TOKEN });
+assert.equal(res.status, 403);
+assert.equal(res.body.relaxed, false);
+
+// --- Tests: threat model ---
+
+// 13. Threat model is documented
+res = handleRequest("GET", "/recovery/threat-model");
+assert.equal(res.status, 200);
+assert.ok(res.body.summary.includes("session attacker"));
+assert.ok(res.body.attackerCapabilities.length > 0);
+assert.ok(res.body.ownerCapabilities.length > 0);
+assert.ok(res.body.removalGuarantee.includes("never rejected"));
+
+// 14. Removal is never blocked by the policy itself (the guarantee)
+// This is verified by the fact that removal only checks auth, not policy state.
+setPolicyState(true, "strict", "CDEPLOYEDXYZ");
+res = handleRequest("POST", "/recovery/remove", { authToken: VALID_TOKEN });
+assert.equal(res.status, 200);
+assert.equal(res.body.removed, true);
+
+// 15. 404 for unknown routes
+res = handleRequest("GET", "/unknown");
+assert.equal(res.status, 404);
+
+console.log("PASS: Issue 11 recovery path suite — all 15 assertions passed");

--- a/contrib/routes/issue-12-verified-only-e2e/README.md
+++ b/contrib/routes/issue-12-verified-only-e2e/README.md
@@ -1,0 +1,45 @@
+# Mock route: verified-only signing E2E suite (Issue #12 — B12)
+
+End-to-end mock route proving that a wallet with verified-only signing attached
+rejects an interaction with an unverified contract and permits one with a
+verified contract. Covers the recovery path from B11 at the UI level.
+
+This route combines the verification check (B4/B10), the recovery path (B11),
+and the trust settings (B9) into a single mock service that an e2e test can
+drive against. It follows the existing mocked pattern: no backend, no secrets,
+no funded account required.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/policy/status` | Returns whether verified-only signing is attached and mode. |
+| POST | `/policy/attach` | Attaches the verified-only policy (mock deploy + attach). |
+| POST | `/policy/remove` | Removes the policy (requires passkey auth). |
+| POST | `/transaction/check` | Given a target contract, checks if the transaction is allowed. |
+| GET | `/verification/:contractId` | Returns the verification status of a contract. |
+| GET | `/explainer/blocked` | Returns the honest blocked-transaction explainer copy. |
+| GET | `/recovery/threat-model` | Returns the documented threat model. |
+
+## Run
+
+```sh
+node route.mjs
+# verified-only e2e mock listening on http://localhost:4012
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## E2E scenario covered
+
+1. **Blocked path**: Policy attached, target contract unverified → transaction
+   rejected, explainer shown, user sees why and what to do next.
+2. **Allowed path**: Policy attached, target contract verified → transaction
+   proceeds to signing.
+3. **Recovery path (B11)**: Owner removes the policy with passkey auth →
+   policy removed, transactions no longer checked.
+4. **Unauthorized recovery**: Session attacker cannot remove the policy.

--- a/contrib/routes/issue-12-verified-only-e2e/route.mjs
+++ b/contrib/routes/issue-12-verified-only-e2e/route.mjs
@@ -1,0 +1,221 @@
+import http from "node:http";
+
+// Mock state for the verified-only signing E2E suite.
+let policyState = {
+  attached: false,
+  mode: null,
+  contractId: null,
+  attachedAt: null,
+};
+
+const verifiedContracts = new Set();
+const VALID_AUTH_TOKEN = "passkey-sig-valid";
+
+const BLOCKED_EXPLAINER = {
+  title: "Transaction blocked — target contract not verified",
+  body: `The target contract's published source has not been verified against the \
+deployed bytecode. Verification means the source you can read reproducibly \
+matches the code that runs on-chain — it does not mean the contract is \
+audited, benign, or safe to use.`,
+  action: `You can inspect the contract's verification status on the verification \
+explorer. If you are the contract author, submit the source for verification.`,
+  explorerLabel: "Open in verification explorer",
+};
+
+const THREAT_MODEL = {
+  summary:
+    "A session attacker (controls the browser session but not the passkey) " +
+    "can initiate transactions but cannot sign them. The verified-only policy " +
+    "adds an additional layer: even if a session is compromised, the policy " +
+    "rejects transactions to unverified contracts.",
+  attackerCapabilities: [
+    "Can view the wallet balance and transaction history.",
+    "Can initiate transactions in the UI.",
+    "Cannot sign transactions (passkey required).",
+    "Cannot remove or relax the verified-only policy (passkey required).",
+  ],
+  ownerCapabilities: [
+    "Can always remove the verified-only policy with passkey authorization.",
+    "The removal operation itself is never blocked by the policy.",
+    "Can relax the policy from strict to trusted_publishers mode.",
+  ],
+  removalGuarantee:
+    "The verified-only policy is designed so that the removal operation is " +
+    "never rejected by the policy itself. The account owner can always " +
+    "recover by removing the policy with passkey authorization.",
+};
+
+function getPolicyStatus() {
+  return {
+    status: 200,
+    body: {
+      attached: policyState.attached,
+      mode: policyState.mode,
+      contractId: policyState.contractId,
+      attachedAt: policyState.attachedAt,
+    },
+  };
+}
+
+function attachPolicy(body) {
+  if (!body || !body.registryAddress) {
+    return { status: 422, body: { error: "registryAddress is required" } };
+  }
+  if (!/^C[A-Z2-7]{55}$/.test(body.registryAddress)) {
+    return { status: 422, body: { error: "registryAddress must be a valid contract address" } };
+  }
+  const mode = body.enforcementMode ?? "strict";
+  if (!["strict", "trusted_publishers"].includes(mode)) {
+    return { status: 422, body: { error: "enforcementMode must be strict or trusted_publishers" } };
+  }
+
+  policyState = {
+    attached: true,
+    mode,
+    contractId: "C" + "1".repeat(55).slice(1),
+    attachedAt: new Date().toISOString(),
+  };
+
+  return {
+    status: 201,
+    body: { attached: true, mode, contractId: policyState.contractId },
+  };
+}
+
+function removePolicy(body) {
+  if (!body || body.authToken !== VALID_AUTH_TOKEN) {
+    return { status: 403, body: { removed: false, error: "passkey authorization required" } };
+  }
+  if (!policyState.attached) {
+    return { status: 200, body: { removed: false, reason: "no_policy_attached" } };
+  }
+
+  policyState = { attached: false, mode: null, contractId: null, attachedAt: null };
+  return { status: 200, body: { removed: true } };
+}
+
+function checkTransaction(body) {
+  if (!body || !body.targetContract) {
+    return { status: 422, body: { error: "targetContract is required" } };
+  }
+  if (!/^C[A-Z2-7]{55}$/.test(body.targetContract)) {
+    return { status: 422, body: { error: "targetContract must be a valid contract address" } };
+  }
+
+  // No policy → always allowed.
+  if (!policyState.attached) {
+    return { status: 200, body: { allowed: true, reason: null } };
+  }
+
+  // Policy attached → check verification status.
+  const isVerified = verifiedContracts.has(body.targetContract);
+  if (isVerified) {
+    return { status: 200, body: { allowed: true, reason: null } };
+  }
+
+  return {
+    status: 200,
+    body: {
+      allowed: false,
+      reason: "contract_not_verified",
+      explainer: {
+        ...BLOCKED_EXPLAINER,
+        explorerUrl: `/verify?contract=${body.targetContract}`,
+      },
+    },
+  };
+}
+
+function getVerification(contractId) {
+  if (!/^C[A-Z2-7]{55}$/.test(contractId)) {
+    return { status: 422, body: { error: "invalid contract address" } };
+  }
+  const isVerified = verifiedContracts.has(contractId);
+  return {
+    status: 200,
+    body: {
+      contractId,
+      status: isVerified ? "verified" : "unverified",
+      records: isVerified
+        ? [
+            {
+              id: "rec-1",
+              contractId,
+              sourceType: "repo",
+              repoUrl: "https://github.com/example/contract",
+              commitHash: "a1b2c3d",
+              toolchainVersion: "1.94.0",
+              outputHash: "0f6b858d".padEnd(64, "0"),
+              deployedHash: "0f6b858d".padEnd(64, "0"),
+              status: "verified",
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          ]
+        : [],
+    },
+  };
+}
+
+function getBlockedExplainer() {
+  return { status: 200, body: { explainer: BLOCKED_EXPLAINER } };
+}
+
+function getThreatModel() {
+  return { status: 200, body: THREAT_MODEL };
+}
+
+// Test helpers.
+export function registerVerified(contractId) {
+  verifiedContracts.add(contractId);
+}
+
+export function setPolicyState(attached, mode = null, contractId = null) {
+  policyState = {
+    attached,
+    mode,
+    contractId,
+    attachedAt: attached ? new Date().toISOString() : null,
+  };
+}
+
+export function resetState() {
+  policyState = { attached: false, mode: null, contractId: null, attachedAt: null };
+  verifiedContracts.clear();
+}
+
+export function handleRequest(method, url, body) {
+  if (method === "GET" && url === "/policy/status") return getPolicyStatus();
+  if (method === "POST" && url === "/policy/attach") return attachPolicy(body);
+  if (method === "POST" && url === "/policy/remove") return removePolicy(body);
+  if (method === "POST" && url === "/transaction/check") return checkTransaction(body);
+  if (method === "GET" && url === "/explainer/blocked") return getBlockedExplainer();
+  if (method === "GET" && url === "/recovery/threat-model") return getThreatModel();
+
+  // /verification/:contractId — extract contractId from URL
+  const verifyMatch = url.match(/^\/verification\/([A-Z2-7]{56})$/);
+  if (method === "GET" && verifyMatch) return getVerification(verifyMatch[1]);
+
+  return { status: 404, body: { error: "not_found" } };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let bodyStr = "";
+    req.on("data", (c) => (bodyStr += c));
+    req.on("end", () => {
+      let parsed;
+      try {
+        if (bodyStr) parsed = JSON.parse(bodyStr);
+      } catch {}
+      const { status, body: resp } = handleRequest(req.method, req.url, parsed);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(resp));
+    });
+  });
+  const port = process.env.PORT || 4012;
+  server.listen(port, () => {
+    console.log(`verified-only e2e mock listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-12-verified-only-e2e/route.test.mjs
+++ b/contrib/routes/issue-12-verified-only-e2e/route.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { handleRequest, registerVerified, setPolicyState, resetState } from "./route.mjs";
+
+const C1 = "CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67";
+const C2 = "CB" + "A".repeat(7) + "B".repeat(47);
+const VALID_TOKEN = "passkey-sig-valid";
+const INVALID_TOKEN = "wrong-token";
+
+// Verify fixtures match the contract regex
+assert.ok(/^C[A-Z2-7]{55}$/.test(C1), "C1 must be valid");
+assert.ok(/^C[A-Z2-7]{55}$/.test(C2), "C2 must be valid");
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 1: Blocked path — unverified contract → transaction rejected
+// ═══════════════════════════════════════════════════════════════════════════
+
+resetState();
+
+// 1. No policy attached → transaction allowed
+let res = handleRequest("POST", "/transaction/check", { targetContract: C1 });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+
+// 2. Attach the verified-only policy
+res = handleRequest("POST", "/policy/attach", {
+  registryAddress: C1,
+  enforcementMode: "strict",
+});
+assert.equal(res.status, 201);
+assert.equal(res.body.attached, true);
+assert.equal(res.body.mode, "strict");
+
+// 3. Policy is attached
+res = handleRequest("GET", "/policy/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, true);
+assert.equal(res.body.mode, "strict");
+
+// 4. Unverified contract → transaction BLOCKED
+res = handleRequest("POST", "/transaction/check", { targetContract: C2 });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+assert.equal(res.body.reason, "contract_not_verified");
+assert.ok(res.body.explainer.title.includes("blocked"));
+assert.ok(res.body.explainer.body.includes("does not mean"));
+assert.ok(res.body.explainer.explorerUrl.includes(C2));
+
+// 5. The blocked explainer endpoint returns honest copy
+res = handleRequest("GET", "/explainer/blocked");
+assert.equal(res.status, 200);
+assert.ok(!res.body.explainer.body.toLowerCase().includes("guaranteed safe"));
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 2: Allowed path — verified contract → transaction proceeds
+// ═══════════════════════════════════════════════════════════════════════════
+
+// 6. Register C1 as verified
+registerVerified(C1);
+
+// 7. Verified contract → transaction ALLOWED
+res = handleRequest("POST", "/transaction/check", { targetContract: C1 });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+assert.equal(res.body.reason, null);
+
+// 8. Verification endpoint shows verified status
+res = handleRequest("GET", `/verification/${C1}`);
+assert.equal(res.status, 200);
+assert.equal(res.body.status, "verified");
+assert.ok(res.body.records.length > 0);
+
+// 9. Unverified contract still blocked
+res = handleRequest("POST", "/transaction/check", { targetContract: C2 });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, false);
+
+// 10. Verification endpoint shows unverified status
+res = handleRequest("GET", `/verification/${C2}`);
+assert.equal(res.status, 200);
+assert.equal(res.body.status, "unverified");
+assert.equal(res.body.records.length, 0);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 3: Recovery path (B11) — owner removes the policy
+// ═══════════════════════════════════════════════════════════════════════════
+
+// 11. Unauthorized removal rejected
+res = handleRequest("POST", "/policy/remove", { authToken: INVALID_TOKEN });
+assert.equal(res.status, 403);
+assert.equal(res.body.removed, false);
+assert.ok(res.body.error.includes("passkey"));
+
+// 12. Policy still attached after unauthorized attempt
+res = handleRequest("GET", "/policy/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, true);
+
+// 13. Owner removes the policy with passkey auth
+res = handleRequest("POST", "/policy/remove", { authToken: VALID_TOKEN });
+assert.equal(res.status, 200);
+assert.equal(res.body.removed, true);
+
+// 14. Policy is gone
+res = handleRequest("GET", "/policy/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, false);
+
+// 15. Transactions no longer checked after policy removal
+res = handleRequest("POST", "/transaction/check", { targetContract: C2 });
+assert.equal(res.status, 200);
+assert.equal(res.body.allowed, true);
+assert.equal(res.body.reason, null);
+
+// 16. Threat model is documented
+res = handleRequest("GET", "/recovery/threat-model");
+assert.equal(res.status, 200);
+assert.ok(res.body.summary.includes("session attacker"));
+assert.ok(res.body.removalGuarantee.includes("never rejected"));
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 4: Edge cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+// 17. Attach with invalid address → 422
+res = handleRequest("POST", "/policy/attach", { registryAddress: "GINVALID" });
+assert.equal(res.status, 422);
+
+// 18. Check with missing targetContract → 422
+res = handleRequest("POST", "/transaction/check", {});
+assert.equal(res.status, 422);
+
+// 19. Remove when nothing attached
+resetState();
+res = handleRequest("POST", "/policy/remove", { authToken: VALID_TOKEN });
+assert.equal(res.status, 200);
+assert.equal(res.body.removed, false);
+
+// 20. 404 for unknown routes
+res = handleRequest("GET", "/unknown");
+assert.equal(res.status, 404);
+
+// 21. Attach with trusted_publishers mode
+res = handleRequest("POST", "/policy/attach", {
+  registryAddress: C1,
+  enforcementMode: "trusted_publishers",
+});
+assert.equal(res.status, 201);
+assert.equal(res.body.mode, "trusted_publishers");
+
+console.log("PASS: Issue 12 verified-only E2E suite — all 21 assertions passed");

--- a/contrib/routes/issue-9-trust-settings-suite/README.md
+++ b/contrib/routes/issue-9-trust-settings-suite/README.md
@@ -1,0 +1,59 @@
+# Mock route: trust settings suite (Issue #9 — B9)
+
+Simulates the trust settings screen for verified-only signing. Exposes endpoints
+to query the current policy attachment state, enforcement mode, and to trigger
+the attach/revoke flows that the UI calls.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/trust/status` | Returns whether a verified-only policy is attached and the enforcement mode. |
+| POST | `/trust/attach` | Simulates attaching a verified-only policy (requires `registryAddress` and optional `enforcementMode`). |
+| POST | `/trust/revoke` | Simulates removing the verified-only policy (requires passkey authorization token). |
+| GET | `/trust/descriptor` | Returns the honest enforcement description from the policy manifest. |
+
+## Run
+
+```sh
+node route.mjs
+# trust-settings mock listening on http://localhost:4009
+```
+
+## Test
+
+```sh
+node route.test.mjs
+```
+
+## Example — unattached state
+
+```
+GET /trust/status
+```
+
+```json
+{ "attached": false, "mode": null }
+```
+
+## Example — attach
+
+```
+POST /trust/attach
+{ "registryAddress": "CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67", "enforcementMode": "strict" }
+```
+
+```json
+{ "attached": true, "mode": "strict", "contractId": "CDEPLOYED..." }
+```
+
+## Example — revoke (owner only)
+
+```
+POST /trust/revoke
+{ "authToken": "passkey-sig-valid" }
+```
+
+```json
+{ "removed": true }
+```

--- a/contrib/routes/issue-9-trust-settings-suite/route.mjs
+++ b/contrib/routes/issue-9-trust-settings-suite/route.mjs
@@ -1,0 +1,137 @@
+import http from "node:http";
+
+// Mock state for the trust settings screen.
+let policyState = {
+  attached: false,
+  mode: null,
+  registryAddress: null,
+  contractId: null,
+  attachedAt: null,
+};
+
+const VALID_AUTH_TOKEN = "passkey-sig-valid";
+
+const ENFORCEMENT_DESCRIPTOR =
+  "This policy contract checks whether the target contract of each transaction " +
+  "is registered in the verified registry. Verification means the published source " +
+  "reproducibly matches the deployed bytecode — it does not mean the contract is " +
+  "audited, benign, or safe to use.";
+
+function getStatus() {
+  return {
+    status: 200,
+    body: {
+      attached: policyState.attached,
+      mode: policyState.mode,
+      contractId: policyState.contractId,
+      attachedAt: policyState.attachedAt,
+    },
+  };
+}
+
+function attach(body) {
+  if (!body || !body.registryAddress) {
+    return { status: 422, body: { error: "registryAddress is required" } };
+  }
+  if (!/^C[A-Z2-7]{55}$/.test(body.registryAddress)) {
+    return {
+      status: 422,
+      body: { error: "registryAddress must be a valid Stellar contract address (C…)" },
+    };
+  }
+  const mode = body.enforcementMode ?? "strict";
+  if (!["strict", "trusted_publishers"].includes(mode)) {
+    return { status: 422, body: { error: "enforcementMode must be strict or trusted_publishers" } };
+  }
+
+  policyState = {
+    attached: true,
+    mode,
+    registryAddress: body.registryAddress,
+    contractId: "C" + "A".repeat(55).slice(1),
+    attachedAt: new Date().toISOString(),
+  };
+
+  return {
+    status: 201,
+    body: {
+      attached: true,
+      mode,
+      contractId: policyState.contractId,
+      attachedAt: policyState.attachedAt,
+    },
+  };
+}
+
+function revoke(body) {
+  if (!body || body.authToken !== VALID_AUTH_TOKEN) {
+    return { status: 403, body: { error: "passkey authorization required" } };
+  }
+  if (!policyState.attached) {
+    return { status: 200, body: { removed: false, reason: "no_policy_attached" } };
+  }
+
+  policyState = {
+    attached: false,
+    mode: null,
+    registryAddress: null,
+    contractId: null,
+    attachedAt: null,
+  };
+
+  return { status: 200, body: { removed: true } };
+}
+
+function getDescriptor() {
+  return {
+    status: 200,
+    body: {
+      descriptor: ENFORCEMENT_DESCRIPTOR,
+      caveats: [
+        "Verification does not imply the contract is audited or safe.",
+        "A verified contract can still behave unexpectedly.",
+        "A verified contract is not audited, benign, or guaranteed safe.",
+      ],
+    },
+  };
+}
+
+export function handleRequest(method, url, body) {
+  if (method === "GET" && url === "/trust/status") return getStatus();
+  if (method === "POST" && url === "/trust/attach") return attach(body);
+  if (method === "POST" && url === "/trust/revoke") return revoke(body);
+  if (method === "GET" && url === "/trust/descriptor") return getDescriptor();
+  return { status: 404, body: { error: "not_found" } };
+}
+
+// Allow tests to reset state between runs.
+export function resetState() {
+  policyState = {
+    attached: false,
+    mode: null,
+    registryAddress: null,
+    contractId: null,
+    attachedAt: null,
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const server = http.createServer((req, res) => {
+    let bodyStr = "";
+    req.on("data", (c) => (bodyStr += c));
+    req.on("end", () => {
+      let parsed;
+      try {
+        if (bodyStr) parsed = JSON.parse(bodyStr);
+      } catch {}
+      const { status, body: resp } = handleRequest(req.method, req.url, parsed);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(resp));
+    });
+  });
+  const port = process.env.PORT || 4009;
+  server.listen(port, () => {
+    console.log(`trust-settings mock listening on http://localhost:${port}`);
+  });
+}

--- a/contrib/routes/issue-9-trust-settings-suite/route.test.mjs
+++ b/contrib/routes/issue-9-trust-settings-suite/route.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { handleRequest, resetState } from "./route.mjs";
+
+const C1 = "CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67";
+const G1 = "GCMCEGOUVALP2H6LTY7IPUUMSFKDQUMK3SDU5DI7LETNEZZKHRIIALKM";
+
+// 1. Initial state — no policy attached
+resetState();
+let res = handleRequest("GET", "/trust/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, false);
+assert.equal(res.body.mode, null);
+
+// 2. Attach with valid definition
+res = handleRequest("POST", "/trust/attach", {
+  registryAddress: C1,
+  enforcementMode: "strict",
+});
+assert.equal(res.status, 201);
+assert.equal(res.body.attached, true);
+assert.equal(res.body.mode, "strict");
+assert.ok(res.body.contractId.startsWith("C"));
+assert.ok(res.body.attachedAt);
+
+// 3. Status now shows attached
+res = handleRequest("GET", "/trust/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, true);
+assert.equal(res.body.mode, "strict");
+
+// 4. Attach rejected with invalid contract address (G… instead of C…)
+res = handleRequest("POST", "/trust/attach", {
+  registryAddress: G1,
+  enforcementMode: "strict",
+});
+assert.equal(res.status, 422);
+assert.ok(res.body.error.includes("Stellar contract address"));
+
+// 5. Attach rejected with invalid enforcement mode
+res = handleRequest("POST", "/trust/attach", {
+  registryAddress: C1,
+  enforcementMode: "invalid",
+});
+assert.equal(res.status, 422);
+assert.ok(res.body.error.includes("enforcementMode"));
+
+// 6. Attach rejected without registryAddress
+res = handleRequest("POST", "/trust/attach", {});
+assert.equal(res.status, 422);
+
+// 7. Revoke fails without auth token
+res = handleRequest("POST", "/trust/revoke", {});
+assert.equal(res.status, 403);
+assert.ok(res.body.error.includes("passkey"));
+
+// 8. Revoke succeeds with valid auth token
+res = handleRequest("POST", "/trust/revoke", { authToken: "passkey-sig-valid" });
+assert.equal(res.status, 200);
+assert.equal(res.body.removed, true);
+
+// 9. Status back to unattached
+res = handleRequest("GET", "/trust/status");
+assert.equal(res.status, 200);
+assert.equal(res.body.attached, false);
+
+// 10. Revoke when nothing attached
+res = handleRequest("POST", "/trust/revoke", { authToken: "passkey-sig-valid" });
+assert.equal(res.status, 200);
+assert.equal(res.body.removed, false);
+assert.equal(res.body.reason, "no_policy_attached");
+
+// 11. Revoke with wrong auth token
+res = handleRequest("POST", "/trust/revoke", { authToken: "wrong-token" });
+assert.equal(res.status, 403);
+
+// 12. Descriptor endpoint returns honest copy
+res = handleRequest("GET", "/trust/descriptor");
+assert.equal(res.status, 200);
+assert.ok(res.body.descriptor.includes("does not mean the contract is"));
+assert.ok(res.body.caveats.length > 0);
+assert.ok(res.body.caveats.some((c) => c.includes("audited")));
+
+// 13. 404 for unknown routes
+res = handleRequest("GET", "/unknown");
+assert.equal(res.status, 404);
+
+// 14. Attach with default mode (strict)
+resetState();
+res = handleRequest("POST", "/trust/attach", { registryAddress: C1 });
+assert.equal(res.status, 201);
+assert.equal(res.body.mode, "strict");
+
+// 15. Attach with trusted_publishers mode
+resetState();
+res = handleRequest("POST", "/trust/attach", {
+  registryAddress: C1,
+  enforcementMode: "trusted_publishers",
+});
+assert.equal(res.status, 201);
+assert.equal(res.body.mode, "trusted_publishers");
+
+console.log("PASS: Issue 9 trust settings suite — all 15 assertions passed");


### PR DESCRIPTION
Closes #9, Closes #10, Closes #11, Closes #12

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Summary

Adds mock route modules and tests for the verified-only signing feature covering four issues:

- **B9** (issue #9): Trust settings screen mock with attach, revoke, status, and descriptor endpoints
- **B10** (issue #10): Blocked transaction explainer mock with honest copy that never claims "verified means safe"
- **B11** (issue #11): Override and recovery path mock with owner removal, unauthorized rejection, and documented threat model
- **B12** (issue #12): End-to-end mock proving blocked path (unverified → rejected), allowed path (verified → proceeds), and recovery path (B11)

## Motivation / Context

All four issues are part of the verified-only signing feature (Feature B). Each route suite follows the existing `contrib/routes/` pattern with `README.md`, `route.mjs`, and `route.test.mjs` using `node:assert/strict`. All tests pass locally.

Closes #9, Closes #10, Closes #11, Closes #12