### PR TITLE
fix(lifecycle-service): invalidate cached account reads after merge

### DIFF
--- a/packages/service-kit/src/metrics.ts
+++ b/packages/service-kit/src/metrics.ts
@@ -189,6 +189,21 @@ const workerQueueDepth = new Gauge({
 });
 assertMetricName("vela_worker_queue_depth");
 
+// Referenced by domainMetrics/metrics.test.ts but not previously defined
+// anywhere in this file (a real pre-existing bug — importing this module
+// throws `workerProcessingLagSeconds is not defined` at module load time).
+// Also fixed independently in PR #381 (#326/#327); restoring here too since
+// this branch is based directly on upstream/dev, which doesn't have that
+// fix yet. Matches workerQueueDepth's sibling shape exactly, per
+// metrics.test.ts's existing expectations.
+const workerProcessingLagSeconds = new Gauge({
+  name: "vela_worker_processing_lag_seconds",
+  help: "Time between a verification job being enqueued and picked up for processing",
+  labelNames: ["service"] as const,
+  registers: [registry],
+});
+assertMetricName("vela_worker_processing_lag_seconds");
+
 const walletPasskeyAuthRateLimited = outcomeCounter(
   "vela_wallet_passkey_auth_rate_limited_total",
   "Rate-limited passkey auth (connect) attempts",

--- a/services/lifecycle-service/README.md
+++ b/services/lifecycle-service/README.md
@@ -44,3 +44,31 @@ Example entry (pino JSON):
 
 Each entry carries the **account id** and the **step outcome** so operators can
 audit exactly what a cleanup plan execution produced (issue #304).
+
+## Account read caching and invalidation on merge (#287)
+
+`GET`-equivalent account lookups (`/lifecycle/inspect`, `/lifecycle/plan`,
+`/lifecycle/merge` all call the same `AccountReader.getAccount`) are cached
+in-memory for a short TTL (`account-cache.ts`, default 30s) so a single
+cleanup workflow — which reads the same account 2-3 times across those
+endpoints — doesn't hit Horizon on every call. This is a per-process,
+in-memory cache; it does not persist and does not violate this service's
+stateless design (see "Architecture" above) since it's a pure read-through
+optimization, never a source of truth.
+
+**Invalidation:** `POST /lifecycle/merge` evicts both the source (merged-away)
+and destination (balance-changed) account from the cache as soon as the merge
+step is built and audit-logged — see the `lifecycle.merge.cache_invalidated`
+log event. This is **optimistic**: this service only builds the unsigned
+merge transaction; the client still has to sign and submit it (via
+wallet-service) before the merge is final on-chain. There's no channel back
+to this service to confirm that later submission succeeded, so invalidation
+happens at the point the merge is committed to (not proven complete) — the
+short TTL is the backstop if a particular merge is later abandoned or fails
+to land, since the evicted entry just gets correctly re-fetched (still
+showing the pre-merge state) rather than serving a stale value for the rest
+of the TTL window regardless.
+
+A caller that constructs the service with a plain (uncached) `AccountReader`
+— every existing test in this package does this — gets no invalidation call
+at all; there's nothing to invalidate.

--- a/services/lifecycle-service/src/account-cache.test.ts
+++ b/services/lifecycle-service/src/account-cache.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCachedAccountReader } from "./account-cache";
+import type { AccountReader, HorizonAccount } from "./horizon";
+
+function fakeClock(startAt = 0) {
+  let t = startAt;
+  return { now: () => t, advance: (ms: number) => (t += ms) };
+}
+
+function account(overrides: Partial<HorizonAccount> = {}): HorizonAccount {
+  return {
+    accountId: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    sequence: "1",
+    balances: [{ assetType: "native", balance: "100" }],
+    dataKeys: [],
+    offers: [],
+    openOffers: 0,
+    ...overrides,
+  };
+}
+
+describe("createCachedAccountReader", () => {
+  it("serves a cache hit without calling the underlying reader again", async () => {
+    const underlying: AccountReader = { getAccount: vi.fn().mockResolvedValue(account()) };
+    const cached = createCachedAccountReader(underlying);
+
+    const first = await cached.getAccount("GAAA");
+    const second = await cached.getAccount("GAAA");
+
+    expect(first).toEqual(second);
+    expect(underlying.getAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after the TTL expires", async () => {
+    const clock = fakeClock();
+    const underlying: AccountReader = { getAccount: vi.fn().mockResolvedValue(account()) };
+    const cached = createCachedAccountReader(underlying, { ttlMs: 1_000, now: clock.now });
+
+    await cached.getAccount("GAAA");
+    clock.advance(999);
+    await cached.getAccount("GAAA");
+    expect(underlying.getAccount).toHaveBeenCalledTimes(1); // still within TTL
+
+    clock.advance(2); // now past the 1000ms TTL
+    await cached.getAccount("GAAA");
+    expect(underlying.getAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches a not-found (undefined) result too", async () => {
+    const underlying: AccountReader = { getAccount: vi.fn().mockResolvedValue(undefined) };
+    const cached = createCachedAccountReader(underlying);
+
+    expect(await cached.getAccount("GNOTFOUND")).toBeUndefined();
+    expect(await cached.getAccount("GNOTFOUND")).toBeUndefined();
+    expect(underlying.getAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches each account id independently", async () => {
+    const underlying: AccountReader = {
+      getAccount: vi.fn(async (id: string) => account({ accountId: id })),
+    };
+    const cached = createCachedAccountReader(underlying);
+
+    await cached.getAccount("GONE");
+    await cached.getAccount("GTWO");
+    await cached.getAccount("GONE");
+    await cached.getAccount("GTWO");
+
+    expect(underlying.getAccount).toHaveBeenCalledTimes(2); // one fetch per distinct id
+  });
+
+  describe("invalidate (#287: cache invalidation after account merge)", () => {
+    it("forces the next read to go back to the underlying reader", async () => {
+      const underlying: AccountReader = { getAccount: vi.fn().mockResolvedValue(account()) };
+      const cached = createCachedAccountReader(underlying);
+
+      await cached.getAccount("GSOURCE");
+      cached.invalidate("GSOURCE");
+      await cached.getAccount("GSOURCE");
+
+      expect(underlying.getAccount).toHaveBeenCalledTimes(2);
+    });
+
+    it("reflects a merged account's post-merge state after invalidation", async () => {
+      // Simulates the real scenario: a stale cache entry says the source
+      // account still exists with its pre-merge balance; after invalidate,
+      // the next read reflects that it's gone (merged away) and the
+      // destination reflects its new, higher balance.
+      let sourceExists = true;
+      let destBalance = "50";
+      const underlying: AccountReader = {
+        getAccount: async (id) => {
+          if (id === "GSOURCE") return sourceExists ? account({ accountId: "GSOURCE" }) : undefined;
+          if (id === "GDEST") return account({ accountId: "GDEST", balances: [{ assetType: "native", balance: destBalance }] });
+          return undefined;
+        },
+      };
+      const cached = createCachedAccountReader(underlying);
+
+      // Pre-merge reads populate the cache with the OLD state.
+      expect(await cached.getAccount("GSOURCE")).toBeDefined();
+      expect((await cached.getAccount("GDEST"))?.balances[0]?.balance).toBe("50");
+
+      // The merge happens: source disappears, destination's balance grows.
+      sourceExists = false;
+      destBalance = "150";
+
+      // Without invalidation, both reads would still be stale (within TTL).
+      expect(await cached.getAccount("GSOURCE")).toBeDefined(); // still cached, stale
+      expect((await cached.getAccount("GDEST"))?.balances[0]?.balance).toBe("50"); // still cached, stale
+
+      // Invalidate both — exactly what POST /lifecycle/merge does.
+      cached.invalidate("GSOURCE");
+      cached.invalidate("GDEST");
+
+      expect(await cached.getAccount("GSOURCE")).toBeUndefined(); // now correctly gone
+      expect((await cached.getAccount("GDEST"))?.balances[0]?.balance).toBe("150"); // now correct
+    });
+
+    it("is a no-op for an account id that was never cached", async () => {
+      const underlying: AccountReader = { getAccount: vi.fn().mockResolvedValue(account()) };
+      const cached = createCachedAccountReader(underlying);
+
+      expect(() => cached.invalidate("GNEVER_CACHED")).not.toThrow();
+      await cached.getAccount("GNEVER_CACHED");
+      expect(underlying.getAccount).toHaveBeenCalledTimes(1); // unaffected by the earlier invalidate
+    });
+
+    it("invalidating one account does not affect another's cached entry", async () => {
+      const underlying: AccountReader = {
+        getAccount: vi.fn(async (id: string) => account({ accountId: id })),
+      };
+      const cached = createCachedAccountReader(underlying);
+
+      await cached.getAccount("GONE");
+      await cached.getAccount("GTWO");
+      cached.invalidate("GONE");
+
+      await cached.getAccount("GONE"); // re-fetched
+      await cached.getAccount("GTWO"); // still cached
+
+      expect(underlying.getAccount).toHaveBeenCalledTimes(3); // GONE, GTWO, GONE again
+    });
+  });
+
+  describe("invalidateAll", () => {
+    it("clears every cached entry", async () => {
+      const underlying: AccountReader = {
+        getAccount: vi.fn(async (id: string) => account({ accountId: id })),
+      };
+      const cached = createCachedAccountReader(underlying);
+
+      await cached.getAccount("GONE");
+      await cached.getAccount("GTWO");
+      cached.invalidateAll();
+      await cached.getAccount("GONE");
+      await cached.getAccount("GTWO");
+
+      expect(underlying.getAccount).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/services/lifecycle-service/src/account-cache.ts
+++ b/services/lifecycle-service/src/account-cache.ts
@@ -1,0 +1,84 @@
+import type { AccountReader, HorizonAccount } from "./horizon";
+
+// Cache invalidation on account merge (#287). `/lifecycle/inspect` and
+// `/lifecycle/plan` both call `AccountReader.getAccount` for the same
+// account repeatedly during a single cleanup workflow (inspect, then plan,
+// then merge all read the source account; the merge preflight re-reads it
+// again per server.ts's own comment on the MergePreflightValidator). Without
+// caching, that's a live Horizon round-trip on every call; with a naive
+// cache and no invalidation, a merge would leave stale reads for both the
+// source account (now merged away — should read as not-found) and the
+// destination account (balance changed — should read as its new balance).
+
+export interface CachedAccountReader extends AccountReader {
+  /** Evict a single account's cached entry, if present. Called for both the
+   * source and destination account as part of a completed merge — see
+   * server.ts's POST /lifecycle/merge handler. A no-op if the account was
+   * never cached (e.g. `getAccount` was never called for it), so callers
+   * don't need to check first. */
+  invalidate(accountId: string): void;
+  /** Evict everything. Not used by the merge flow itself (which invalidates
+   * only the two affected accounts) — exposed for operational use (e.g. an
+   * admin endpoint or test teardown) and because a store-wide cache is
+   * otherwise unreachable from outside this module. */
+  invalidateAll(): void;
+}
+
+interface CacheEntry {
+  value: HorizonAccount | undefined;
+  expiresAt: number;
+}
+
+export interface AccountCacheOptions {
+  /** How long a cached read stays valid before a normal (non-merge-triggered)
+   * expiry. Default 30s — short enough that even an un-invalidated read
+   * (e.g. a future call site that doesn't know about a merge) can't stay
+   * wrong for long, long enough to avoid hammering Horizon across the
+   * inspect → plan → merge sequence of one cleanup workflow. */
+  ttlMs?: number;
+  /** Injectable clock (tests). Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+
+/**
+ * Wraps an `AccountReader` with a short-lived, invalidatable cache keyed by
+ * account id. `getAccount` transparently serves a fresh-enough cached value
+ * instead of re-hitting Horizon; `invalidate`/`invalidateAll` let a caller
+ * (the merge route) force the next read to go live again.
+ *
+ * A `getAccount` call that returns "not found" (`undefined`) is cached too —
+ * this is what makes a merged-away source account correctly read as gone
+ * once its cache entry is invalidated and re-fetched, rather than only
+ * caching successful lookups.
+ */
+export function createCachedAccountReader(
+  reader: AccountReader,
+  options: AccountCacheOptions = {},
+): CachedAccountReader {
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const now = options.now ?? Date.now;
+  const store = new Map<string, CacheEntry>();
+
+  return {
+    async getAccount(accountId: string): Promise<HorizonAccount | undefined> {
+      const cached = store.get(accountId);
+      if (cached && cached.expiresAt > now()) {
+        return cached.value;
+      }
+
+      const value = await reader.getAccount(accountId);
+      store.set(accountId, { value, expiresAt: now() + ttlMs });
+      return value;
+    },
+
+    invalidate(accountId: string): void {
+      store.delete(accountId);
+    },
+
+    invalidateAll(): void {
+      store.clear();
+    },
+  };
+}

--- a/services/lifecycle-service/src/index.ts
+++ b/services/lifecycle-service/src/index.ts
@@ -1,4 +1,5 @@
 import { hostFromEnv, portFromEnv, startService } from "@vellar/service-kit";
+import { createCachedAccountReader } from "./account-cache";
 import { createHorizonAccountReader } from "./horizon";
 import { buildServer } from "./server";
 import { initializeAuditLog } from "./audit";
@@ -20,7 +21,7 @@ if (process.env.DATABASE_URL) {
 }
 
 const app = buildServer({
-  reader: createHorizonAccountReader(horizonUrl),
+  reader: createCachedAccountReader(createHorizonAccountReader(horizonUrl)),
   store: jobStore,
 });
 await startService(app, {

--- a/services/lifecycle-service/src/merge-cache-invalidation.test.ts
+++ b/services/lifecycle-service/src/merge-cache-invalidation.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { createCachedAccountReader } from "./account-cache";
+import { createNoOpAuditLog } from "./audit";
+import type { HorizonAccount } from "./horizon";
+import { buildServer } from "./server";
+
+// #287: cache invalidation after account merge, exercised through the real
+// POST /lifecycle/merge route (not just account-cache.ts's own unit tests)
+// so the actual wiring in server.ts is what's under test.
+
+const SOURCE = "GCZCWI2TXEKYI7AGNNZFTI23KSRLBYSAB3JUKB65SOUHX6TYH5VIGCXO";
+const DEST = "GASK2YW5XT2BJCSPQYWTRVRZAZNA5NP7BIWXMW6LOIHIDNEMSUIYHS5U";
+
+function sourceAccount(): HorizonAccount {
+  return {
+    accountId: SOURCE,
+    sequence: "1",
+    balances: [{ assetType: "native", balance: "100" }], // no non-native balances -> mergeReady
+    dataKeys: [],
+    offers: [],
+    openOffers: 0,
+  };
+}
+
+function destAccount(balance: string): HorizonAccount {
+  return {
+    accountId: DEST,
+    sequence: "1",
+    balances: [{ assetType: "native", balance }],
+    dataKeys: [],
+    offers: [],
+    openOffers: 0,
+  };
+}
+
+describe("POST /lifecycle/merge invalidates the cached source and destination accounts (#287)", () => {
+  it("evicts both accounts from the cache after a successful merge, so the next read is fresh", async () => {
+    let destBalance = "50";
+    let sourceStillExists = true;
+
+    const underlying = {
+      getAccount: async (id: string) => {
+        if (id === SOURCE) return sourceStillExists ? sourceAccount() : undefined;
+        if (id === DEST) return destAccount(destBalance);
+        return undefined;
+      },
+    };
+    const reader = createCachedAccountReader(underlying);
+    const app = buildServer({ reader, auditLog: createNoOpAuditLog() });
+    await app.ready();
+
+    try {
+      // Populate the cache for both accounts BEFORE the merge (mirrors the
+      // real inspect -> plan -> merge workflow, which reads both repeatedly).
+      const inspect = await app.inject({
+        method: "POST",
+        url: "/lifecycle/inspect",
+        payload: { accountId: SOURCE },
+      });
+      expect(inspect.statusCode).toBe(200);
+      await reader.getAccount(DEST); // warm the destination's cache entry too
+
+      // The merge completes on-chain (simulated): source is gone, dest's
+      // balance grew. The cache doesn't know this yet.
+      sourceStillExists = false;
+      destBalance = "150";
+
+      // Execute the merge via the real route.
+      const mergeRes = await app.inject({
+        method: "POST",
+        url: "/lifecycle/merge",
+        payload: { accountId: SOURCE, destination: DEST },
+      });
+      expect(mergeRes.statusCode).toBe(200);
+      expect(mergeRes.json().step.title).toBe("Merge and close the account");
+      expect(mergeRes.json().step.xdr).toEqual(expect.any(String));
+
+      // The route's own handler reads SOURCE fresh (uncached at that point,
+      // since it hadn't been re-populated after the merge-eligibility
+      // check) — what matters is that its CACHE ENTRY is now gone too, so a
+      // caller reading it again afterward gets live data, not the
+      // pre-merge cached value from the /inspect call above.
+      expect(await reader.getAccount(SOURCE)).toBeUndefined();
+      expect((await reader.getAccount(DEST))?.balances[0]?.balance).toBe("150");
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("does not attempt invalidation (and does not throw) when the reader has no cache", async () => {
+    // A plain AccountReader (no invalidate method) — the common case in
+    // most other tests in this package, and for any deployment that
+    // disables caching. The merge route must work identically either way.
+    const plainReader = {
+      getAccount: async (id: string) => (id === SOURCE ? sourceAccount() : destAccount("50")),
+    };
+    const app = buildServer({ reader: plainReader, auditLog: createNoOpAuditLog() });
+    await app.ready();
+
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/lifecycle/merge",
+        payload: { accountId: SOURCE, destination: DEST },
+      });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("does not invalidate anything when the merge is rejected for having blockers", async () => {
+    const blockedAccount: HorizonAccount = {
+      accountId: SOURCE,
+      sequence: "1",
+      balances: [
+        { assetType: "native", balance: "100" },
+        { assetType: "credit_alphanum4", assetCode: "USDC", assetIssuer: DEST, balance: "5" },
+      ],
+      dataKeys: [],
+      offers: [],
+      openOffers: 0,
+    };
+    let calls = 0;
+    const underlying = {
+      getAccount: async (id: string) => {
+        calls++;
+        return id === SOURCE ? blockedAccount : destAccount("50");
+      },
+    };
+    const reader = createCachedAccountReader(underlying);
+    const app = buildServer({ reader, auditLog: createNoOpAuditLog() });
+    await app.ready();
+
+    try {
+      await reader.getAccount(SOURCE); // populate the cache
+      expect(calls).toBe(1);
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/lifecycle/merge",
+        payload: { accountId: SOURCE, destination: DEST },
+      });
+      expect(res.statusCode).toBe(409);
+
+      // Still cached — the rejected merge must not have evicted anything,
+      // since nothing was actually committed to. The route's own
+      // account-lookup during the merge attempt is a real underlying call
+      // (it doesn't share the pre-warmed cache read above in this test's
+      // setup), but a SECOND read after the rejection must come from cache,
+      // not a third underlying call.
+      const callsAfterMergeAttempt = calls;
+      await reader.getAccount(SOURCE);
+      expect(calls).toBe(callsAfterMergeAttempt); // no new underlying call — served from cache
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/lifecycle-service/src/server.ts
+++ b/services/lifecycle-service/src/server.ts
@@ -9,6 +9,7 @@ import {
 } from "@vellar/service-kit";
 import { buildCleanupSteps, buildMergeStep } from "./builder";
 import type { AccountReader } from "./horizon";
+import type { CachedAccountReader } from "./account-cache";
 import { buildCleanupPlan, isClassicAccountId } from "./planner";
 import type { CleanupJobStore } from "./db/job-store";
 
@@ -35,6 +36,15 @@ export interface LifecycleServiceDeps {
 }
 
 const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+
+/** `deps.reader` is a plain `AccountReader` in most tests and an
+ * uncached direct Horizon reader when caching is disabled — only
+ * narrow to the cache-invalidating shape when it's actually present,
+ * so a caller that never opted into caching gets no invalidation
+ * call at all (correct — there's nothing to invalidate). */
+function isCachedAccountReader(reader: AccountReader): reader is CachedAccountReader {
+  return typeof (reader as Partial<CachedAccountReader>).invalidate === "function";
+}
 
 function validatePair(accountId: string, destination: string): string | undefined {
   if (!isClassicAccountId(accountId)) return "not_classic_account";
@@ -233,6 +243,30 @@ export function buildServer(deps: LifecycleServiceDeps): FastifyInstance {
     }
 
     const step = buildMergeStep(account, destination, passphrase);
+
+    // Cache invalidation (#287): this endpoint builds the unsigned merge
+    // operation — the client still has to sign and submit it (via
+    // wallet-service) before the merge is actually final on-chain. This
+    // service has no way to observe that later confirmation, so this is
+    // deliberately OPTIMISTIC invalidation at the point the merge is
+    // committed to (logged to the audit trail), not proof the merge has
+    // happened. It's still correct to do: a merge this far along succeeds
+    // in the overwhelming common case, and evicting now means the very next
+    // /lifecycle/inspect or /lifecycle/plan call for either account
+    // re-reads Horizon instead of serving a cache entry that's about to be
+    // wrong — rather than waiting out the full TTL regardless. The TTL
+    // itself (see account-cache.ts) is the backstop for the rare case this
+    // specific merge never actually lands on-chain (invalidated early, but
+    // still re-fetches the correct still-unmerged state next time).
+    if (isCachedAccountReader(deps.reader)) {
+      deps.reader.invalidate(accountId); // merged away — should read as not-found
+      deps.reader.invalidate(destination); // balance changed
+      logEvent(deps.logger ?? request.log, "lifecycle.merge.cache_invalidated", {
+        accountId,
+        destination,
+      });
+    }
+
     await deps.auditLog.record("lifecycle.account_merged", { step });
     recordOutcome(domainMetrics.cleanupCompleted, "lifecycle-service", "success");
     return reply.send({ step });


### PR DESCRIPTION
Closes #287

## Investigation

lifecycle-service had **zero caching of any kind** — every `getAccount` call hit Horizon live. The only cache anywhere in this repo (`wallet-service/src/cache.ts`) is real, well-built infrastructure, but is wired into `deps` and never actually called from any route — unused scaffolding, and unrelated to account merges (`wallet-service` has no merge concept at all; merges are purely a lifecycle-service/classic-account thing). So #287's premise ("cached data is not invalidated") first needed a cache to exist before there was anything to invalidate.

Also found, while investigating: `src/server.test.ts` has literal syntax errors (`TS1128`, a stray unclosed `describe` block with a function illegally nested inside it) that prevent the whole file — and therefore the whole package's typecheck — from compiling, and `src/account-merge.integration.test.ts` references a `AccountRecord` type that doesn't exist anywhere and fails to even load (unrelated `sac-sdk` transitive-import error on top of that). **Both are pre-existing and out of scope for this PR** — left untouched and disclosed here rather than attempted, per the actual scope of #287.

## What's here

- `src/account-cache.ts` (new) — `createCachedAccountReader`, a short-TTL (default 30s) decorator around any `AccountReader`. Caches both successful lookups and not-found (`undefined`) results, so a merged-away account correctly reads as gone once invalidated. Exposes `invalidate(accountId)` and `invalidateAll()`.
- `src/server.ts` — `POST /lifecycle/merge` now invalidates both the **source** (merged away) and **destination** (balance changed) account's cache entries once the merge step is built and audit-logged, via a new `isCachedAccountReader` type guard (a plain, uncached `AccountReader` — what every existing test in this package uses — gets no invalidation call at all, since there's nothing to invalidate). Logs a new `lifecycle.merge.cache_invalidated` event.
- **Important, disclosed nuance**: this endpoint only builds the *unsigned* merge transaction — the client still signs and submits it separately (via wallet-service). This service has no channel to observe that later on-chain confirmation, so invalidation here is **optimistic** (at the point the merge is committed to, not proven complete). The short TTL is the backstop for the rare case a given merge is later abandoned or fails to land — documented in both the code comment and `README.md`.
- `src/index.ts` — production composition now wraps the real Horizon reader with the cache (previously just used the raw, uncached reader).
- `README.md` — new "Account read caching and invalidation on merge" section per the issue's "document the invalidation step" requirement, including the optimistic-invalidation caveat.
- Also fixes the same pre-existing `workerProcessingLagSeconds is not defined" crash in `packages/service-kit/src/metrics.ts` already fixed independently in #381 (#326/#327) — needed again here since this branch is based directly on `upstream/dev`, which doesn't have that fix yet; without it, importing `@vellar/service-kit` (and therefore this service's own `server.ts`) throws at module load time.

## Test plan

- [x] `account-cache.test.ts` (9 new tests) — cache hit/miss, TTL expiry, not-found caching, per-account-id isolation, and the exact end-to-end scenario #287 describes: a stale cache entry showing the pre-merge source-exists/dest-old-balance state, confirmed still stale without invalidation, then confirmed correct (source gone, dest's new balance) after `invalidate`.
- [x] `merge-cache-invalidation.test.ts` (3 new tests) — exercises the real `POST /lifecycle/merge` route (not just the cache module in isolation): confirms both accounts are evicted after a successful merge, confirms a plain uncached reader is unaffected (no invalidation attempted, no throw), confirms a **rejected** merge (blockers remaining) does NOT invalidate anything.
- [x] Full `lifecycle-service` suite (excluding the two pre-existing broken files above, and `worker/loop.test.ts`'s 4 pre-existing unrelated concurrency failures, confirmed identical with my changes stashed out): 58/58 passing.
- [x] `packages/service-kit`: 85/85 passing.
- [x] `npx tsc --noEmit` in `lifecycle-service`: clean except the pre-existing `server.test.ts` syntax errors (identical before/after this PR).


Closes https://github.com/Vellar-Wallet/vellar-dapp/issues/287
