### PR TITLE
fix(deps): bump vellar-sdk 0.6.1 → 0.6.2

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -17,7 +17,7 @@
     "@vellar/types": "workspace:*",
     "@vellar/ui": "workspace:*",
     "@vellar/verification-sdk": "workspace:*",
-    "vellar-sdk": "^0.6.1",
+    "vellar-sdk": "^0.6.2",
     "buffer": "^6.0.3",
     "passkey-kit": "^0.14.0",
     "react": "^19.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "react-hook-form": "^7.60.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "vellar-sdk": "^0.6.1",
+    "vellar-sdk": "^0.6.2",
     "zod": "^4.0.0",
     "zustand": "^5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.7(react@19.2.7)
       vellar-sdk:
-        specifier: ^0.6.1
-        version: 0.6.1(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7)
+        specifier: ^0.6.2
+        version: 0.6.2(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -149,8 +149,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       vellar-sdk:
-        specifier: ^0.6.1
-        version: 0.6.1(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7)
+        specifier: ^0.6.2
+        version: 0.6.2(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7)
       zod:
         specifier: ^4.0.0
         version: 4.4.3
@@ -4183,8 +4183,8 @@ packages:
     resolution: {integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==}
     hasBin: true
 
-  vellar-sdk@0.6.1:
-    resolution: {integrity: sha512-gYfxsZdwyaGbtxaQRvapQHRqFmrSjCMkuHBvGxa7E1u5MJ7NG+zMN2is23a59rifAYj495PI6mErHPWjpfBk3g==}
+  vellar-sdk@0.6.2:
+    resolution: {integrity: sha512-YZUX8SkKk5HjxQ3uLlqwWcBn1UbZhVM41Xs1ik0MUVU+nGdqwqZtzdmsa38wY0E68srnxHeRVO3Tbx98pLgBzA==}
     peerDependencies:
       '@stellar/stellar-sdk': ^16.0.0
       passkey-kit: '>=0.13.0 <0.17.0'
@@ -8065,7 +8065,7 @@ snapshots:
 
   uuid@14.0.2: {}
 
-  vellar-sdk@0.6.1(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7):
+  vellar-sdk@0.6.2(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7):
     dependencies:
       '@stellar/stellar-sdk': 16.0.1
       zustand: 5.0.14(@types/react@19.2.17)(react@19.2.7)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ allowBuilds:
   spawn-sync: false
   "@tailwindcss/oxide": true
 minimumReleaseAgeExclude:
-  - vellar-sdk@0.6.1
+  - vellar-sdk@0.6.2
 # Security overrides: force patched versions of vulnerable TRANSITIVE deps
 # (Dependabot alerts, 2026-07). All same-major, backward-compatible patch/minor
 # bumps. Re-check + prune when the direct deps that pull these in are upgraded.


### PR DESCRIPTION
Follows the same pattern as #390. Three source lines plus the lockfile.

## What is in 0.6.2

**Added** — `usdcIssuer` and `usdcContractId` on `NetworkConfig` for both TESTNET and MAINNET, verified against Circle's official USDC on Stellar docs (tests derive each SAC from the issuer rather than hardcoding it). Plus new coverage for `nativeToken()`.

**Security** — `fast-uri` pinned to 3.1.7 inside ajv's declared `^3.0.1` range, closing four high-severity advisories (host confusion via IDN canonicalization and percent-encoded scheme normalization; SSRF via malformed IPv6 normalization and repeated hostname percent-decoding).

## The one thing worth checking, and why it does not apply

The changelog flags `usdcIssuer`/`usdcContractId` as **new required fields** on `NetworkConfig`. Consumers constructing a custom `NetworkConfig` object literal must add both.

The wallet does not construct one — `grep -rn "NetworkConfig"` across `apps/web` and `apps/extension` app code returns nothing. So no call-site changes are needed.

## Testing

| Check | Result |
| --- | --- |
| `apps/web` tests | **62/62** — unchanged from the 0.6.1 baseline |
| `turbo run test` | 13/13 tasks (includes the extension) |
| `turbo run typecheck` | 18/18 clean |
| `turbo run build` | succeeds |
| `prettier --check` | clean |
| `pnpm audit` | No known vulnerabilities found |

## Note

The SDK's own publish workflow temporarily lowered its audit gate from `high` to `critical` for this release — the remaining highs are in the `toml` chain via `passkey-kit` → `@openzeppelin/relayer-plugin-channels` → `@stellar/stellar-sdk` ≤15.x (SDK issue #378). That does not affect this repo: our own `toml@<4.2.0: ">=4.2.0"` override already closes that chain here, and `pnpm audit` is clean.