### PR TITLE
fix(deps): bump vellar-sdk 0.4.0 → 0.6.1 (security)

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -17,7 +17,7 @@
     "@vellar/types": "workspace:*",
     "@vellar/ui": "workspace:*",
     "@vellar/verification-sdk": "workspace:*",
-    "vellar-sdk": "^0.4.0",
+    "vellar-sdk": "^0.6.1",
     "buffer": "^6.0.3",
     "passkey-kit": "^0.14.0",
     "react": "^19.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "react-hook-form": "^7.60.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "vellar-sdk": "^0.4.0",
+    "vellar-sdk": "^0.6.1",
     "zod": "^4.0.0",
     "zustand": "^5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.7(react@19.2.7)
       vellar-sdk:
-        specifier: ^0.4.0
-        version: 0.4.0(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(react@19.2.7)
+        specifier: ^0.6.1
+        version: 0.6.1(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -149,8 +149,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       vellar-sdk:
-        specifier: ^0.4.0
-        version: 0.4.0(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(react@19.2.7)
+        specifier: ^0.6.1
+        version: 0.6.1(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7)
       zod:
         specifier: ^4.0.0
         version: 4.4.3
@@ -4183,10 +4183,14 @@ packages:
     resolution: {integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==}
     hasBin: true
 
-  vellar-sdk@0.4.0:
-    resolution: {integrity: sha512-VD6s5ZZrzXNxDWt9bPqiYL8Mg0Lx3W3A60CBAhjTrLHSVO1zugZgPD+ct+BnEfybG5ueNprxqDVZosv9gHojJw==}
+  vellar-sdk@0.6.1:
+    resolution: {integrity: sha512-gYfxsZdwyaGbtxaQRvapQHRqFmrSjCMkuHBvGxa7E1u5MJ7NG+zMN2is23a59rifAYj495PI6mErHPWjpfBk3g==}
     peerDependencies:
       '@stellar/stellar-sdk': ^16.0.0
+      passkey-kit: '>=0.13.0 <0.17.0'
+    peerDependenciesMeta:
+      passkey-kit:
+        optional: true
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -8061,10 +8065,12 @@ snapshots:
 
   uuid@14.0.2: {}
 
-  vellar-sdk@0.4.0(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(react@19.2.7):
+  vellar-sdk@0.6.1(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7):
     dependencies:
       '@stellar/stellar-sdk': 16.0.1
       zustand: 5.0.14(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      passkey-kit: 0.14.0(@stellar/stellar-sdk@16.0.1)
     transitivePeerDependencies:
       - '@types/react'
       - immer

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ allowBuilds:
   spawn-sync: false
   "@tailwindcss/oxide": true
 minimumReleaseAgeExclude:
-  - vellar-sdk@0.4.0
+  - vellar-sdk@0.6.1
 # Security overrides: force patched versions of vulnerable TRANSITIVE deps
 # (Dependabot alerts, 2026-07). All same-major, backward-compatible patch/minor
 # bumps. Re-check + prune when the direct deps that pull these in are upgraded.


### PR DESCRIPTION
## Why this is urgent

The wallet was running vellar-sdk 0.4.0, which predates the 0.6.0 security release.

**0.6.0 Critical fix (V-1):** auth entries were signed after checking only that the credential address was ours, never what the entry authorised. A hostile RPC could have redirected the signed amount or recipient to a different contract call.

## What changed in the wallet

Nothing — the wallet uses none of the x402 surface that changed (no `x402Client`, no x402 subpaths). The bump is package.json + lockfile only.

Both 0.6.0 behavioural changes land in the x402 client:
- auth-entry validation before signing (`AuthEntryMismatchError`)
- seller signature lifetime capped at 300s

Neither is reachable from this codebase. The 0.6.1 guards (`X402NotConfiguredError`, `PasskeyBrowserRequiredError`) fire on x402 config and non-browser passkey ceremonies — also unused paths. `PasskeyBrowserRequiredError` is checked per ceremony, so SSR construction still works.

## What this unlocks

`wallet.agents` and `createSessionKeySigner` landed in 0.5.0. The wallet could not use them while pinned to 0.4.0. These are needed for Group 2 agent payments.

## Testing

| Check | Result |
| --- | --- |
| `apps/web` tests | **62/62** — identical to the 0.4.0 baseline |
| `turbo run test` | 13/13 tasks (includes the extension, which also consumes the SDK) |
| `turbo run typecheck` | 18/18 clean |
| `turbo run build` | succeeds |
| `prettier --check` | clean |

## Note

`passkey-kit` became an *optional peer dependency* in 0.6.1 with range `>=0.13.0 <0.17.0`. The repo's `^0.14.0` sits inside that range, so no change was needed. `passkey-kit` and `@stellar/stellar-sdk` were deliberately left alone — one bump at a time.