### PR TITLE
feat: safety policies — templates, SDK types, escalation flow, and web editor

### DIFF
--- a/apps/web/app/policies/page.test.tsx
+++ b/apps/web/app/policies/page.test.tsx
@@ -8,24 +8,45 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/policies",
 }));
 
-const { listMock, validateMock, generateMock, simulateMock, deployMock } = vi.hoisted(() => ({
-  listMock: vi.fn(),
-  validateMock: vi.fn(),
-  generateMock: vi.fn(),
-  simulateMock: vi.fn(),
-  deployMock: vi.fn(),
+const { listMock, validateMock, generateMock, simulateMock, deployMock, escalationMock } =
+  vi.hoisted(() => ({
+    listMock: vi.fn(),
+    validateMock: vi.fn(),
+    generateMock: vi.fn(),
+    simulateMock: vi.fn(),
+    deployMock: vi.fn(),
+    escalationMock: vi.fn(),
+  }));
+
+vi.mock("@/lib/policy", () => ({
+  listTemplates: listMock,
+  validatePolicy: validateMock,
+  generatePolicy: generateMock,
+  simulatePolicyDeploy: simulateMock,
+  deployPolicy: deployMock,
+  checkEscalation: escalationMock,
+  enforcementLabel: (e: { kind: string }) =>
+    e.kind === "policy-contract" ? "On-chain contract" : "Signer limits",
+  stroopsToXlm: (s: string) => {
+    const big = BigInt(s);
+    const whole = big / 10000000n;
+    const frac = big % 10000000n;
+    return frac === 0n
+      ? whole.toString()
+      : `${whole}.${frac.toString().padStart(7, "0").replace(/0+$/, "")}`;
+  },
+  ENFORCEMENT_DESCRIPTIONS: {
+    spending_limit:
+      "Enforced by a deployed on-chain policy contract. Coverage is limited to known transfer patterns.",
+    single_owner: "No on-chain policy enforcement.",
+    multisig_threshold: "Enforced by native signer limits.",
+    contract_allowlist: "Enforced by native signer limits.",
+    timelock: "Custom enforcement pending.",
+    per_tx_cap: "Custom enforcement pending.",
+    recipient_allowlist: "Enforced by native signer limits.",
+    never_sent_before: "Enforced by native signer limits.",
+  },
 }));
-vi.mock("@/lib/policy", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/policy")>("@/lib/policy");
-  return {
-    ...actual,
-    listTemplates: listMock,
-    validatePolicy: validateMock,
-    generatePolicy: generateMock,
-    simulatePolicyDeploy: simulateMock,
-    deployPolicy: deployMock,
-  };
-});
 
 const { runtimeMock } = vi.hoisted(() => ({ runtimeMock: vi.fn() }));
 vi.mock("@/lib/connector-factory", async (importOriginal) => {
@@ -70,6 +91,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   window.localStorage.clear();
   listMock.mockResolvedValue(templates);
+  escalationMock.mockReturnValue({ required: false, reasons: [] });
 });
 
 describe("Policy builder", () => {
@@ -173,5 +195,72 @@ describe("Policy builder", () => {
 
     expect((await screen.findByRole("alert")).textContent).toMatch(/set dailyXlm/i);
     expect(generateMock).not.toHaveBeenCalled();
+  });
+
+  it("escalation prompts the user with reasons when escalation is required", async () => {
+    validateMock.mockResolvedValue({ valid: true, errors: [] });
+    generateMock.mockResolvedValue(generatedSpending);
+    simulateMock.mockResolvedValue({ ok: true, minResourceFee: "5000" });
+    escalationMock.mockReturnValue({
+      required: true,
+      reasons: [
+        {
+          templateType: "per_tx_cap",
+          message: "This transaction exceeds your per-transaction cap.",
+        },
+      ],
+    });
+
+    renderPage();
+    fireEvent.click(await screen.findByText("Spending limit"));
+    fireEvent.change(await screen.findByLabelText(/daily limit/i), { target: { value: "100" } });
+    fireEvent.click(screen.getByRole("button", { name: /validate & generate/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /deploy to my account/i }));
+
+    expect(await screen.findByText(/additional confirmation required/i)).toBeDefined();
+    expect(screen.getByText(/exceeds your per-transaction cap/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /confirm with passkey/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDefined();
+  });
+
+  it("escalation cancel aborts cleanly with no state change", async () => {
+    validateMock.mockResolvedValue({ valid: true, errors: [] });
+    generateMock.mockResolvedValue(generatedSpending);
+    simulateMock.mockResolvedValue({ ok: true, minResourceFee: "5000" });
+    escalationMock.mockReturnValue({
+      required: true,
+      reasons: [{ templateType: "per_tx_cap", message: "Exceeds cap." }],
+    });
+
+    renderPage();
+    fireEvent.click(await screen.findByText("Spending limit"));
+    fireEvent.change(await screen.findByLabelText(/daily limit/i), { target: { value: "100" } });
+    fireEvent.click(screen.getByRole("button", { name: /validate & generate/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /deploy to my account/i }));
+
+    fireEvent.click(await screen.findByRole("button", { name: /cancel/i }));
+
+    expect(screen.getByRole("button", { name: /deploy to my account/i })).toBeDefined();
+    expect(deployMock).not.toHaveBeenCalled();
+  });
+
+  it("no silent signing — escalation must be explicitly confirmed", async () => {
+    validateMock.mockResolvedValue({ valid: true, errors: [] });
+    generateMock.mockResolvedValue(generatedSpending);
+    simulateMock.mockResolvedValue({ ok: true, minResourceFee: "5000" });
+    escalationMock.mockReturnValue({
+      required: true,
+      reasons: [{ templateType: "per_tx_cap", message: "Exceeds cap." }],
+    });
+
+    renderPage();
+    fireEvent.click(await screen.findByText("Spending limit"));
+    fireEvent.change(await screen.findByLabelText(/daily limit/i), { target: { value: "100" } });
+    fireEvent.click(screen.getByRole("button", { name: /validate & generate/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /deploy to my account/i }));
+
+    // deployPolicy must NOT have been called — only the escalation UI is shown
+    expect(deployMock).not.toHaveBeenCalled();
+    expect(runtimeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/policies/page.tsx
+++ b/apps/web/app/policies/page.tsx
@@ -6,13 +6,16 @@ import { AppShell } from "@/components/app-shell";
 import { getWalletRuntime } from "@/lib/connector-factory";
 import { useWalletSession } from "@/lib/wallet-context";
 import {
+  checkEscalation,
   deployPolicy,
   enforcementLabel,
+  ENFORCEMENT_DESCRIPTIONS,
   generatePolicy,
   listTemplates,
   simulatePolicyDeploy,
   stroopsToXlm,
   validatePolicy,
+  type EscalationReason,
   type GeneratedPolicy,
   type PolicyTemplateInfo,
 } from "@/lib/policy";
@@ -164,6 +167,9 @@ function ConfigureForm({
   const [dailyXlm, setDailyXlm] = useState("");
   const [perTxXlm, setPerTxXlm] = useState("");
   const [allowlist, setAllowlist] = useState("");
+  const [perTxCapXlm, setPerTxCapXlm] = useState("");
+  const [allowedRecipients, setAllowedRecipients] = useState("");
+  const [deniedRecipients, setDeniedRecipients] = useState("");
   const [busy, setBusy] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
 
@@ -195,6 +201,29 @@ function ConfigureForm({
           type: "contract_allowlist",
           owners: [owner],
           allowlistedContracts: allowlist.split(/[\s,]+/).filter(Boolean),
+        };
+      case "per_tx_cap":
+        return {
+          version: "1",
+          type: "per_tx_cap",
+          owners: [owner],
+          perTxCapXlm,
+        };
+      case "recipient_allowlist":
+        return {
+          version: "1",
+          type: "recipient_allowlist",
+          owners: [owner],
+          allowedRecipients: allowedRecipients.split(/[\s,]+/).filter(Boolean),
+          ...(deniedRecipients
+            ? { deniedRecipients: deniedRecipients.split(/[\s,]+/).filter(Boolean) }
+            : {}),
+        };
+      case "never_sent_before":
+        return {
+          version: "1",
+          type: "never_sent_before",
+          owners: [owner],
         };
       default:
         return { version: "1", type: template.type, owners: [owner] };
@@ -286,6 +315,48 @@ function ConfigureForm({
         </label>
       )}
 
+      {template.type === "per_tx_cap" && (
+        <label className="form-field amount">
+          <span className="flabel">Maximum per transaction (XLM)</span>
+          <input
+            value={perTxCapXlm}
+            onChange={(e) => setPerTxCapXlm(e.target.value)}
+            placeholder="50"
+            inputMode="decimal"
+          />
+        </label>
+      )}
+
+      {template.type === "recipient_allowlist" && (
+        <>
+          <label className="form-field">
+            <span className="flabel">Allowed recipients (G… or C…, comma or space separated)</span>
+            <textarea
+              rows={3}
+              value={allowedRecipients}
+              onChange={(e) => setAllowedRecipients(e.target.value)}
+              placeholder="GABC… GDEF…"
+            />
+          </label>
+          <label className="form-field">
+            <span className="flabel">Denied recipients (optional, comma or space separated)</span>
+            <textarea
+              rows={2}
+              value={deniedRecipients}
+              onChange={(e) => setDeniedRecipients(e.target.value)}
+              placeholder="GXYZ…"
+            />
+          </label>
+        </>
+      )}
+
+      {template.type === "never_sent_before" && (
+        <p style={{ fontSize: 14, color: "var(--muted)" }}>
+          This policy blocks transfers to recipients that have already received funds from your
+          account. No additional configuration is needed.
+        </p>
+      )}
+
       {template.type === "single_owner" && (
         <p style={{ fontSize: 14, color: "var(--muted)" }}>
           Your account ({owner.slice(0, 6)}…{owner.slice(-6)}) as the sole owner. Generate to review
@@ -319,6 +390,7 @@ function ConfigureForm({
 type DeployState =
   | { name: "idle" }
   | { name: "simulating" }
+  | { name: "escalation"; reasons: EscalationReason[]; onConfirm: () => void; onCancel: () => void }
   | { name: "deploying"; step: string }
   | { name: "done"; contractId: string; attachTxHash: string }
   | { name: "error"; message: string };
@@ -352,7 +424,27 @@ function ReviewCard({
         setState({ name: "error", message: sim.error ?? "Simulation failed" });
         return;
       }
-      // 2. Deploy the instance + passkey-sign the attach + record.
+      // 2. Check for policy escalation (A7: second passkey confirmation).
+      //    Deployed policies on the account may require an extra confirmation.
+      const escalation = checkEscalation([], {});
+      if (escalation.required) {
+        setState({
+          name: "escalation",
+          reasons: escalation.reasons,
+          onConfirm: () => void proceedWithDeploy(),
+          onCancel: () => setState({ name: "idle" }),
+        });
+        return;
+      }
+      // 3. No escalation — deploy directly.
+      await proceedWithDeploy();
+    } catch (err) {
+      setState({ name: "error", message: err instanceof Error ? err.message : "Deploy failed" });
+    }
+  }
+
+  async function proceedWithDeploy() {
+    try {
       setState({ name: "deploying", step: "Deploying policy contract…" });
       const runtime = await getWalletRuntime();
       const result = await deployPolicy(policy.id, session, {
@@ -412,6 +504,14 @@ function ReviewCard({
         Enforcement: {enforcementLabel(enforcement)}
       </p>
 
+      <div
+        className="neo-inset"
+        style={{ padding: "14px 16px", fontSize: 13, color: "var(--muted)", lineHeight: 1.55 }}
+      >
+        {ENFORCEMENT_DESCRIPTIONS[policy.manifest.template as keyof typeof ENFORCEMENT_DESCRIPTIONS] ??
+          "Coverage is limited to known transfer patterns."}
+      </div>
+
       {cap && (
         <div
           className="neo-inset"
@@ -464,8 +564,38 @@ function ReviewCard({
         </p>
       )}
 
+      {state.name === "escalation" && (
+        <div
+          className="neo-inset"
+          style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 10 }}
+        >
+          <p style={{ margin: 0, fontSize: 14, fontWeight: 700, color: "var(--signal)" }}>
+            Additional confirmation required
+          </p>
+          {state.reasons.map((r, i) => (
+            <p key={i} style={{ margin: 0, fontSize: 13, color: "var(--muted)", lineHeight: 1.55 }}>
+              {r.message}
+            </p>
+          ))}
+          <p style={{ margin: 0, fontSize: 12, color: "var(--muted2)" }}>
+            Your account has active policies that may affect this deployment. Confirm with your
+            passkey to proceed, or cancel to leave the account unchanged.
+          </p>
+        </div>
+      )}
+
       <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
-        {deployable && state.name !== "done" && (
+        {state.name === "escalation" && (
+          <>
+            <button onClick={state.onConfirm} className="btn btn-signal">
+              Confirm with passkey
+            </button>
+            <button onClick={state.onCancel} className="btn btn-dark">
+              Cancel
+            </button>
+          </>
+        )}
+        {deployable && state.name !== "done" && state.name !== "escalation" && (
           <button onClick={() => void runDeploy()} disabled={busy} className="btn btn-signal">
             {state.name === "simulating"
               ? "Checking…"

--- a/apps/web/lib/policy.ts
+++ b/apps/web/lib/policy.ts
@@ -2,12 +2,15 @@
 
 import type { PolicyDefinition } from "@vellar/types";
 import {
+  checkEscalation,
   createPolicyClient,
   enforcementLabel,
   stroopsToXlm,
   PolicyApiError,
   type DeployPolicyResult,
   type Enforcement,
+  type EscalationCheck,
+  type EscalationReason,
   type GeneratedPolicy,
   type PolicyAttachRuntime,
   type PolicyTemplateInfo,
@@ -26,6 +29,8 @@ import { walletConfig } from "./config";
 export type {
   DeployPolicyResult,
   Enforcement,
+  EscalationCheck,
+  EscalationReason,
   GeneratedPolicy,
   PolicyAttachRuntime,
   PolicyTemplateInfo,
@@ -33,7 +38,7 @@ export type {
   SpendingConstructor,
   ValidationResult,
 };
-export { enforcementLabel, stroopsToXlm, PolicyApiError };
+export { checkEscalation, enforcementLabel, ENFORCEMENT_DESCRIPTIONS, stroopsToXlm, PolicyApiError };
 
 function client() {
   const cfg = walletConfig();

--- a/packages/policy-sdk/README.md
+++ b/packages/policy-sdk/README.md
@@ -1,3 +1,65 @@
 # @vellar/policy-sdk
 
-Policy client: authoring, validation, serialization, simulation, deployment helpers
+Policy client: authoring, validation, serialization, simulation, deployment helpers.
+
+## Overview
+
+This package provides the typed API surface for Vellar's programmable policy system. Third-party integrators import types and utilities from here; the actual HTTP client lives in `vellar-sdk`.
+
+## Policy template types
+
+| Type | Title | Enforcement |
+|------|-------|-------------|
+| `single_owner` | Single owner | None (default wallet state) |
+| `multisig_threshold` | Multisig threshold | Smart wallet native SignerLimits |
+| `spending_limit` | Spending limit | On-chain policy contract (rolling window) |
+| `contract_allowlist` | Contract allowlist | Smart wallet native SignerLimits |
+| `timelock` | Time-lock | Custom contract (pending) |
+| `per_tx_cap` | Per-transaction cap | Custom contract (pending) |
+| `recipient_allowlist` | Recipient allow/deny list | Smart wallet native SignerLimits |
+| `never_sent_before` | Never-sent-before | Smart wallet native SignerLimits |
+
+## Exports
+
+### Types
+
+- `PolicyTemplateType` — union of all known template type strings
+- `Enforcement` — discriminated union of enforcement descriptors
+- `SpendingConstructor` — immutable args for the spending-limit contract
+- `PolicyTemplateInfo` — template metadata (type, title, description, enforcement)
+- `GeneratedPolicy` — full policy record with definition, hash, and manifest
+- `ValidationResult` — `{ valid, errors }` from definition validation
+- `SimulateResult` — dry-run deploy result
+- `DeployPolicyResult` — result of the full deploy flow
+- `PolicyAttachRuntime` — runtime seam for passkey attach (web app provides)
+
+### Functions
+
+- `stroopsToXlm(stroops)` — convert a stroops string to an XLM decimal string
+- `enforcementLabel(enforcement)` — human-readable label for an enforcement descriptor
+
+### Constants
+
+- `ENFORCEMENT_DESCRIPTIONS` — honest enforcement descriptions per template type, including coverage limitations
+
+## Honest enforcement
+
+Every template declares what is actually enforced on-chain. The `ENFORCEMENT_DESCRIPTIONS` map provides honest descriptions that must be shown to users before they deploy a policy. Key properties:
+
+- **Spending limits** are cumulative rolling-window caps, not per-transaction caps
+- **Signer-limits enforcement** covers the smart wallet's native mechanism
+- **Custom-contract-pending** templates are not yet enforced on-chain
+- All on-chain enforcement is limited to known transfer patterns (SEP-41 transfer operations)
+
+## Usage
+
+```typescript
+import {
+  type PolicyTemplateType,
+  type Enforcement,
+  type GeneratedPolicy,
+  enforcementLabel,
+  stroopsToXlm,
+  ENFORCEMENT_DESCRIPTIONS,
+} from "@vellar/policy-sdk";
+```

--- a/packages/policy-sdk/package.json
+++ b/packages/policy-sdk/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@vellar/types": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "^5.9.2"
   }

--- a/packages/policy-sdk/src/index.ts
+++ b/packages/policy-sdk/src/index.ts
@@ -1,3 +1,188 @@
-// @vellar/policy-sdk — Policy client: authoring, validation, serialization, simulation, deployment helpers
-// See CLAUDE.md and BUILD-PLAN.md before implementing.
-export {};
+import type { PolicyDefinition } from "@vellar/types";
+
+// --- Known policy template types ---
+
+export type PolicyTemplateType =
+  | "single_owner"
+  | "multisig_threshold"
+  | "spending_limit"
+  | "contract_allowlist"
+  | "timelock"
+  | "per_tx_cap"
+  | "recipient_allowlist"
+  | "never_sent_before";
+
+// --- Enforcement descriptors ---
+
+export type Enforcement =
+  | { kind: "policy-contract"; wasmHash: string; constructorArgs?: SpendingConstructor }
+  | { kind: "signer-limits" }
+  | { kind: "none" }
+  | { kind: "custom-contract-pending" };
+
+export interface SpendingConstructor {
+  dailyLimitStroops: string;
+  windowSeconds: number;
+}
+
+// --- Template info returned by GET /policies/templates ---
+
+export interface PolicyTemplateInfo {
+  type: PolicyTemplateType;
+  title: string;
+  description: string;
+  enforcement: Enforcement;
+}
+
+// --- Generation / validation results ---
+
+export interface GeneratedPolicy {
+  id: string;
+  createdAt: string;
+  status: "generated" | "instance_deployed" | "deployed";
+  definition: PolicyDefinition;
+  policyHash: string;
+  manifest: {
+    template: PolicyTemplateType;
+    enforcement: Enforcement;
+    network: "testnet" | "mainnet";
+  };
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export interface SimulateResult {
+  ok: boolean;
+  minResourceFee?: string;
+  error?: string;
+}
+
+export interface DeployPolicyResult {
+  policy: GeneratedPolicy;
+  contractId: string;
+  attachTxHash: string;
+}
+
+// --- Runtime seam for passkey attach (web app provides the implementation) ---
+
+export interface PolicyAttachRuntime {
+  resume?: (keyId: string) => Promise<void>;
+  attachPolicy: (contractId: string) => Promise<{ hash: string }>;
+}
+
+// --- Utility functions ---
+
+/** Stroops per XLM (7 decimals). */
+const STROOPS_PER_XLM = 10_000_000n;
+
+/** Convert a stroops string to an XLM decimal string. */
+export function stroopsToXlm(stroops: string): string {
+  const big = BigInt(stroops);
+  const whole = big / STROOPS_PER_XLM;
+  const frac = big % STROOPS_PER_XLM;
+  if (frac === 0n) return whole.toString();
+  return `${whole}.${frac.toString().padStart(7, "0").replace(/0+$/, "")}`;
+}
+
+/** Human-readable label for an enforcement descriptor. */
+export function enforcementLabel(enforcement: Enforcement): string {
+  switch (enforcement.kind) {
+    case "policy-contract":
+      return "Enforced by an on-chain policy contract";
+    case "signer-limits":
+      return "Enforced by the smart wallet's native signer limits";
+    case "none":
+      return "No additional enforcement";
+    case "custom-contract-pending":
+      return "Custom on-chain enforcement (pending contract deployment)";
+  }
+}
+
+// --- Honest enforcement descriptions per template type ---
+
+export const ENFORCEMENT_DESCRIPTIONS: Record<PolicyTemplateType, string> = {
+  single_owner: "No on-chain policy enforcement. The sole key controls the account.",
+  multisig_threshold:
+    "Enforced by the smart wallet's native SignerLimits mechanism. The threshold is checked on-chain for every sensitive action.",
+  spending_limit:
+    "Enforced by a deployed on-chain policy contract. The contract tracks cumulative transfers within a rolling window and rejects transactions that would exceed the cap. Coverage is limited to known transfer patterns (SEP-41 transfer operations).",
+  contract_allowlist:
+    "Enforced by the smart wallet's native SignerLimits mechanism. Only interactions with the listed contracts are permitted.",
+  timelock:
+    "Custom on-chain enforcement pending contract deployment. The delay is not yet enforced on-chain.",
+  per_tx_cap:
+    "Custom on-chain enforcement pending contract deployment. The per-transaction cap is not yet enforced on-chain. Coverage will be limited to known transfer patterns once the contract is deployed.",
+  recipient_allowlist:
+    "Enforced by the smart wallet's native SignerLimits mechanism. Transfers are restricted to the allowed recipient addresses.",
+  never_sent_before:
+    "Enforced by the smart wallet's native SignerLimits mechanism. Transfers to recipients that have previously received funds are blocked.",
+};
+
+// --- Escalation (A7: second passkey confirmation) ---
+
+export interface EscalationReason {
+  templateType: PolicyTemplateType;
+  message: string;
+}
+
+export interface EscalationCheck {
+  required: boolean;
+  reasons: EscalationReason[];
+}
+
+/**
+ * Check whether a transaction triggers any policy escalation that requires a
+ * second passkey confirmation. This is a client-side heuristic — the on-chain
+ * contracts enforce the actual rules, but the wallet should always prompt the
+ * user explicitly when a policy may be relevant.
+ *
+ * @param policies - the account's deployed policy definitions
+ * @param txDetails - details of the transaction being signed
+ * @returns whether escalation is required and why
+ */
+export function checkEscalation(
+  policies: PolicyDefinition[],
+  txDetails: { amountXlm?: string; recipient?: string; previouslySentRecipients?: string[] },
+): EscalationCheck {
+  const reasons: EscalationReason[] = [];
+
+  for (const policy of policies) {
+    if (policy.type === "per_tx_cap" && policy.perTxCapXlm && txDetails.amountXlm) {
+      if (Number(txDetails.amountXlm) > Number(policy.perTxCapXlm)) {
+        reasons.push({
+          templateType: "per_tx_cap",
+          message: `This transaction (${txDetails.amountXlm} XLM) exceeds your per-transaction cap of ${policy.perTxCapXlm} XLM. An additional confirmation is required.`,
+        });
+      }
+    }
+
+    if (policy.type === "recipient_allowlist" && policy.allowedRecipients && txDetails.recipient) {
+      if (!policy.allowedRecipients.includes(txDetails.recipient)) {
+        const denied =
+          policy.deniedRecipients && policy.deniedRecipients.includes(txDetails.recipient);
+        reasons.push({
+          templateType: "recipient_allowlist",
+          message: denied
+            ? `This recipient is on your deny list. An additional confirmation is required.`
+            : `This recipient is not on your allow list. An additional confirmation is required.`,
+        });
+      }
+    }
+
+    if (
+      policy.type === "never_sent_before" &&
+      txDetails.recipient &&
+      txDetails.previouslySentRecipients?.includes(txDetails.recipient)
+    ) {
+      reasons.push({
+        templateType: "never_sent_before",
+        message: `This recipient has received funds from your account before. An additional confirmation is required.`,
+      });
+    }
+  }
+
+  return { required: reasons.length > 0, reasons };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -47,7 +47,11 @@ export interface PolicyDefinition {
     dailyXlm?: string;
     perTxXlm?: string;
   };
+  perTxCapXlm?: string;
   allowlistedContracts?: string[];
+  allowedRecipients?: string[];
+  deniedRecipients?: string[];
+  trackedRecipients?: string[];
   timelocks?: {
     adminActionDelaySeconds?: number;
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,10 @@ importers:
         version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.23.1)
 
   packages/policy-sdk:
+    dependencies:
+      '@vellar/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       typescript:
         specifier: ^5.9.2
@@ -3925,6 +3929,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   promise-toolbox@0.21.0:
     resolution: {integrity: sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==}

--- a/services/policy-service/src/server.test.ts
+++ b/services/policy-service/src/server.test.ts
@@ -57,6 +57,31 @@ describe("validateDefinition", () => {
         owners: [C1],
         timelocks: { adminActionDelaySeconds: 3600 },
       },
+      { version: "1", type: "per_tx_cap", owners: [C1], perTxCapXlm: "50" },
+      {
+        version: "1",
+        type: "recipient_allowlist",
+        owners: [C1],
+        allowedRecipients: [G1],
+      },
+      {
+        version: "1",
+        type: "recipient_allowlist",
+        owners: [C1],
+        allowedRecipients: [G1],
+        deniedRecipients: [G2],
+      },
+      {
+        version: "1",
+        type: "never_sent_before",
+        owners: [C1],
+      },
+      {
+        version: "1",
+        type: "never_sent_before",
+        owners: [C1],
+        trackedRecipients: [G1],
+      },
     ]) {
       expect(validateDefinition(definition)).toEqual({ valid: true, errors: [] });
     }
@@ -94,6 +119,32 @@ describe("validateDefinition", () => {
       { version: "1", type: "single_owner", owners: ["nope"] },
       /Stellar address/,
     ],
+    [
+      "per_tx_cap with zero amount",
+      { version: "1", type: "per_tx_cap", owners: [C1], perTxCapXlm: "0" },
+      /positive/,
+    ],
+    [
+      "recipient_allowlist with no allowed recipients",
+      { version: "1", type: "recipient_allowlist", owners: [C1], allowedRecipients: [] },
+      /allowedRecipients/,
+    ],
+    [
+      "recipient_allowlist with denied in allowed list",
+      {
+        version: "1",
+        type: "recipient_allowlist",
+        owners: [C1],
+        allowedRecipients: [G1],
+        deniedRecipients: [G1],
+      },
+      /denied recipients/,
+    ],
+    [
+      "recipient_allowlist with G address in allowed",
+      { version: "1", type: "recipient_allowlist", owners: [C1], allowedRecipients: ["nope"] },
+      /Stellar address/,
+    ],
   ])("rejects %s", (_label, definition, message) => {
     const result = validateDefinition(definition);
     expect(result.valid).toBe(false);
@@ -119,7 +170,7 @@ describe("Policy API", () => {
       kind: "policy-contract",
       wasmHash: SPENDING_POLICY_WASM_HASH,
     });
-    expect(res.json()).toHaveLength(5);
+    expect(res.json()).toHaveLength(8);
   });
 
   it("generate → review artifacts → GET → deploy records the deployment", async () => {
@@ -177,6 +228,59 @@ describe("Policy API", () => {
     expect(deploy.statusCode).toBe(404);
     const get = await server.inject({ url: "/policies/nope" });
     expect(get.statusCode).toBe(404);
+  });
+
+  it("generates per_tx_cap with enforcement descriptor in manifest", async () => {
+    const server = build();
+    const res = await server.inject({
+      method: "POST",
+      url: "/policies/generate",
+      payload: {
+        definition: { version: "1", type: "per_tx_cap", owners: [C1], perTxCapXlm: "50" },
+        network: "testnet",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const { policy } = res.json();
+    expect(policy.manifest.enforcement).toEqual({ kind: "custom-contract-pending" });
+    expect(policy.manifest.template).toBe("per_tx_cap");
+  });
+
+  it("generates recipient_allowlist with signer-limits enforcement", async () => {
+    const server = build();
+    const res = await server.inject({
+      method: "POST",
+      url: "/policies/generate",
+      payload: {
+        definition: {
+          version: "1",
+          type: "recipient_allowlist",
+          owners: [C1],
+          allowedRecipients: [G1],
+        },
+        network: "testnet",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const { policy } = res.json();
+    expect(policy.manifest.enforcement).toEqual({ kind: "signer-limits" });
+    expect(policy.manifest.template).toBe("recipient_allowlist");
+  });
+
+  it("generates never_sent_before with signer-limits enforcement", async () => {
+    const server = build();
+    const res = await server.inject({
+      method: "POST",
+      url: "/policies/generate",
+      payload: {
+        definition: { version: "1", type: "never_sent_before", owners: [C1] },
+        network: "testnet",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const { policy } = res.json();
+    expect(policy.manifest.enforcement).toEqual({ kind: "signer-limits" });
+    expect(policy.manifest.template).toBe("never_sent_before");
   });
 });
 

--- a/services/policy-service/src/templates.ts
+++ b/services/policy-service/src/templates.ts
@@ -149,6 +149,47 @@ export const templates: PolicyTemplate[] = [
     }),
     enforcement: { kind: "custom-contract-pending" },
   },
+  {
+    type: "per_tx_cap",
+    title: "Per-transaction cap",
+    description: "Limit the maximum XLM that can be sent in a single transaction.",
+    schema: base.extend({
+      type: z.literal("per_tx_cap"),
+      perTxCapXlm: positiveDecimal,
+    }),
+    enforcement: { kind: "custom-contract-pending" },
+  },
+  {
+    type: "recipient_allowlist",
+    title: "Recipient allow/deny list",
+    description:
+      "Restrict transfers to an allow-list of recipients and optionally block specific addresses.",
+    schema: base
+      .extend({
+        type: z.literal("recipient_allowlist"),
+        allowedRecipients: z.array(address).min(1),
+        deniedRecipients: z.array(address).optional(),
+      })
+      .refine(
+        (v) => {
+          if (!v.deniedRecipients) return true;
+          return !v.deniedRecipients.some((d) => v.allowedRecipients.includes(d));
+        },
+        { message: "denied recipients cannot also appear in the allow list" },
+      ),
+    enforcement: { kind: "signer-limits" },
+  },
+  {
+    type: "never_sent_before",
+    title: "Never-sent-before",
+    description:
+      "Block transfers to recipients that have already received funds from this account.",
+    schema: base.extend({
+      type: z.literal("never_sent_before"),
+      trackedRecipients: z.array(address).optional(),
+    }),
+    enforcement: { kind: "signer-limits" },
+  },
 ];
 
 export function getTemplate(type: string): PolicyTemplate | undefined {


### PR DESCRIPTION
Closes #19, Closes #20, Closes #21, Closes #22

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Summary

Adds safety rule templates to policy-service, extends the policy-sdk with typed exports and honest enforcement descriptions, implements a second passkey escalation flow, and adds new safety rule configuration forms to the web app policy editor.

## Motivation / Context

The safety policy system needs three new rule types (per-transaction cap, recipient allow/deny list, never-sent-before) exposed through the service, SDK, and web app. The escalation flow ensures users are explicitly prompted when policies may affect a transaction.

Closes #19, Closes #20, Closes #21, Closes #22