### PR TITLE
test(e2e): reconnect after session expiry with data-loss verification

### DIFF
--- a/apps/web/e2e/wallet.spec.ts
+++ b/apps/web/e2e/wallet.spec.ts
@@ -4,14 +4,12 @@ import { fundSmartWallet } from "./fund";
 // The critical e2e scenarios from idea.md §15, against LIVE testnet with a
 // virtual platform authenticator standing in for Touch ID:
 //   create wallet with passkey -> fund -> sign and submit payment -> reconnect.
+//
+// idea.md itself is not present anywhere in this repository as of writing —
+// referenced here only because these existing spec files already cite it by
+// section number; §15's exact wording could not be independently verified.
 
-test("passkey wallet: create, fund, pay, reconnect (live testnet)", async ({ page, context }) => {
-  // Browser-side failures are the most valuable diagnostic in live e2e runs.
-  page.on("console", (msg) => {
-    if (msg.type() === "error") console.log("[browser]", msg.text());
-  });
-  page.on("pageerror", (err) => console.log("[pageerror]", err.message));
-
+async function enableVirtualAuthenticator(context: import("@playwright/test").BrowserContext, page: import("@playwright/test").Page) {
   const cdp = await context.newCDPSession(page);
   await cdp.send("WebAuthn.enable");
   await cdp.send("WebAuthn.addVirtualAuthenticator", {
@@ -24,6 +22,16 @@ test("passkey wallet: create, fund, pay, reconnect (live testnet)", async ({ pag
       automaticPresenceSimulation: true,
     },
   });
+}
+
+test("passkey wallet: create, fund, pay, reconnect (live testnet)", async ({ page, context }) => {
+  // Browser-side failures are the most valuable diagnostic in live e2e runs.
+  page.on("console", (msg) => {
+    if (msg.type() === "error") console.log("[browser]", msg.text());
+  });
+  page.on("pageerror", (err) => console.log("[pageerror]", err.message));
+
+  await enableVirtualAuthenticator(context, page);
 
   // --- Create wallet with passkey (deploys the smart account via relayer) ---
   await page.goto("/app");
@@ -70,4 +78,94 @@ test("passkey wallet: create, fund, pay, reconnect (live testnet)", async ({ pag
   await expect(page).toHaveURL(/\/dashboard/, { timeout: 60_000 });
   await page.getByRole("button", { name: "Receive" }).click();
   await expect(page.locator("p.mono", { hasText: contractId })).toBeVisible({ timeout: 30_000 });
+});
+
+// #321: reconnect after session expiry, with a data-loss check the existing
+// "create, fund, pay, reconnect" scenario above does not make (it only
+// re-checks the contract id).
+//
+// IMPORTANT SCOPE NOTE, disclosed rather than silently assumed: this repo
+// has no client-side session-expiry DETECTION today — `WalletSession` (see
+// `@vellar/types`) carries no `expiresAt`, `wallet-context.tsx` never checks
+// for a 401 and never auto-prompts a reconnect, and the server-side 7-day
+// sliding-window expiry (`wallet-service/src/server.ts`'s
+// `SESSION_TTL_MS`/`resolveSessionCapability`) is only exercised by that
+// service's own unit tests (`server.test.ts`'s "an EXPIRED session bearer is
+// treated as ABSENT" case), never surfaced to the UI. There is therefore no
+// UI behavior today that specifically distinguishes "your session expired,
+// please sign in again" from a manual disconnect — both currently look
+// identical to a user: the app has no persisted session, and the ONLY path
+// back in either case is the same manual "Sign in" flow the scenario above
+// already exercises.
+//
+// What THIS test adds on top of that: it treats the manual reconnect
+// trigger as standing in for an expired session (the only trigger the app
+// actually implements), and — unlike the existing scenario — verifies the
+// "regains access without data loss" half of #321's acceptance criteria
+// concretely: the balance carries over, and a genuinely NEW server-side
+// session is established (visible as a fresh "This device" entry in
+// Settings), not a reused/rehydrated stale one.
+test("reconnect after a lost session regains access with no data loss (live testnet)", async ({
+  page,
+  context,
+}) => {
+  page.on("console", (msg) => {
+    if (msg.type() === "error") console.log("[browser]", msg.text());
+  });
+  page.on("pageerror", (err) => console.log("[pageerror]", err.message));
+
+  await enableVirtualAuthenticator(context, page);
+
+  // --- Create and fund a wallet ---
+  await page.goto("/app");
+  await page.getByLabel(/wallet name/i).fill("e2e reconnect user");
+  await page.getByRole("button", { name: "Create wallet" }).click();
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 120_000 });
+
+  await page.getByRole("button", { name: "Receive" }).click();
+  const addressLocator = page.locator("p.mono", { hasText: /^C[A-Z2-7]{55}$/ }).first();
+  await expect(addressLocator).toBeVisible({ timeout: 30_000 });
+  const contractId = (await addressLocator.textContent())!.trim();
+  await page.getByRole("button", { name: "Close" }).click();
+
+  const balanceHero = page.locator(".bal");
+  const funder = await fundSmartWallet(contractId, 10n);
+  await page.reload();
+  await expect(balanceHero).toContainText("10", { timeout: 60_000 });
+  void funder; // funded for balance state only; no payment needed in this scenario
+
+  // Record the ORIGINAL session before it's lost, via Settings' session list
+  // (the same page reconnect verification checks afterward) — "This device"
+  // marks whichever session the currently-loaded page is using.
+  await page.goto("/settings");
+  const sessionEntries = page.locator("li", { hasText: "This device" });
+  await expect(sessionEntries).toHaveCount(1, { timeout: 30_000 });
+  const originalSessionText = await sessionEntries.first().textContent();
+
+  // --- Lose the session (standing in for expiry — see the scope note above) ---
+  await page.goto("/dashboard");
+  await page.getByRole("button", { name: "Disconnect" }).click();
+  await expect(page.getByRole("button", { name: "Create wallet" })).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // --- Reconnect with the same passkey ---
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 60_000 });
+
+  // No data loss: same account, same balance — nothing was reset or re-created.
+  await page.getByRole("button", { name: "Receive" }).click();
+  await expect(page.locator("p.mono", { hasText: contractId })).toBeVisible({ timeout: 30_000 });
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(balanceHero).toContainText("10", { timeout: 60_000 });
+
+  // Access is via a genuinely NEW session, not a stale rehydrated one: the
+  // old session's audit/session record is gone from "current", and a fresh
+  // one has taken its place. (The revoked/former session may still be
+  // listed as a past — non-"This device" — entry; this only asserts the
+  // CURRENT one changed, matching what a user could actually observe.)
+  await page.goto("/settings");
+  await expect(sessionEntries).toHaveCount(1, { timeout: 30_000 });
+  const newSessionText = await sessionEntries.first().textContent();
+  expect(newSessionText).not.toBe(originalSessionText);
 });


### PR DESCRIPTION
Closes #321

## Important scope disclosure — read before reviewing

This repo has **no client-side session-expiry detection today**:
- `WalletSession` (`@vellar/types`) carries no `expiresAt` field.
- `apps/web/lib/wallet-context.tsx` never checks for a 401 and never auto-triggers a reconnect prompt.
- The server-side 7-day sliding-window expiry (`services/wallet-service/src/server.ts`'s `SESSION_TTL_MS`/`resolveSessionCapability`) is exercised only by that service's own existing unit test (`server.test.ts`: "an EXPIRED session bearer is treated as ABSENT") — it is never surfaced to the UI.
- `idea.md` (referenced by `wallet.spec.ts`'s own existing comment, "§15") does not exist anywhere in this repository as of writing — could not verify the scenario's exact original wording.
- The extension has **no analogous session-expiry concept at all** to reconnect from — its persisted state (`apps/extension/lib/state.ts`'s `PairedWallet`) is a pairing (address/network/RPC/origin) that never expires on its own; the closest thing, the device signer's own 7-day expiry (`signer-expiration.ts`), is an on-chain signing-authority bound enforced by the contract, not a UI flow. There is nothing there to write a meaningful "extension reconnect" test against, so I did not fabricate one — flagging this explicitly rather than silently skipping the extension half of the issue's ask.

Given that, there is currently no UI behavior that distinguishes "your session expired" from a manual disconnect — both look identical to a user (no persisted session; "Sign in" is the only way back). This PR's new test therefore uses the same trigger the existing "create, fund, pay, reconnect" scenario already uses (manual disconnect, the only reconnect trigger the app actually implements) as the stand-in for expiry, and focuses its actual new value on the part of #321's acceptance criteria the existing test does NOT check: **verifying no data loss** across reconnect.

## What's here

- `apps/web/e2e/wallet.spec.ts`:
  - Extracted the repeated CDP virtual-authenticator setup into a shared `enableVirtualAuthenticator` helper (used by both the pre-existing test and the new one — was duplicated inline before).
  - New test: **"reconnect after a lost session regains access with no data loss (live testnet)"**. Creates and funds a wallet, records the current server-side session via the Settings page's "This device" entry, disconnects, reconnects with the same passkey, then verifies: (a) same contract id, (b) balance unchanged (10 XLM, not reset), (c) a genuinely **new** server-side session is now current (the Settings "This device" entry's text changed) — proving access was actually re-established via a fresh session, not a stale rehydrated one.

## Why this couldn't be executed here

Per `playwright.config.ts`'s own comment, this suite requires `api-gateway` (:4000) and `wallet-service` (:4001) running with real relayer + Postgres config, against live Stellar testnet with real friendbot funding. None of that infrastructure is available in this environment. Verified as much as is possible without it:

- [x] `npx playwright test --list` — both tests parse and are discovered correctly (2 tests in 1 file), confirming no syntax/structural errors.
- [x] `npx tsc --noEmit` in `apps/web` — 20 errors, byte-identical before and after this change (confirmed via a stash/restore diff) — zero new errors introduced. All 20 are pre-existing and unrelated (a `WalletSession.contractId`/`sessionId` mismatch in `dashboard/page.tsx`, strict-null issues in `analytics.test.ts`, and the `workerProcessingLagSeconds is not defined` bug in `packages/service-kit` already flagged and fixed independently in #381/#384).

I was not able to run this against real testnet infrastructure — flagging clearly so a reviewer with that environment available can do a real run before relying on this test in CI.

Closes https://github.com/Vellar-Wallet/vellar-dapp/issues/321
