### PR TITLE
fix(e2e): update stale address selector to data-testid

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -67,7 +67,7 @@ export default function Dashboard() {
           {/* Account overview */}
           <section className="lpa-panel flex flex-col">
             <Eyebrow>Account balance</Eyebrow>
-            <div className="lpa-balance mt-2.5">
+            <div data-testid="account-balance" className="lpa-balance mt-2.5">
               {balances.isPending ? (
                 <span className="animate-pulse text-[var(--lp-ink-faint)]">…</span>
               ) : (

--- a/apps/web/app/dashboard/receive-card.tsx
+++ b/apps/web/app/dashboard/receive-card.tsx
@@ -25,7 +25,10 @@ export function ReceiveCard({ accountId, onClose }: { accountId: string; onClose
         <span className="flabel block text-[11px] font-bold uppercase tracking-[0.14em] text-[var(--lp-ink-faint)]">
           YOUR ADDRESS
         </span>
-        <p className="mt-1.5! break-all font-[family-name:var(--lp-mono)] text-[13px]">
+        <p
+          data-testid="wallet-address"
+          className="mt-1.5! break-all font-[family-name:var(--lp-mono)] text-[13px]"
+        >
           {accountId}
         </p>
       </div>

--- a/apps/web/app/policies/page.tsx
+++ b/apps/web/app/policies/page.tsx
@@ -416,7 +416,10 @@ function ReviewCard({
       {state.name === "done" || state.name === "detaching" ? (
         <div className="lpa-well text-[13px] leading-relaxed text-[var(--lp-ink-soft)]">
           <p className="lpa-ok m-0! font-bold">✓ Policy attached to your account</p>
-          <p className="mt-2! break-all font-[family-name:var(--lp-mono)] text-[11px]">
+          <p
+            data-testid="policy-contract-id"
+            className="mt-2! break-all font-[family-name:var(--lp-mono)] text-[11px]"
+          >
             contract {state.contractId}
           </p>
           {state.name === "done" && (

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -3,12 +3,18 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
 import { WalletProvider } from "@/lib/wallet-context";
+import { ConnectedWalletProvider } from "@/lib/connected-wallet-context";
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
   return (
     <QueryClientProvider client={queryClient}>
-      <WalletProvider>{children}</WalletProvider>
+      {/* Connected (G-address) wallets for the marketplace surfaces and the
+          passkey wallet for /app are independent and both always mounted —
+          new-build-technical-doc.md §3.1. */}
+      <ConnectedWalletProvider>
+        <WalletProvider>{children}</WalletProvider>
+      </ConnectedWalletProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/web/app/sell/listings/[id]/page.tsx
+++ b/apps/web/app/sell/listings/[id]/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { use, useEffect, useState, type FormEvent } from "react";
+import Link from "next/link";
+import { WalletRequired } from "../../../../components/marketplace/WalletRequired";
+import { useConnectedWallet } from "../../../../lib/connected-wallet-context";
+import { marketplaceApiUrl } from "../../../../lib/config";
+import { formatPriceAtomic, type ListingRecord } from "../../../../lib/marketplace-types";
+import { connectedWalletErrorMessage } from "@vellar/provider-sdk/connected-wallet";
+import "../../../landing/landing.css";
+
+// Listing detail / basic edit — new-build-technical-doc.md §7.3. Client
+// component: ownership (does the connected address match the seller?) can
+// only be checked client-side, and the edit form needs signTransaction.
+// Full edit (price/scheme/status) is a follow-on; this covers title and
+// description only, per the Step 3 scope.
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}
+
+function EditForm({
+  listing,
+  walletAddress,
+  onUpdated,
+}: {
+  listing: ListingRecord;
+  walletAddress: string;
+  onUpdated: (listing: ListingRecord) => void;
+}) {
+  const { signTransaction } = useConnectedWallet();
+  const [title, setTitle] = useState(listing.title);
+  const [description, setDescription] = useState(listing.description ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      // TODO(step-4): PLACEHOLDER signature — see ListingForm.tsx and
+      // PayButton.tsx for the same note. Real transaction construction is
+      // deferred to the follow-on step; this verifies the edit UI flow.
+      const signedXdr = await signTransaction("placeholder");
+      const res = await fetch(`${marketplaceApiUrl()}/listings/${listing.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title, description, signedXdr, walletAddress }),
+      });
+      const body = (await readJson(res)) as { listing?: ListingRecord; message?: string };
+      if (!res.ok || !body.listing) {
+        setError(body.message ?? "Could not update the listing");
+        return;
+      }
+      onUpdated(body.listing);
+    } catch (err) {
+      setError(connectedWalletErrorMessage(err, "Could not update the listing"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form className="lp-mkt-form" onSubmit={(e) => void handleSubmit(e)}>
+      <div className="lp-mkt-field">
+        <label htmlFor="edit-title">Title</label>
+        <input id="edit-title" type="text" required value={title} onChange={(e) => setTitle(e.target.value)} />
+      </div>
+      <div className="lp-mkt-field">
+        <label htmlFor="edit-description">Description</label>
+        <textarea id="edit-description" value={description} onChange={(e) => setDescription(e.target.value)} />
+      </div>
+      {error && (
+        <div className="lp-mkt-error" role="alert">
+          <div>
+            <strong>Could not save</strong>
+            <p>{error}</p>
+          </div>
+        </div>
+      )}
+      <div className="lp-cta-row">
+        <button type="submit" disabled={saving} className="lp-btn lp-btn--sun lp-btn--sm">
+          {saving ? "Saving..." : "Save changes"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ListingDetail({ id, address }: { id: string; address: string }) {
+  const [listing, setListing] = useState<ListingRecord | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${marketplaceApiUrl()}/listings/${id}`);
+        const body = (await readJson(res)) as { listing?: ListingRecord; message?: string };
+        if (cancelled) return;
+        if (!res.ok || !body.listing) {
+          setLoadError(body.message ?? "Listing not found");
+          return;
+        }
+        setListing(body.listing);
+      } catch (err) {
+        if (!cancelled) setLoadError(err instanceof Error ? err.message : "Could not reach the marketplace");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (loadError) {
+    return (
+      <div className="lp-mkt-error" role="alert">
+        <div>
+          <strong>Could not load this listing</strong>
+          <p>{loadError}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!listing) {
+    return <div className="lp-mkt-skeleton lp-mkt-skeleton-card" />;
+  }
+
+  const isOwner = listing.sellerAddress === address;
+
+  return (
+    <>
+      <div className="lp-sechead" data-reveal>
+        <div>
+          <span className="lp-eyebrow">Seller Portal</span>
+          <h1>{listing.title}</h1>
+        </div>
+      </div>
+
+      <div className="lp-mkt-card lp-mkt-card--mint">
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+          <h3 className="mkt-title">{listing.title}</h3>
+          <span className="lp-badge">{listing.status}</span>
+        </div>
+        <p className="mkt-desc">{listing.description || "No description provided."}</p>
+        <div className="mkt-foot">
+          <span className="mkt-price">{formatPriceAtomic(listing.priceAtomic)} USDC</span>
+          <span className="mkt-meta">{listing.resourceUrl}</span>
+        </div>
+      </div>
+
+      <section className="lp-sec lp-sec--tight">
+        <div className="lp-rlist">
+          <div className="lp-rrow">
+            <div className="rn">
+              <b>Total settlements</b>
+              <span>Payments received</span>
+            </div>
+            <span className="open">{listing.totalSettlements}</span>
+          </div>
+          <div className="lp-rrow">
+            <div className="rn">
+              <b>Total revenue</b>
+              <span>Cumulative earnings</span>
+            </div>
+            <span className="open">{formatPriceAtomic(listing.totalRevenue)} USDC</span>
+          </div>
+          <div className="lp-rrow">
+            <div className="rn">
+              <b>First settled</b>
+              <span>When this listing went active</span>
+            </div>
+            <span className="open">{listing.firstSettledAt ?? "Not yet active"}</span>
+          </div>
+        </div>
+      </section>
+
+      {isOwner ? (
+        <section className="lp-sec lp-sec--tight">
+          <EditForm listing={listing} walletAddress={address} onUpdated={setListing} />
+        </section>
+      ) : (
+        <div className="lp-mkt-error" role="alert">
+          <div>
+            <strong>Read-only</strong>
+            <p>Only the seller who registered this listing can edit it.</p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default function ListingDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { isConnected, address } = useConnectedWallet();
+
+  return (
+    <main className="lp">
+      <div className="lp-wrap">
+        <Link href="/sell" className="lp-btn lp-btn--ghost">
+          ← Back to listings
+        </Link>
+        <div style={{ marginTop: "var(--lp-sp-6)" }}>
+          <WalletRequired message="Connect your wallet to manage this listing">
+            {isConnected && address && <ListingDetail id={id} address={address} />}
+          </WalletRequired>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/marketplace/PayButton.tsx
+++ b/apps/web/components/marketplace/PayButton.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import { useConnectedWallet } from "../../lib/connected-wallet-context";
+import { marketplaceApiUrl } from "../../lib/config";
+import { connectedWalletErrorMessage } from "@vellar/provider-sdk/connected-wallet";
+
+// The full payment flow — new-build-technical-doc.md §4.5, §7.2. Deliberately
+// does NOT use WalletRequired: that gate REPLACES its children when
+// disconnected, but here the button itself must still render (as a "Connect
+// to Pay" prompt) rather than disappear.
+
+type PayState =
+  | { phase: "idle" }
+  | { phase: "quoting" }
+  | { phase: "confirming"; price: string | null; asset: string | null }
+  | { phase: "paying" }
+  | { phase: "success"; txHash: string }
+  | { phase: "error"; message: string };
+
+interface QuoteResponse {
+  free: boolean;
+  price: string | number | null;
+  asset: string | null;
+}
+
+interface PayResponse {
+  content: string | null;
+  txHash: string | null;
+  ledger: number | null;
+  amountPaid: string | null;
+  asset: string | null;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}
+
+export function PayButton({
+  resourceUrl,
+  priceAtomic,
+}: {
+  resourceUrl: string;
+  priceAtomic?: string;
+}) {
+  const { isConnected, address, connect, signTransaction } = useConnectedWallet();
+  const [state, setState] = useState<PayState>({ phase: "idle" });
+
+  if (!isConnected || !address) {
+    return (
+      <button type="button" className="lp-btn lp-btn--sun lp-btn--sm" onClick={() => void connect()}>
+        Connect to Pay
+      </button>
+    );
+  }
+
+  async function requestQuote() {
+    setState({ phase: "quoting" });
+    try {
+      const res = await fetch(`${marketplaceApiUrl()}/payments/quote`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ resourceUrl, walletAddress: address }),
+      });
+      const body = (await readJson(res)) as Partial<QuoteResponse> & { message?: string };
+      if (!res.ok) {
+        setState({ phase: "error", message: body.message ?? "Could not fetch a quote" });
+        return;
+      }
+      setState({
+        phase: "confirming",
+        price: body.price === null || body.price === undefined ? null : String(body.price),
+        asset: body.asset ?? null,
+      });
+    } catch (err) {
+      setState({
+        phase: "error",
+        message: connectedWalletErrorMessage(err, "Could not reach the marketplace"),
+      });
+    }
+  }
+
+  async function confirmPay() {
+    setState({ phase: "paying" });
+    try {
+      // TODO(step-4): this is a PLACEHOLDER. The real flow builds a Stellar
+      // transaction encoding the x402 payment authorization (the exact shape
+      // depends on what the resource's 402 challenge asked for) and signs
+      // THAT. Signing a literal string lets us verify the UI state machine —
+      // connect → quote → confirm → pay → success/error — end to end before
+      // wiring real transaction construction. The backend's signature check
+      // (lib/signature.ts) will correctly reject this XDR; expect a 401/400
+      // here until step 4 replaces it.
+      const signedXdr = await signTransaction("placeholder");
+      const res = await fetch(`${marketplaceApiUrl()}/payments/pay`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          resourceUrl,
+          signedXdr,
+          walletAddress: address,
+          maxAmount: priceAtomic ?? "0",
+        }),
+      });
+      const body = (await readJson(res)) as Partial<PayResponse> & { message?: string };
+      if (!res.ok) {
+        setState({ phase: "error", message: body.message ?? "Payment failed" });
+        return;
+      }
+      setState({ phase: "success", txHash: body.txHash ?? "" });
+      setTimeout(() => setState({ phase: "idle" }), 3000);
+    } catch (err) {
+      setState({
+        phase: "error",
+        message: connectedWalletErrorMessage(err, "Payment failed"),
+      });
+    }
+  }
+
+  if (state.phase === "error") {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--lp-sp-2)" }}>
+        <button type="button" className="lp-btn lp-btn--sun lp-btn--sm" onClick={() => void requestQuote()}>
+          Pay
+        </button>
+        <div className="lp-mkt-error">
+          <p>{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.phase === "success") {
+    const short = state.txHash ? `${state.txHash.slice(0, 6)}...${state.txHash.slice(-4)}` : "";
+    return (
+      <span className="lp-verified">
+        Paid{short && ` · ${short}`}
+      </span>
+    );
+  }
+
+  if (state.phase === "paying") {
+    return (
+      <button type="button" disabled className="lp-btn lp-btn--sun lp-btn--sm" style={{ opacity: 0.6 }}>
+        Paying...
+      </button>
+    );
+  }
+
+  if (state.phase === "confirming") {
+    const priceLabel = state.price !== null ? `${state.price} ${state.asset ?? ""}`.trim() : "price";
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--lp-sp-2)" }}>
+        <span style={{ fontFamily: "var(--lp-mono)", fontSize: "var(--lp-fs-sm)", color: "var(--lp-ink)" }}>
+          {priceLabel}
+        </span>
+        <button type="button" className="lp-btn lp-btn--sun lp-btn--sm" onClick={() => void confirmPay()}>
+          Confirm
+        </button>
+        <button
+          type="button"
+          className="lp-btn lp-btn--ghost lp-btn--sm"
+          onClick={() => setState({ phase: "idle" })}
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  const busy = state.phase === "quoting";
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      className="lp-btn lp-btn--sun lp-btn--sm"
+      style={busy ? { opacity: 0.6, cursor: "not-allowed" } : undefined}
+      onClick={() => void requestQuote()}
+    >
+      {busy ? "Loading..." : "Pay"}
+    </button>
+  );
+}

--- a/apps/web/components/marketplace/WalletConnectButton.tsx
+++ b/apps/web/components/marketplace/WalletConnectButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useConnectedWallet } from "../../lib/connected-wallet-context";
+
+// UI entry point for connecting a classic Stellar wallet —
+// new-build-technical-doc.md §3.2. Used in the marketplace, seller portal,
+// and team dashboard headers.
+
+export function WalletConnectButton() {
+  const { isConnected, isConnecting, address, connect, disconnect, error } = useConnectedWallet();
+
+  if (isConnecting) {
+    return (
+      <button
+        disabled
+        className="cursor-not-allowed rounded-lg bg-neutral-800 px-4 py-2 text-sm text-neutral-400"
+      >
+        Connecting...
+      </button>
+    );
+  }
+
+  if (isConnected && address) {
+    return (
+      <div className="flex items-center gap-2">
+        <span
+          className="font-mono text-sm text-neutral-300"
+          title={address}
+          data-testid="connected-wallet-address"
+        >
+          {address.slice(0, 4)}...{address.slice(-4)}
+        </span>
+        <button
+          onClick={disconnect}
+          className="rounded-lg bg-neutral-800 px-3 py-1.5 text-xs text-neutral-400 transition-colors hover:bg-neutral-700"
+        >
+          Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={() => void connect()}
+        className="rounded-lg bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-neutral-100"
+      >
+        Connect Wallet
+      </button>
+      {error && (
+        <p role="alert" className="text-xs text-red-400">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/marketplace/WalletRequired.tsx
+++ b/apps/web/components/marketplace/WalletRequired.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useConnectedWallet } from "../../lib/connected-wallet-context";
+import { WalletConnectButton } from "./WalletConnectButton";
+
+// Gate for any action that needs a connected wallet —
+// new-build-technical-doc.md §3.4. Wraps PayButton, ListingForm, and
+// TeamBudgetCard in later milestones.
+
+export function WalletRequired({
+  children,
+  message = "Connect your wallet to continue",
+}: {
+  children: React.ReactNode;
+  message?: string;
+}) {
+  const { isConnected } = useConnectedWallet();
+
+  if (!isConnected) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-12">
+        <p className="text-sm text-neutral-400">{message}</p>
+        <WalletConnectButton />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/components/seller/ListingForm.tsx
+++ b/apps/web/components/seller/ListingForm.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useConnectedWallet } from "../../lib/connected-wallet-context";
+import { marketplaceApiUrl } from "../../lib/config";
+import type { ListingRecord } from "../../lib/marketplace-types";
+import { connectedWalletErrorMessage } from "@vellar/provider-sdk/connected-wallet";
+
+// Seller registration form — new-build-technical-doc.md §5.2, §7.2. The
+// registration nonce is fetched on mount (step 1 of the flow) so it's ready
+// the moment the seller submits; §5.2's 5-minute TTL comfortably covers the
+// time spent filling in the form.
+
+interface FormState {
+  title: string;
+  description: string;
+  resourceUrl: string;
+  priceAtomic: string;
+  asset: string;
+  scheme: "exact" | "upto";
+}
+
+const EMPTY_FORM: FormState = {
+  title: "",
+  description: "",
+  resourceUrl: "",
+  priceAtomic: "",
+  asset: "",
+  scheme: "exact",
+};
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}
+
+export function ListingForm({
+  walletAddress,
+  onSuccess,
+}: {
+  walletAddress: string;
+  onSuccess: (listing: ListingRecord) => void;
+}) {
+  const { signTransaction } = useConnectedWallet();
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [nonce, setNonce] = useState<string | null>(null);
+  const [nonceError, setNonceError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Step 1 of the nonce flow (§5.2): fetch on mount so it's already in hand
+  // by the time the seller finishes the form.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `${marketplaceApiUrl()}/listings/nonce?address=${encodeURIComponent(walletAddress)}`,
+        );
+        const body = (await readJson(res)) as { nonce?: string; message?: string };
+        if (cancelled) return;
+        if (!res.ok || !body.nonce) {
+          setNonceError(body.message ?? "Could not get a registration nonce");
+          return;
+        }
+        setNonce(body.nonce);
+      } catch (err) {
+        if (!cancelled) {
+          setNonceError(err instanceof Error ? err.message : "Could not reach the marketplace");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [walletAddress]);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!nonce) {
+      setSubmitError("No registration nonce available yet — try again in a moment.");
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      // TODO(step-4): PLACEHOLDER signature. The real flow builds a Stellar
+      // transaction with a single ManageData("vellar-register", nonce)
+      // operation (new-build-technical-doc.md §5.2 step 2) and signs THAT —
+      // it requires @stellar/stellar-sdk's TransactionBuilder client-side,
+      // which is deferred to the follow-on step so this one can verify the
+      // nonce-fetch → form → submit UI flow end to end first. The backend's
+      // verifyRegistrationSignature will correctly reject this placeholder;
+      // expect 400/401 here until step 4 replaces it.
+      const signedXdr = await signTransaction("placeholder");
+      const res = await fetch(`${marketplaceApiUrl()}/listings`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          resourceUrl: form.resourceUrl,
+          title: form.title,
+          description: form.description || undefined,
+          priceAtomic: form.priceAtomic,
+          asset: form.asset,
+          scheme: form.scheme,
+          signedXdr,
+          walletAddress,
+        }),
+      });
+      const body = (await readJson(res)) as { listing?: ListingRecord; message?: string };
+      if (!res.ok || !body.listing) {
+        setSubmitError(body.message ?? "Could not create the listing");
+        return;
+      }
+      onSuccess(body.listing);
+    } catch (err) {
+      setSubmitError(connectedWalletErrorMessage(err, "Could not create the listing"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="lp-mkt-form" onSubmit={(e) => void handleSubmit(e)}>
+      {nonceError && (
+        <div className="lp-mkt-error" role="alert">
+          <div>
+            <strong>Setup failed</strong>
+            <p>{nonceError}</p>
+          </div>
+        </div>
+      )}
+
+      <div className="lp-mkt-field">
+        <label htmlFor="listing-title">Title</label>
+        <input
+          id="listing-title"
+          type="text"
+          required
+          value={form.title}
+          onChange={(e) => update("title", e.target.value)}
+        />
+      </div>
+
+      <div className="lp-mkt-field">
+        <label htmlFor="listing-description">Description</label>
+        <textarea
+          id="listing-description"
+          value={form.description}
+          onChange={(e) => update("description", e.target.value)}
+        />
+      </div>
+
+      <div className="lp-mkt-field">
+        <label htmlFor="listing-resource-url">Resource URL</label>
+        <input
+          id="listing-resource-url"
+          type="url"
+          required
+          value={form.resourceUrl}
+          onChange={(e) => update("resourceUrl", e.target.value)}
+        />
+        <span className="field-hint">The URL that returns 402 Payment Required</span>
+      </div>
+
+      <div className="lp-mkt-field">
+        <label htmlFor="listing-price">Price (base units)</label>
+        <input
+          id="listing-price"
+          type="number"
+          inputMode="numeric"
+          min={0}
+          step={1}
+          required
+          value={form.priceAtomic}
+          onChange={(e) => update("priceAtomic", e.target.value)}
+        />
+        <span className="field-hint">Price in base units (1 USDC = 10,000,000)</span>
+      </div>
+
+      <div className="lp-mkt-field">
+        <label htmlFor="listing-asset">Asset</label>
+        <input
+          id="listing-asset"
+          type="text"
+          required
+          value={form.asset}
+          onChange={(e) => update("asset", e.target.value)}
+        />
+        <span className="field-hint">Asset contract ID</span>
+      </div>
+
+      <div className="lp-mkt-field">
+        <label htmlFor="listing-scheme">Scheme</label>
+        <select
+          id="listing-scheme"
+          value={form.scheme}
+          onChange={(e) => update("scheme", e.target.value as FormState["scheme"])}
+        >
+          <option value="exact">exact</option>
+          <option value="upto">upto</option>
+        </select>
+      </div>
+
+      {submitError && (
+        <div className="lp-mkt-error" role="alert">
+          <div>
+            <strong>Could not list this service</strong>
+            <p>{submitError}</p>
+          </div>
+        </div>
+      )}
+
+      <div className="lp-cta-row">
+        <button type="submit" disabled={submitting} className="lp-btn lp-btn--sun">
+          {submitting ? "Listing..." : "List service"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/e2e/extension.spec.ts
+++ b/apps/web/e2e/extension.spec.ts
@@ -61,7 +61,7 @@ test("extension: pair, dApp connect, one-click device-signer payment (live testn
     await expect(web).toHaveURL(/\/dashboard/, { timeout: 120_000 });
 
     await web.getByRole("button", { name: "Receive" }).click();
-    const addressLocator = web.locator("p.mono", { hasText: /^C[A-Z2-7]{55}$/ }).first();
+    const addressLocator = web.getByTestId("wallet-address");
     await expect(addressLocator).toBeVisible({ timeout: 30_000 });
     const contractId = (await addressLocator.textContent())!.trim();
     await web.getByRole("button", { name: "Close" }).click();

--- a/apps/web/e2e/policy.spec.ts
+++ b/apps/web/e2e/policy.spec.ts
@@ -39,7 +39,7 @@ test("passkey wallet: create, fund, deploy spending-limit policy (live testnet)"
   await expect(page).toHaveURL(/\/dashboard/, { timeout: 120_000 });
 
   await page.getByRole("button", { name: "Receive" }).click();
-  const addressLocator = page.locator("p.mono", { hasText: /^C[A-Z2-7]{55}$/ }).first();
+  const addressLocator = page.getByTestId("wallet-address");
   await expect(addressLocator).toBeVisible({ timeout: 30_000 });
   const contractId = (await addressLocator.textContent())!.trim();
   await page.getByRole("button", { name: "Close" }).click();
@@ -47,7 +47,7 @@ test("passkey wallet: create, fund, deploy spending-limit policy (live testnet)"
   // --- Fund the wallet (the account must exist on-chain to add a signer) ---
   await fundSmartWallet(contractId, 25n);
   await page.reload();
-  await expect(page.locator(".bal")).toContainText("25", { timeout: 60_000 });
+  await expect(page.getByTestId("account-balance")).toContainText("25", { timeout: 60_000 });
 
   // --- Build a spending-limit policy ---
   await page.goto("/policies");
@@ -67,7 +67,7 @@ test("passkey wallet: create, fund, deploy spending-limit policy (live testnet)"
     timeout: 240_000,
   });
   // The attached policy contract id is shown (C…).
-  await expect(page.locator("p.mono", { hasText: /^contract C[A-Z2-7]{55}$/ })).toBeVisible({
+  await expect(page.getByTestId("policy-contract-id")).toHaveText(/^contract C[A-Z2-7]{55}$/, {
     timeout: 30_000,
   });
 });

--- a/apps/web/e2e/wallet.spec.ts
+++ b/apps/web/e2e/wallet.spec.ts
@@ -33,13 +33,13 @@ test("passkey wallet: create, fund, pay, reconnect (live testnet)", async ({ pag
 
   // Read the full contract id from the Receive panel.
   await page.getByRole("button", { name: "Receive" }).click();
-  const addressLocator = page.locator("p.mono", { hasText: /^C[A-Z2-7]{55}$/ }).first();
+  const addressLocator = page.getByTestId("wallet-address");
   await expect(addressLocator).toBeVisible({ timeout: 30_000 });
   const contractId = (await addressLocator.textContent())!.trim();
   await page.getByRole("button", { name: "Close" }).click();
 
   // Fresh wallet: balance hero reads 0 XLM.
-  const balanceHero = page.locator(".bal");
+  const balanceHero = page.getByTestId("account-balance");
   await expect(balanceHero).toContainText("0", { timeout: 60_000 });
 
   // --- Fund the smart wallet on-chain, then confirm the dashboard sees it ---
@@ -69,5 +69,5 @@ test("passkey wallet: create, fund, pay, reconnect (live testnet)", async ({ pag
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page).toHaveURL(/\/dashboard/, { timeout: 60_000 });
   await page.getByRole("button", { name: "Receive" }).click();
-  await expect(page.locator("p.mono", { hasText: contractId })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("wallet-address")).toHaveText(contractId, { timeout: 30_000 });
 });

--- a/apps/web/lib/connected-wallet-context.tsx
+++ b/apps/web/lib/connected-wallet-context.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  connectedWalletErrorMessage,
+  connectedWalletPassphrase,
+  createConnectedWalletKit,
+  type ConnectedWalletNetwork,
+  type ConnectedWalletState,
+} from "@vellar/provider-sdk/connected-wallet";
+import { walletConfig } from "./config";
+
+// Connected (classic G-address) wallet context for the marketplace surfaces —
+// new-build-technical-doc.md §3.2. This deliberately shares NOTHING with the
+// passkey wallet context (lib/wallet-context.tsx): the two run in parallel and
+// the passkey app (/app, /dashboard, /policies) is untouched by this file.
+
+type ConnectedWalletContextValue = ConnectedWalletState & {
+  connect: (walletId?: string) => Promise<void>;
+  disconnect: () => void;
+  signTransaction: (xdr: string) => Promise<string>;
+};
+
+const ConnectedWalletContext = createContext<ConnectedWalletContextValue | null>(null);
+
+const DISCONNECTED: ConnectedWalletState = {
+  address: null,
+  walletId: null,
+  isConnecting: false,
+  isConnected: false,
+  error: null,
+};
+
+export function ConnectedWalletProvider({
+  children,
+  network,
+}: {
+  children: React.ReactNode;
+  /** Defaults to the same network the passkey path reads from config. */
+  network?: ConnectedWalletNetwork;
+}) {
+  // One passphrase source of truth for both surfaces (follow-on note 1): the
+  // passkey path resolves it in lib/config.ts, so the connected path reads the
+  // same config rather than hardcoding a second value.
+  const config = useMemo(() => walletConfig(), []);
+  const resolvedNetwork: ConnectedWalletNetwork = network ?? config.network;
+  // config.networkPassphrase is operator-overridable via env; fall back to the
+  // network's canonical passphrase when it is unset.
+  const networkPassphrase =
+    config.networkPassphrase || connectedWalletPassphrase(resolvedNetwork);
+
+  const [state, setState] = useState<ConnectedWalletState>(DISCONNECTED);
+
+  // Guards a late restore from clobbering a connect/disconnect that raced it.
+  const restoredRef = useRef(false);
+
+  // Restore on mount (follow-on note 2). The kit persists activeAddress and
+  // selectedModuleId to localStorage itself (its state/effects.ts
+  // updateActiveSession effect) and re-hydrates those signals at import, so
+  // there is no second storage layer to maintain here. But a hydrated address
+  // only proves what this browser last saw — it does NOT prove the wallet is
+  // still connected. fetchAddress() round-trips to the wallet to confirm;
+  // getAddress() would merely echo the cached signal back.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const kit = await createConnectedWalletKit(resolvedNetwork);
+        const { address } = await kit.fetchAddress();
+        if (cancelled || restoredRef.current) return;
+        restoredRef.current = true;
+        setState({
+          address,
+          walletId: kit.selectedModule.productId,
+          isConnecting: false,
+          isConnected: true,
+          error: null,
+        });
+      } catch {
+        // No live session (nothing persisted, permission revoked, extension
+        // removed, wrong network). Stay disconnected and surface no error —
+        // the user never asked to connect on this page load.
+        if (cancelled || restoredRef.current) return;
+        restoredRef.current = true;
+        try {
+          const kit = await createConnectedWalletKit(resolvedNetwork);
+          await kit.disconnect();
+        } catch {
+          // Clearing stale state is best-effort.
+        }
+        if (!cancelled) setState(DISCONNECTED);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [resolvedNetwork]);
+
+  const connect = useCallback(
+    async (walletId?: string) => {
+      restoredRef.current = true;
+      setState((s) => ({ ...s, isConnecting: true, error: null }));
+      try {
+        const kit = await createConnectedWalletKit(resolvedNetwork);
+        let address: string;
+        if (walletId) {
+          kit.setWallet(walletId);
+          ({ address } = await kit.fetchAddress());
+        } else {
+          // authModal both selects the module and resolves the address.
+          ({ address } = await kit.authModal());
+        }
+        setState({
+          address,
+          walletId: kit.selectedModule.productId,
+          isConnecting: false,
+          isConnected: true,
+          error: null,
+        });
+      } catch (err) {
+        setState({
+          ...DISCONNECTED,
+          error: connectedWalletErrorMessage(err, "Failed to connect wallet"),
+        });
+      }
+    },
+    [resolvedNetwork],
+  );
+
+  const disconnect = useCallback(() => {
+    restoredRef.current = true;
+    setState(DISCONNECTED);
+    // Clears the kit's in-memory signals AND its persisted localStorage keys.
+    void (async () => {
+      try {
+        const kit = await createConnectedWalletKit(resolvedNetwork);
+        await kit.disconnect();
+      } catch {
+        // Local state is already cleared; nothing further to do.
+      }
+    })();
+  }, [resolvedNetwork]);
+
+  const signTransaction = useCallback(
+    async (xdr: string) => {
+      const kit = await createConnectedWalletKit(resolvedNetwork);
+      // Always explicit (follow-on note 1): the kit would otherwise fall back
+      // to its own selected-network signal, which can drift from the app's
+      // configured network and silently sign for the wrong one.
+      const { signedTxXdr } = await kit.signTransaction(xdr, { networkPassphrase });
+      return signedTxXdr;
+    },
+    [resolvedNetwork, networkPassphrase],
+  );
+
+  const value = useMemo<ConnectedWalletContextValue>(
+    () => ({ ...state, connect, disconnect, signTransaction }),
+    [state, connect, disconnect, signTransaction],
+  );
+
+  return (
+    <ConnectedWalletContext.Provider value={value}>{children}</ConnectedWalletContext.Provider>
+  );
+}
+
+export function useConnectedWallet(): ConnectedWalletContextValue {
+  const ctx = useContext(ConnectedWalletContext);
+  if (!ctx) {
+    throw new Error("useConnectedWallet must be used within ConnectedWalletProvider");
+  }
+  return ctx;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test:e2e:ci": "playwright test --grep @ci"
   },
   "dependencies": {
+    "@creit.tech/stellar-wallets-kit": "^2.6.0",
     "@hookform/resolvers": "^5.1.0",
     "@stellar/stellar-sdk": "^16.0.1",
     "@tanstack/react-query": "^5.83.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
     "@vellar/verification-sdk": "workspace:*",
     "gsap": "^3.15.0",
     "lenis": "^1.3.26",
-    "next": "^16.2.11",
+    "next": "^16.3.4",
     "ogl": "^1.0.11",
     "passkey-kit": "^0.14.0",
     "react": "^19.2.0",

--- a/packages/provider-sdk/package.json
+++ b/packages/provider-sdk/package.json
@@ -5,13 +5,15 @@
   "description": "dApp provider interface, request/response schemas, permission model helpers, extension bridge utilities",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./connected-wallet": "./src/connected-wallet.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
+    "@creit.tech/stellar-wallets-kit": "^2.6.0",
     "@vellar/types": "workspace:*",
     "zod": "^4.0.0"
   },

--- a/packages/provider-sdk/src/connected-wallet.test.ts
+++ b/packages/provider-sdk/src/connected-wallet.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { connectedWalletErrorMessage, connectedWalletPassphrase } from "./connected-wallet";
+
+describe("connectedWalletPassphrase", () => {
+  it("maps testnet to the SDF test passphrase", () => {
+    expect(connectedWalletPassphrase("testnet")).toBe("Test SDF Network ; September 2015");
+  });
+
+  it("maps mainnet to the public network passphrase", () => {
+    expect(connectedWalletPassphrase("mainnet")).toBe(
+      "Public Global Stellar Network ; September 2015",
+    );
+  });
+
+  // The passkey path (apps/web/lib/config.ts) defaults to exactly this string;
+  // a drift between the two surfaces would sign for the wrong network.
+  it("agrees with the passkey path's testnet default", () => {
+    expect(connectedWalletPassphrase("testnet")).toBe("Test SDF Network ; September 2015");
+  });
+});
+
+describe("connectedWalletErrorMessage", () => {
+  it("unwraps a real Error", () => {
+    expect(connectedWalletErrorMessage(new Error("boom"), "fallback")).toBe("boom");
+  });
+
+  // Stellar Wallets Kit rejects with a PLAIN OBJECT, not an Error (see its
+  // sdk/utils.ts parseError) — e.g. { code: -1, message: "The user closed the
+  // modal." }. An `err instanceof Error` check alone silently drops these.
+  it("unwraps the kit's plain {code,message} rejection", () => {
+    expect(
+      connectedWalletErrorMessage({ code: -1, message: "The user closed the modal." }, "fallback"),
+    ).toBe("The user closed the modal.");
+  });
+
+  it("unwraps the kit's 'no wallet connected' rejection", () => {
+    expect(
+      connectedWalletErrorMessage({ code: -1, message: "No wallet has been connected." }, "fb"),
+    ).toBe("No wallet has been connected.");
+  });
+
+  it("accepts a bare string rejection", () => {
+    expect(connectedWalletErrorMessage("nope", "fallback")).toBe("nope");
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty object", {}],
+    ["message wrong type", { message: 42 }],
+    ["empty message", { message: "" }],
+    ["array", []],
+  ])("falls back for %s", (_label, input) => {
+    expect(connectedWalletErrorMessage(input, "fallback")).toBe("fallback");
+  });
+});

--- a/packages/provider-sdk/src/connected-wallet.ts
+++ b/packages/provider-sdk/src/connected-wallet.ts
@@ -1,0 +1,110 @@
+// Connected (classic G-address) wallet support for the marketplace surfaces,
+// via Stellar Wallets Kit — new-build-technical-doc.md §3.1/§3.2.
+//
+// This is deliberately NOT re-exported from the package barrel (index.ts):
+// apps/extension consumes @vellar/provider-sdk and must not inherit the kit's
+// dependency tree. Import it through the "./connected-wallet" subpath export.
+//
+// API NOTE: @creit.tech/stellar-wallets-kit v2.x exposes StellarWalletsKit as
+// an ALL-STATIC class over a module-global singleton — there is no constructor
+// and no per-instance state. The spec (new-build-technical-doc.md §3.2) was
+// written against an assumed `new StellarWalletsKit({...})` instance API that
+// does not exist in the shipping package. We keep the spec's exported names
+// and shapes and implement them against the real static API (docs/decisions.md).
+
+import {
+  StellarWalletsKit,
+  Networks,
+  type ISupportedWallet,
+} from "@creit.tech/stellar-wallets-kit";
+
+export type ConnectedWalletNetwork = "testnet" | "mainnet";
+
+export type ConnectedWalletState = {
+  address: string | null;
+  walletId: string | null;
+  isConnecting: boolean;
+  isConnected: boolean;
+  error: string | null;
+};
+
+export type ConnectedWalletActions = {
+  connect: (walletId?: string) => Promise<void>;
+  disconnect: () => void;
+  signTransaction: (xdr: string) => Promise<string>;
+  getAddress: () => Promise<string>;
+};
+
+/** Network passphrase for a Vellar network name. Mirrors the values
+ * apps/web/lib/config.ts resolves for the passkey path. */
+export function connectedWalletPassphrase(network: ConnectedWalletNetwork): string {
+  return network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+}
+
+// The kit's state is a module-global singleton, so init() must run exactly
+// once per page. Re-running it would reset activeModules and drop the
+// modules array on every provider remount.
+let initializedNetwork: ConnectedWalletNetwork | null = null;
+
+/**
+ * Idempotently initializes the global kit with the four wallet modules named
+ * in new-build-technical-doc.md §3.1 and returns it.
+ *
+ * The modules are imported lazily because several of them reach for browser
+ * globals (and their upstream CJS deps break under raw Node ESM), so this must
+ * only ever be awaited in the browser — never during SSR.
+ */
+export async function createConnectedWalletKit(
+  network: ConnectedWalletNetwork,
+): Promise<typeof StellarWalletsKit> {
+  if (initializedNetwork === network) return StellarWalletsKit;
+
+  const kitNetwork = network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+  if (initializedNetwork !== null) {
+    // Already initialized for a different network: swap the network only,
+    // keeping the registered modules intact.
+    StellarWalletsKit.setNetwork(kitNetwork);
+    initializedNetwork = network;
+    return StellarWalletsKit;
+  }
+
+  const [{ FreighterModule }, { AlbedoModule }, { xBullModule }, { LobstrModule }] =
+    await Promise.all([
+      import("@creit.tech/stellar-wallets-kit/modules/freighter"),
+      import("@creit.tech/stellar-wallets-kit/modules/albedo"),
+      import("@creit.tech/stellar-wallets-kit/modules/xbull"),
+      import("@creit.tech/stellar-wallets-kit/modules/lobstr"),
+    ]);
+
+  StellarWalletsKit.init({
+    modules: [
+      new FreighterModule(),
+      new AlbedoModule(),
+      new xBullModule(),
+      new LobstrModule(),
+    ],
+    network: kitNetwork,
+  });
+
+  initializedNetwork = network;
+  return StellarWalletsKit;
+}
+
+/**
+ * The kit rejects with a plain `{ code, message }` object rather than an
+ * `Error` (see its sdk/utils.ts parseError), so `err instanceof Error` alone
+ * silently loses the message.
+ */
+export function connectedWalletErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  if (err && typeof err === "object" && "message" in err) {
+    const { message } = err as { message?: unknown };
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  return fallback;
+}
+
+export type { ISupportedWallet };
+export { StellarWalletsKit, Networks };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,13 +87,16 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
       wxt:
         specifier: ^0.20.0
         version: 0.20.27(@types/node@24.13.3)(jiti@2.7.0)(rolldown@1.1.5)(rollup@4.62.2)(tsx@4.23.1)
 
   apps/web:
     dependencies:
+      '@creit.tech/stellar-wallets-kit':
+        specifier: ^2.6.0
+        version: 2.6.0(@types/react@19.2.17)(bufferutil@4.1.0)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       '@hookform/resolvers':
         specifier: ^5.1.0
         version: 5.4.0(react-hook-form@7.81.0(react@19.2.7))(zod@4.4.3)
@@ -181,7 +184,7 @@ importers:
         version: link:../../services/wallet-service
       jsdom:
         specifier: ^26.1.0
-        version: 26.1.0
+        version: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       postcss:
         specifier: ^8.5.0
         version: 8.5.23
@@ -193,7 +196,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   packages/lifecycle-sdk:
     devDependencies:
@@ -208,7 +211,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   packages/policy-sdk:
     devDependencies:
@@ -218,6 +221,9 @@ importers:
 
   packages/provider-sdk:
     dependencies:
+      '@creit.tech/stellar-wallets-kit':
+        specifier: ^2.6.0
+        version: 2.6.0(@types/react@19.2.17)(bufferutil@4.1.0)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       '@vellar/types':
         specifier: workspace:*
         version: link:../types
@@ -230,7 +236,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   packages/service-kit:
     dependencies:
@@ -249,7 +255,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   packages/types:
     devDependencies:
@@ -271,7 +277,7 @@ importers:
         version: 19.2.17
       jsdom:
         specifier: ^26.0.0
-        version: 26.1.0
+        version: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -283,7 +289,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   packages/verification-sdk:
     dependencies:
@@ -296,7 +302,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   services/all-in-one:
     dependencies:
@@ -333,7 +339,7 @@ importers:
         version: 13.1.0
       '@fastify/http-proxy':
         specifier: ^11.0.0
-        version: 11.5.0
+        version: 11.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@fastify/rate-limit':
         specifier: ^10.2.0
         version: 10.3.0
@@ -352,7 +358,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   services/lifecycle-service:
     dependencies:
@@ -380,7 +386,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   services/permission-service:
     devDependencies:
@@ -426,7 +432,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   services/verification-service:
     dependencies:
@@ -466,7 +472,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   services/wallet-service:
     dependencies:
@@ -509,7 +515,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
   services/worker-service:
     dependencies:
@@ -546,7 +552,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
 
 packages:
 
@@ -559,6 +565,9 @@ packages:
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
   '@aklinker1/rollup-plugin-visualizer@5.12.0':
     resolution: {integrity: sha512-X24LvEGw6UFmy0lpGJDmXsMyBD58XmX1bbwsaMLhNoM+UMQfQ3b2RtC+nz4b/NoRK5r6QJSKJHBNVeUdwqybaQ==}
     engines: {node: '>=14'}
@@ -568,6 +577,9 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@albedo-link/intent@0.12.0':
+    resolution: {integrity: sha512-UlGBhi0qASDYOjLrOL4484vQ26Ee3zTK2oAgvPMClOs+1XNk3zbs3dECKZv+wqeSI8SkHow8mXLTa16eVh+dQA==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -666,6 +678,39 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-org/account@2.4.0':
+    resolution: {integrity: sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==}
+
+  '@bufbuild/protobuf@2.14.1':
+    resolution: {integrity: sha512-agRJn3+EJDUe8AvxTx/LnHA/GErvLE62pSaSk7+MwFOtOv8eWBu/qCq2qoZjBjVZ3C2aiFJCveuSs17KMkYGOw==}
+
+  '@coinbase/cdp-sdk@1.55.0':
+    resolution: {integrity: sha512-5PbUg3n3Jk9nm8nEStskRv6jTrVZKkgwxMFjW+i/xUDDzK1fXksKwXdjgUiHB1hf0FZx1LiYBosrh4IULxFyPA==}
+    peerDependencies:
+      '@x402/core': ^2.21.0
+      '@x402/evm': ^2.21.0
+      '@x402/extensions': ^2.21.0
+      '@x402/svm': ^2.21.0
+    peerDependenciesMeta:
+      '@x402/core':
+        optional: true
+      '@x402/evm':
+        optional: true
+      '@x402/extensions':
+        optional: true
+      '@x402/svm':
+        optional: true
+
+  '@coinbase/wallet-sdk@4.3.6':
+    resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
+
+  '@creit.tech/stellar-wallets-kit@2.6.0':
+    resolution: {integrity: sha512-jrqCBhbYUOBLZu/UmaItv/i1CISDImjucY8RhtHzvpx6WXBKb9vW+wqeyjK578tPf+CV24ZTZq+vy7qGlyooKg==}
+
+  '@creit.tech/xbull-wallet-connect@0.4.0':
+    resolution: {integrity: sha512-LrCUIqUz50SkZ4mv2hTqSmwews8CNRYVoZ9+VjLsK/1U8PByzXTxv1vZyenj6avRTG86ifpoeihz7D3D5YIDrQ==}
+    engines: {node: '>=16'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -887,6 +932,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -925,6 +979,9 @@ packages:
     peerDependencies:
       react-hook-form: ^7.55.0
       zod: '*'
+
+  '@hot-wallet/sdk@1.0.11':
+    resolution: {integrity: sha512-qRDH/4yqnRCnk7L/Qd0/LDOKDUKWcFgvf6eRELJkP0OgxIe65i/iXaG+u2lL0mLbTGkiWYk67uAvEerNUv2gzA==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1104,9 +1161,49 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@ledgerhq/devices@8.6.1':
+    resolution: {integrity: sha512-PQR2fyWz7P/wMFHY9ZLz17WgFdxC/Im0RVDcWXpp24+iRQRyxhQeX2iG4mBKUzfaAW6pOIEiWt+vmJh88QP9rQ==}
+
+  '@ledgerhq/errors@6.37.0':
+    resolution: {integrity: sha512-T5yiKI5UX7ugeocdTF3TUsCIN2BH41Bio4ZeN410YFjFOf3es08n/5JyMzzKwzRgP0blG3HfBf7s7vJKqCSAeg==}
+
+  '@ledgerhq/hw-app-str@7.2.8':
+    resolution: {integrity: sha512-VHICY9jyZW5LM/8zc/mSbW7fS2bAC1OTVOtRwdQLEDn6Gv9UaNcCWjaHI1UKAnDUqYX7DUQuIPiTP1b4O+mtUQ==}
+
+  '@ledgerhq/hw-transport-webusb@6.29.12':
+    resolution: {integrity: sha512-mMGKPYAUz9MNcURe+hSTSHwqPwCli6D0lCl15Z4hDOpcqhZ26vwoeWVKeQp53NNCetHOl0lauPkN43Gt9pIggg==}
+
+  '@ledgerhq/hw-transport@6.31.12':
+    resolution: {integrity: sha512-FO5LRIXYC8ELtaohlO8qK0b3TfHUNBZ3+CXKPHiHj2jJwrxPf4s5kcgBYrmzuf1C/1vfrMOjzyty6OgrMIbU6Q==}
+
+  '@ledgerhq/logs@6.19.0':
+    resolution: {integrity: sha512-kmWj18C7eTtuytdaWygzVrQm9EoD4YWuYnd/kY8stVBBAzRdJzrGlm013ijQF6I/kGLKlGY7JKmll6j32KGpfQ==}
+
+  '@lit-labs/ssr-dom-shim@1.6.0':
+    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
+
+  '@lit/react@1.0.8':
+    resolution: {integrity: sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==}
+    peerDependencies:
+      '@types/react': 17 || 18 || 19
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@lobstrco/signer-extension-api@2.0.0':
+    resolution: {integrity: sha512-jwlVyzMFF296iaNgMWn1lu+EU6BeUD4mgPurEsy8EygYNCrjA8igLpsDlXhfvXhst9tX5w4wRuTDX+FZtpfCug==}
+
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+
+  '@msgpack/msgpack@3.1.2':
+    resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
+    engines: {node: '>= 18'}
+
+  '@msgpack/msgpack@3.1.3':
+    resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
+    engines: {node: '>= 18'}
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -1114,6 +1211,44 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+
+  '@near-js/accounts@1.4.1':
+    resolution: {integrity: sha512-ni3QT9H3NdrbVVKyx56yvz93r89Dvpc/vgVtiIK2OdXjkK6jcj+UKMDRQ6F7rd9qJOInLkHZbVBtcR6j1CXLjw==}
+
+  '@near-js/crypto@1.4.2':
+    resolution: {integrity: sha512-GRfchsyfWvSAPA1gI9hYhw5FH94Ac1BUo+Cmp5rSJt/V0K3xVzCWgOQxvv4R3kDnWjaXJEuAmpEEnr4Bp3FWrA==}
+
+  '@near-js/keystores-browser@0.2.2':
+    resolution: {integrity: sha512-Pxqm7WGtUu6zj32vGCy9JcEDpZDSB5CCaLQDTQdF3GQyL0flyRv2I/guLAgU5FLoYxU7dJAX9mslJhPW7P2Bfw==}
+
+  '@near-js/keystores-node@0.1.2':
+    resolution: {integrity: sha512-MWLvTszZOVziiasqIT/LYNhUyWqOJjDGlsthOsY6dTL4ZcXjjmhmzrbFydIIeQr+CcEl5wukTo68ORI9JrHl6g==}
+
+  '@near-js/keystores@0.2.2':
+    resolution: {integrity: sha512-DLhi/3a4qJUY+wgphw2Jl4S+L0AKsUYm1mtU0WxKYV5OBwjOXvbGrXNfdkheYkfh3nHwrQgtjvtszX6LrRXLLw==}
+
+  '@near-js/providers@1.0.3':
+    resolution: {integrity: sha512-VJMboL14R/+MGKnlhhE3UPXCGYvMd1PpvF9OqZ9yBbulV7QVSIdTMfY4U1NnDfmUC2S3/rhAEr+3rMrIcNS7Fg==}
+
+  '@near-js/signers@0.2.2':
+    resolution: {integrity: sha512-M6ib+af9zXAPRCjH2RyIS0+RhCmd9gxzCeIkQ+I2A3zjgGiEDkBZbYso9aKj8Zh2lPKKSH7h+u8JGymMOSwgyw==}
+
+  '@near-js/transactions@1.3.3':
+    resolution: {integrity: sha512-1AXD+HuxlxYQmRTLQlkVmH+RAmV3HwkAT8dyZDu+I2fK/Ec9BQHXakOJUnOBws3ihF+akQhamIBS5T0EXX/Ylw==}
+
+  '@near-js/types@0.3.1':
+    resolution: {integrity: sha512-8qIA7ynAEAuVFNAQc0cqz2xRbfyJH3PaAG5J2MgPPhD18lu/tCGd6pzYg45hjhtiJJRFDRjh/FUWKS+ZiIIxUw==}
+
+  '@near-js/utils@1.1.0':
+    resolution: {integrity: sha512-5XWRq7xpu8Wud9pRXe2U347KXyi0mXofedUY2DQ9TaqiZUcMIaN9xj7DbCs2v6dws3pJyYrT1KWxeNp5fSaY3w==}
+
+  '@near-js/wallet-account@1.3.3':
+    resolution: {integrity: sha512-GDzg/Kz0GBYF7tQfyQQQZ3vviwV8yD+8F2lYDzsWJiqIln7R1ov0zaXN4Tii86TeS21KPn2hHAsVu3Y4txa8OQ==}
+
+  '@near-wallet-selector/core@8.10.2':
+    resolution: {integrity: sha512-MH8sg6XHyylq2ZXxnOjrKHMCmuRgFfpfdC816fW0R8hctZiXZ0lmfLvgG1xfA2BAxrVytiU1g3dcE97/P5cZqg==}
+    peerDependencies:
+      near-api-js: ^4.0.0 || ^5.0.0
 
   '@next/env@16.3.0':
     resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
@@ -1170,12 +1305,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.8.0':
+    resolution: {integrity: sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.8.1':
+    resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/ed25519@3.1.0':
     resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
+
+  '@noble/hashes@1.3.3':
+    resolution: {integrity: sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==}
+    engines: {node: '>= 16'}
+
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
+
+  '@noble/hashes@1.7.0':
+    resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.7.1':
+    resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -1200,6 +1367,9 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
+  '@phosphor-icons/webcomponents@2.1.5':
+    resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -1219,6 +1389,43 @@ packages:
   '@pnpm/npm-conf@3.0.3':
     resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
     engines: {node: '>=12'}
+
+  '@preact/signals-core@1.14.4':
+    resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
+
+  '@preact/signals@2.9.0':
+    resolution: {integrity: sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==}
+    peerDependencies:
+      preact: '>= 10.25.0 || >=11.0.0-0'
+
+  '@reown/appkit-common@1.8.21':
+    resolution: {integrity: sha512-FigrZbke9dHVdc4GjG4JNqClIN58gOhREugLx2oEBUFD2e3oQNvX2gcjoUDM2yP0ZAaIEYJOXwjw4sbBU4gzLQ==}
+
+  '@reown/appkit-controllers@1.8.21':
+    resolution: {integrity: sha512-2xh64lhPb+p0pwKQDQXpokUGqklB+xWD0JpfBvMVEZxeYzKXyJ7piRBB45TH01Etyitkh5Fh4pzBYz4gbIZSog==}
+
+  '@reown/appkit-pay@1.8.21':
+    resolution: {integrity: sha512-Tsio2tVcJgBa3WGhDty3Wy9XevTkZISrDsEpR8iaOnaPHdJrKXt7lbFrTEfptKjSgdnKcjhQXqzOdgiF9ljfnA==}
+
+  '@reown/appkit-polyfills@1.8.21':
+    resolution: {integrity: sha512-EurjE4G6M27yf77GPSuOu1gjUvpRKS3NC5FJgFMzZxmkF5/Dm9kQdokvzK1rdmtQ8JKe+XHmQ75NbmCFt1/7FQ==}
+
+  '@reown/appkit-scaffold-ui@1.8.21':
+    resolution: {integrity: sha512-bJxHdZmjwwAd1fIQmMgr0jjvyT1EI0KetFP+7UlTs51SxOflXzZ+rz9ZcWKNSLFtSQOro1+Xu6aPRO+5OapmhA==}
+
+  '@reown/appkit-ui@1.8.21':
+    resolution: {integrity: sha512-1AthTwGq1/gR1Xjib1kkt7unz0Hgh7wbdm1LvOA+Tfp79W8gM1BI/ELP/D8VwTOtaTgHCWERmlnps65p8MHi5Q==}
+
+  '@reown/appkit-utils@1.8.21':
+    resolution: {integrity: sha512-WzEYji9oQIh9P8WkqXiqrLyx/ZYy+svpwT4u2ZC8n7sMSl0j+AzRqMaVrblyFEYAFkW/BtxVqJEqstDZ8f0FYw==}
+    peerDependencies:
+      valtio: 2.1.7
+
+  '@reown/appkit-wallet@1.8.21':
+    resolution: {integrity: sha512-4Y0W8QUdnXpy/KA9Lg1ESZN6VQurBIX3BhLQYIGwQ2/D3CuFe3xCbQDQOuDdgeAr0cMjgnFOvpGy0iOBH9Aivg==}
+
+  '@reown/appkit@1.8.21':
+    resolution: {integrity: sha512-+6IRUBc9cgXKhNHzxlzxEp7nL1Jx/lcYgHdqwD10O7MPzU2/Ao5/epwt5vqn1nUlwyI6Awm/YCUWIa0Zg5RVEA==}
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -1459,11 +1666,419 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@safe-global/safe-apps-provider@0.18.6':
+    resolution: {integrity: sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==}
+
+  '@safe-global/safe-apps-sdk@9.1.0':
+    resolution: {integrity: sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==}
+
+  '@safe-global/safe-gateway-typescript-sdk@3.23.1':
+    resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
+    engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
   '@simplewebauthn/browser@13.3.0':
     resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
+  '@sinclair/typebox@0.34.52':
+    resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
+
+  '@solana-program/system@0.10.0':
+    resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
+  '@solana-program/token@0.9.0':
+    resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
+  '@solana/accounts@5.5.1':
+    resolution: {integrity: sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/addresses@5.5.1':
+    resolution: {integrity: sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/assertions@5.5.1':
+    resolution: {integrity: sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/buffer-layout@4.0.1':
+    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
+    engines: {node: '>=5.10'}
+
+  '@solana/codecs-core@5.5.1':
+    resolution: {integrity: sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-data-structures@5.5.1':
+    resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-numbers@5.5.1':
+    resolution: {integrity: sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-strings@5.5.1':
+    resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+      typescript:
+        optional: true
+
+  '@solana/codecs@5.5.1':
+    resolution: {integrity: sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/errors@5.5.1':
+    resolution: {integrity: sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fast-stable-stringify@5.5.1':
+    resolution: {integrity: sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/functional@5.5.1':
+    resolution: {integrity: sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instruction-plans@5.5.1':
+    resolution: {integrity: sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instructions@5.5.1':
+    resolution: {integrity: sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/keys@5.5.1':
+    resolution: {integrity: sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/kit@5.5.1':
+    resolution: {integrity: sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/nominal-types@5.5.1':
+    resolution: {integrity: sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/offchain-messages@5.5.1':
+    resolution: {integrity: sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/options@5.5.1':
+    resolution: {integrity: sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/plugin-core@5.5.1':
+    resolution: {integrity: sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/programs@5.5.1':
+    resolution: {integrity: sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/promises@5.5.1':
+    resolution: {integrity: sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-api@5.5.1':
+    resolution: {integrity: sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-parsed-types@5.5.1':
+    resolution: {integrity: sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec-types@5.5.1':
+    resolution: {integrity: sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec@5.5.1':
+    resolution: {integrity: sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-api@5.5.1':
+    resolution: {integrity: sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-channel-websocket@5.5.1':
+    resolution: {integrity: sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-spec@5.5.1':
+    resolution: {integrity: sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions@5.5.1':
+    resolution: {integrity: sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transformers@5.5.1':
+    resolution: {integrity: sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transport-http@5.5.1':
+    resolution: {integrity: sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-types@5.5.1':
+    resolution: {integrity: sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc@5.5.1':
+    resolution: {integrity: sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/signers@5.5.1':
+    resolution: {integrity: sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/subscribable@5.5.1':
+    resolution: {integrity: sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/sysvars@5.5.1':
+    resolution: {integrity: sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-confirmation@5.5.1':
+    resolution: {integrity: sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-messages@5.5.1':
+    resolution: {integrity: sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@5.5.1':
+    resolution: {integrity: sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/wallet-adapter-base@0.9.28':
+    resolution: {integrity: sha512-RCowsJPUs/UgLL/AbyeB6hozVov2UzHf7TrVZkZyJ8HLbuLswJguOnFUhRg6V1YhCp6FO7+1/qXrgeWC0qm1Jg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@solana/web3.js': ^1.99.0
+
+  '@solana/wallet-standard-features@1.5.0':
+    resolution: {integrity: sha512-gxlLaEfPAqbhd3LNkK0Ks2pbVvDm1SDGqBK/ynDQy13Gu+qiURLpRCfSPjbtrw5bmqQsZ6rS2YJHL31bY/Koag==}
+    engines: {node: '>=22'}
+
+  '@solana/web3.js@1.99.0':
+    resolution: {integrity: sha512-QZYQ2T1z6xWisoyALPq25i/QZTsRlM02BABtAsfaQ1p8wX4SdTfxrKTRue/ZZqrhNVh5oL7T/DUFiTS9DRgxow==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stellar/freighter-api@6.0.0':
+    resolution: {integrity: sha512-8CTQcKQmTq/wL715ZUzn1x1POpR0eYhYPKEiaeA7AT0WYBOauOGTxfWPFtSidX3ohAlJZP5HFXy1kG29cVjqxw==}
 
   '@stellar/js-xdr@3.1.2':
     resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
@@ -1471,6 +2086,10 @@ packages:
   '@stellar/js-xdr@4.0.0':
     resolution: {integrity: sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==}
     engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
+
+  '@stellar/js-xdr@5.0.0':
+    resolution: {integrity: sha512-HBDNKnxr+ecdaEmbZ0mcKkirOF8tXXEbWSw34P3wT40Tn3g+u+cCH17xAWZymzscq8cojHB8340pR8QNVaD32w==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
 
   '@stellar/stellar-base@14.1.0':
     resolution: {integrity: sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==}
@@ -1485,6 +2104,11 @@ packages:
   '@stellar/stellar-sdk@16.0.1':
     resolution: {integrity: sha512-bxKohaiyKVqoudRhbOOHeHhHIaeYV5Zab4rCjxhP4Ty1h1ozTLBOv8lWFnZz9ilBzXG8Bb7usQI3rlEcfvUynA==}
     engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  '@stellar/stellar-sdk@17.0.1':
+    resolution: {integrity: sha512-fsHHbzJ14N5Ttq5Qpz4AX0ytmPSLCzcy4XC3uIgSQz0cBkEgv0Zb4KE6tWEd3nDQUk/1qP8ZX9cRonIaUXO3Sw==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
 
   '@swc/helpers@0.5.15':
@@ -1609,6 +2233,52 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@trezor/connect-common@10.0.0-beta.1':
+    resolution: {integrity: sha512-iRXsc9e84IQsqn/hb4PpFnmt/ozMezmRmN/diAK/KbDCYPPBvzbMQRAs/ZCClO2YbhbxmYUX//4NveX+FCZeAw==}
+    peerDependencies:
+      tslib: ^2.6.2
+
+  '@trezor/connect-web@10.0.0-beta.1':
+    resolution: {integrity: sha512-zfYNRYJU4wC1tOxU57YIgB3zt134AVJmVLe/vxIuqyl1IIIm7sanWaz6ff1khJHRiKkYzneExmFNNUlQRPVC3A==}
+    peerDependencies:
+      tslib: ^2.6.2
+
+  '@trezor/crypto-utils@10.0.0-beta.1':
+    resolution: {integrity: sha512-BokMrEgCm6QIwjIfwHZZswbvRRLjGHvS70uMqVcZIOofIIqD+pGXWi2Ll8KW3ZZmIztZqZWPFKUrW2hfH07z+w==}
+    peerDependencies:
+      tslib: ^2.6.2
+
+  '@trezor/device-utils@10.0.0-beta.1':
+    resolution: {integrity: sha512-Hms2U0lv6lUh4eNtYHz2/347/aYkl0l1U5cMLYDu8X0gLf2NGDYEnRC3QGVR1hm9Ha2bzjjgEI25J4Xrz6O+CQ==}
+
+  '@trezor/protobuf@10.0.0-beta.1':
+    resolution: {integrity: sha512-kwKaQloSdfSnIvuERp2sFYdqrk6QUZz8EmIXzPbAgZ+SPPhrpapU00GnVxpg4lR/P8cWHtb/8BKG82lU+Lp3ZQ==}
+    peerDependencies:
+      tslib: ^2.6.2
+
+  '@trezor/protocol@10.0.0-beta.1':
+    resolution: {integrity: sha512-kYcnIjSE1mnAkDDQz7roEDEIy3iBS2dkDPtOcd7lI37jpmvXj2Iu4P7jhG+n9SKb0bwu/e69EpmQOrjrwUX0Yw==}
+    peerDependencies:
+      tslib: ^2.6.2
+
+  '@trezor/schema-utils@10.0.0-beta.1':
+    resolution: {integrity: sha512-a1+6MfvqWFGuAJ+NfFAUOfxoMmtOC1s97GwW43vOSnOxRi5JT1LqRrOWfdZWLMap/uIXRRHAHD8B96xtTrLqlg==}
+    peerDependencies:
+      tslib: ^2.6.2
+
+  '@trezor/type-utils@10.0.0-beta.1':
+    resolution: {integrity: sha512-W8tNL8j0oSJvGi85wzacmUowMDTZaL4ABDrbw6ByRlARxIhjcrBTcy6o9aO6ChABBAZuIEMty4mCeJmQttIhpw==}
+
+  '@trezor/utils@10.0.0-beta.1':
+    resolution: {integrity: sha512-kKBYHzSwvfW9k1zkTukLscucsOuOJ08f3mnQGY0rYszgP7jBUdJ61zUdljIDZ73WaJsUb0/ZnnzGVxUHtdcGvw==}
+    peerDependencies:
+      tslib: ^2.6.2
+
+  '@trezor/websocket-client@10.0.0-beta.1':
+    resolution: {integrity: sha512-ctYcledlp3PRTeQluR2JG5t9eeGa678kUIZjR+1/vPgjM3D1Hd/54BY0is1SytkG3LXb0MDvi0OKpP5ZG+fSFw==}
+    peerDependencies:
+      tslib: ^2.6.2
+
   '@turbo/darwin-64@2.10.5':
     resolution: {integrity: sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw==}
     cpu: [x64]
@@ -1639,6 +2309,35 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@twind/core@1.1.3':
+    resolution: {integrity: sha512-/B/aNFerMb2IeyjSJy3SJxqVxhrT77gBDknLMiZqXIRr4vNJqiuhx7KqUSRzDCwUmyGuogkamz+aOLzN6MeSLw==}
+    engines: {node: '>=14.15.0'}
+    peerDependencies:
+      typescript: ^4.8.4
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@twind/preset-autoprefix@1.0.7':
+    resolution: {integrity: sha512-3wmHO0pG/CVxYBNZUV0tWcL7CP0wD5KpyWAQE/KOalWmOVBj+nH6j3v6Y3I3pRuMFaG5DC78qbYbhA1O11uG3w==}
+    engines: {node: '>=14.15.0'}
+    peerDependencies:
+      '@twind/core': ^1.1.0
+      typescript: ^4.8.4
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@twind/preset-tailwind@1.1.4':
+    resolution: {integrity: sha512-zv85wrP/DW4AxgWrLfH7kyGn/KJF3K04FMLVl2AjoxZGYdCaoZDkL8ma3hzaKQ+WGgBFRubuB/Ku2Rtv/wjzVw==}
+    engines: {node: '>=14.15.0'}
+    peerDependencies:
+      '@twind/core': ^1.1.0
+      typescript: ^4.8.4
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -1659,6 +2358,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -1684,6 +2386,9 @@ packages:
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1692,6 +2397,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
@@ -1707,14 +2415,26 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
   '@types/webextension-polyfill@0.12.5':
     resolution: {integrity: sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==}
+
+  '@types/ws@7.4.7':
+    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
@@ -1754,6 +2474,106 @@ packages:
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
+  '@wallet-standard/base@1.1.1':
+    resolution: {integrity: sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==}
+    engines: {node: '>=22'}
+
+  '@wallet-standard/features@1.1.1':
+    resolution: {integrity: sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==}
+    engines: {node: '>=22'}
+
+  '@wallet-standard/wallet@1.1.0':
+    resolution: {integrity: sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==}
+    engines: {node: '>=16'}
+
+  '@walletconnect/core@2.23.0':
+    resolution: {integrity: sha512-W++xuXf+AsMPrBWn1It8GheIbCTp1ynTQP+aoFB86eUwyCtSiK7UQsn/+vJZdwElrn+Ptp2A0RqQx2onTMVHjQ==}
+    engines: {node: '>=18.20.8'}
+
+  '@walletconnect/core@2.23.7':
+    resolution: {integrity: sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==}
+    engines: {node: '>=18.20.8'}
+
+  '@walletconnect/environment@1.0.1':
+    resolution: {integrity: sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==}
+
+  '@walletconnect/events@1.0.1':
+    resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
+
+  '@walletconnect/heartbeat@1.2.2':
+    resolution: {integrity: sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==}
+
+  '@walletconnect/jsonrpc-http-connection@1.0.8':
+    resolution: {integrity: sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==}
+
+  '@walletconnect/jsonrpc-provider@1.0.14':
+    resolution: {integrity: sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==}
+
+  '@walletconnect/jsonrpc-types@1.0.4':
+    resolution: {integrity: sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==}
+
+  '@walletconnect/jsonrpc-utils@1.0.8':
+    resolution: {integrity: sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==}
+
+  '@walletconnect/jsonrpc-ws-connection@1.0.16':
+    resolution: {integrity: sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==}
+
+  '@walletconnect/keyvaluestorage@1.1.1':
+    resolution: {integrity: sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==}
+    peerDependencies:
+      '@react-native-async-storage/async-storage': 1.x
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
+  '@walletconnect/logger@3.0.0':
+    resolution: {integrity: sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==}
+
+  '@walletconnect/logger@3.0.2':
+    resolution: {integrity: sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==}
+
+  '@walletconnect/relay-api@1.0.11':
+    resolution: {integrity: sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==}
+
+  '@walletconnect/relay-auth@1.1.0':
+    resolution: {integrity: sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==}
+
+  '@walletconnect/safe-json@1.0.2':
+    resolution: {integrity: sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==}
+
+  '@walletconnect/sign-client@2.23.0':
+    resolution: {integrity: sha512-Nzf5x/LnQgC0Yjk0NmkT8kdrIMcScpALiFm9gP0n3CulL+dkf3HumqWzdoTmQSqGPxwHu/TNhGOaRKZLGQXSqw==}
+
+  '@walletconnect/sign-client@2.23.7':
+    resolution: {integrity: sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==}
+
+  '@walletconnect/time@1.0.2':
+    resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
+
+  '@walletconnect/types@2.23.0':
+    resolution: {integrity: sha512-9ZEOJyx/kNVCRncDHh3Qr9eH7Ih1dXBFB4k1J8iEudkv3t4GhYpXhqIt2kNdQWluPb1BBB4wEuckAT96yKuA8g==}
+
+  '@walletconnect/types@2.23.7':
+    resolution: {integrity: sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==}
+
+  '@walletconnect/types@2.23.9':
+    resolution: {integrity: sha512-IUl1PpD/Dig8IE2OZ9XtjbPohEyOZJ73xs92EDUzoIyzRtfm36g2D340pY3iu3AAdLv1yFiaZafB8Hf8RFze8A==}
+
+  '@walletconnect/universal-provider@2.23.7':
+    resolution: {integrity: sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==}
+
+  '@walletconnect/utils@2.23.0':
+    resolution: {integrity: sha512-bVyv4Hl+/wVGueZ6rEO0eYgDy5deSBA4JjpJHAMOdaNoYs05NTE1HymV2lfPQQHuqc7suYexo9jwuW7i3JLuAA==}
+
+  '@walletconnect/utils@2.23.7':
+    resolution: {integrity: sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==}
+
+  '@walletconnect/window-getters@1.0.1':
+    resolution: {integrity: sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==}
+
+  '@walletconnect/window-metadata@1.0.1':
+    resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
+
   '@webext-core/fake-browser@1.5.2':
     resolution: {integrity: sha512-nkDQwOJ23X5Q7cEtN6LRuBtVFf1KVOFi5GoQAro0lzqdh59F5E+K350j1isbnqYbzsXRh1NJtboudIcHfZtvOQ==}
 
@@ -1778,6 +2598,39 @@ packages:
   '@wxt-dev/storage@1.2.8':
     resolution: {integrity: sha512-GWCFKgF5+d7eslOxUDFC70ypA9njupmJb1nQM8uZoX0J3sWT2BO5xJLzb1sYahWAfID9p2BMtnUBN1lkWxPsbQ==}
 
+  abitype@1.0.6:
+    resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.3.0:
+    resolution: {integrity: sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -1797,6 +2650,10 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1836,6 +2693,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1874,6 +2735,14 @@ packages:
   avvio@9.3.0:
     resolution: {integrity: sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==}
 
+  axios-retry@4.5.0:
+    resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
+    peerDependencies:
+      axios: '>=1.18.1'
+
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
+
   axios@1.18.1:
     resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
@@ -1883,6 +2752,12 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
   base32.js@0.1.0:
     resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
@@ -1905,6 +2780,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  big.js@6.2.2:
+    resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
+
   bignumber.js@11.1.5:
     resolution: {integrity: sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==}
 
@@ -1914,12 +2792,33 @@ packages:
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
+  bip32-path@0.4.2:
+    resolution: {integrity: sha512-ZBMCELjJfcNMkz5bDuJ1WrYvjlhEF5k6mQ8vUr4N7MbVRsXei7ZOg8VhhwMfNiW68NWmLkgkc6WvTickrLGprQ==}
+
+  blakejs@1.2.1:
+    resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
+
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
+  bn.js@4.12.5:
+    resolution: {integrity: sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==}
+
+  bn.js@5.2.5:
+    resolution: {integrity: sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==}
 
   boolbase@2.0.0:
     resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
     engines: {node: '>=20.19.0'}
+
+  borsh@0.7.0:
+    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
+
+  borsh@1.0.0:
+    resolution: {integrity: sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==}
+
+  borsh@2.0.0:
+    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -1929,10 +2828,19 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+
   browserslist@4.28.9:
     resolution: {integrity: sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1942,6 +2850,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1975,6 +2887,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
@@ -2007,6 +2923,9 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -2043,9 +2962,16 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2061,9 +2987,16 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@14.0.2:
+    resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
+    engines: {node: '>=20'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@2.9.0:
     resolution: {integrity: sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==}
@@ -2097,12 +3030,24 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
   css-select@7.0.0:
     resolution: {integrity: sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==}
@@ -2126,6 +3071,9 @@ packages:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
 
+  dayjs@1.11.13:
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
+
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
@@ -2146,6 +3094,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -2184,9 +3136,21 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2195,12 +3159,18 @@ packages:
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
+  detect-browser@5.3.0:
+    resolution: {integrity: sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -2356,11 +3326,17 @@ packages:
   electron-to-chromium@1.5.422:
     resolution: {integrity: sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==}
 
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encode-utf8@1.0.3:
+    resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2414,8 +3390,20 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.39.3:
+    resolution: {integrity: sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww==}
+
+  es-toolkit@1.44.0:
+    resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
+  es6-promisify@5.0.0:
+    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -2444,8 +3432,15 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
@@ -2463,11 +3458,18 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  eyes@0.1.8:
+    resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
+    engines: {node: '> 0.1.90'}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -2487,6 +3489,9 @@ packages:
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
+
+  fast-stable-stringify@1.0.0:
+    resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
   fast-uri@4.1.4:
     resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
@@ -2522,6 +3527,10 @@ packages:
   find-my-way@9.7.0:
     resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   firefox-profile@4.7.0:
     resolution: {integrity: sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==}
@@ -2573,6 +3582,12 @@ packages:
   fx-runner@1.4.0:
     resolution: {integrity: sha512-rci1g6U0rdTg6bAaBboP7XdRu01dzTAaKXxFf+PUqGuCv6Xu7o8NZdY1D5MvKGIjb6EdS1g3VlXOgksir1uGkg==}
     hasBin: true
+
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
+  generate-object-property@1.2.0:
+    resolution: {integrity: sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2630,6 +3645,9 @@ packages:
   gsap@3.15.0:
     resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -2640,6 +3658,9 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -2655,8 +3676,14 @@ packages:
     resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
     engines: {node: '>=18.0.0'}
 
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  htm@3.1.1:
+    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -2671,6 +3698,10 @@ packages:
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
+  http-errors@1.7.2:
+    resolution: {integrity: sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==}
+    engines: {node: '>= 0.6'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -2683,9 +3714,18 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  idb-keyval@6.2.1:
+    resolution: {integrity: sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==}
+
+  idb-keyval@6.3.0:
+    resolution: {integrity: sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2695,6 +3735,9 @@ packages:
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  inherits@2.0.3:
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2717,6 +3760,9 @@ packages:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
     engines: {node: '>= 10'}
 
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
   is-absolute@0.1.7:
     resolution: {integrity: sha512-Xi9/ZSn4NFapG8RP98iNPMOeaV3mXPisxKxzKtHVqr3g56j/fBn+yZmnxSVAA8lmZbl2J9b/a4kJvfU3hqQYgA==}
     engines: {node: '>=0.10.0'}
@@ -2729,6 +3775,9 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -2776,6 +3825,12 @@ packages:
     resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
     engines: {node: '>=18'}
 
+  is-my-ip-valid@1.0.1:
+    resolution: {integrity: sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==}
+
+  is-my-json-valid@2.20.6:
+    resolution: {integrity: sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==}
+
   is-npm@6.1.0:
     resolution: {integrity: sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2799,9 +3854,16 @@ packages:
     resolution: {integrity: sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==}
     engines: {node: '>=0.10.0'}
 
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
   is-relative@0.1.3:
     resolution: {integrity: sha512-wBOr+rNM4gkAZqoLRJI4myw5WzzIdQosFAAbnvfXP5z1LyzgAI3ivOKehC5KfqlQJZoihVhirgtCBj378Eg8GA==}
     engines: {node: '>=0.10.0'}
+
+  is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
 
   is-retry-allowed@3.0.0:
     resolution: {integrity: sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==}
@@ -2835,9 +3897,33 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
+
+  jayson@4.3.0:
+    resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.12:
+    resolution: {integrity: sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==}
+
+  js-sha256@0.11.1:
+    resolution: {integrity: sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==}
+
+  js-sha256@0.9.0:
+    resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2869,6 +3955,9 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -2876,6 +3965,10 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -2889,6 +3982,9 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  keyvaluestorage-interface@1.0.0:
+    resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3090,9 +4186,22 @@ packages:
     resolution: {integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==}
     engines: {node: '>=22.13.0'}
 
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
+
+  lit@3.3.0:
+    resolution: {integrity: sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==}
+
   local-pkg@1.2.1:
     resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
     engines: {node: '>=14'}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -3131,8 +4240,15 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -3160,6 +4276,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -3302,6 +4421,12 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -3314,9 +4439,17 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  multiformats@9.9.0:
+    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
+
   multimatch@6.0.0:
     resolution: {integrity: sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  mustache@4.0.0:
+    resolution: {integrity: sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA==}
+    engines: {npm: '>=1.4.0'}
+    hasBin: true
 
   nano-spawn@2.1.0:
     resolution: {integrity: sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==}
@@ -3334,6 +4467,12 @@ packages:
 
   nanospinner@1.2.2:
     resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
+  near-abi@0.2.0:
+    resolution: {integrity: sha512-kCwSf/3fraPU2zENK18sh+kKG4uKbEUEQdyWQkmW8ZofmLarObIz2+zAYjA1teDZLeMvEQew3UysnPDXgjneaA==}
+
+  near-api-js@5.1.1:
+    resolution: {integrity: sha512-h23BGSKxNv8ph+zU6snicstsVK1/CTXsQz4LuGGwoRE24Hj424nSe4+/1tzoiC285Ljf60kPAqRCmsfv9etF2g==}
 
   next@16.3.0:
     resolution: {integrity: sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==}
@@ -3356,12 +4495,40 @@ packages:
       sass:
         optional: true
 
+  node-addon-api@5.1.0:
+    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  node-mock-http@1.0.5:
+    resolution: {integrity: sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==}
 
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==}
@@ -3422,6 +4589,42 @@ packages:
     resolution: {integrity: sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==}
     engines: {node: '>= 0.4.0'}
 
+  ox@0.14.44:
+    resolution: {integrity: sha512-O54qXXHEk4ySamMSyBpI0AeBegS5frxU6+LA6Jb9Sf6kMOxcTNaxYmwZfpOu22DIQsdKfgQxHq8EsAGaoBQScA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.6.9:
+    resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.9.3:
+    resolution: {integrity: sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
@@ -3450,6 +4653,10 @@ packages:
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@stellar/stellar-sdk': '>=16.0.0'
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3519,6 +4726,10 @@ packages:
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
+  pino@10.0.0:
+    resolution: {integrity: sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==}
+    hasBin: true
+
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
@@ -3542,6 +4753,10 @@ packages:
     resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3574,6 +4789,17 @@ packages:
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.24.2:
+    resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prettier@3.9.5:
     resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
@@ -3612,6 +4838,9 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  proxy-compare@3.0.1:
+    resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -3629,11 +4858,19 @@ packages:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
 
+  qrcode@1.5.3:
+    resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -3715,6 +4952,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -3743,12 +4983,21 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rpc-websockets@9.3.9:
+    resolution: {integrity: sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==}
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
+
+  rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   sac-sdk@0.4.3:
     resolution: {integrity: sha512-uJIqf/VK3vxcB3wj7n+Z1X0yI3PaapXrN6AeW7mbRvvltFJ4L+oF1pAPiylhIvCsR1PCeg3JAmcCwT7oT1qEYA==}
@@ -3785,6 +5034,10 @@ packages:
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
+  secp256k1@5.0.1:
+    resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
+    engines: {node: '>=18.0.0'}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -3792,10 +5045,23 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -3811,10 +5077,16 @@ packages:
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
+  setprototypeof@1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+
   sha.js@2.4.12:
     resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
     engines: {node: '>= 0.10'}
     hasBin: true
+
+  sha1@1.1.1:
+    resolution: {integrity: sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==}
 
   sharp@0.35.3:
     resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
@@ -3849,6 +5121,9 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  slow-redact@0.3.2:
+    resolution: {integrity: sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==}
 
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
@@ -3888,8 +5163,18 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3944,6 +5229,9 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  style-vendorizer@2.2.3:
+    resolution: {integrity: sha512-/VDRsWvQAgspVy9eATN3z6itKTuyg+jW1q6UoTCQCFRqPDw8bi3E1hXIKnGw5LvXS2AQPuJ7Af4auTLYeBOLEg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -3957,6 +5245,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -3969,6 +5261,9 @@ packages:
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+
+  text-encoding-utf-8@1.0.2:
+    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
 
   thread-stream@3.2.0:
     resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
@@ -4025,6 +5320,10 @@ packages:
     resolution: {integrity: sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==}
     engines: {node: '>=20'}
 
+  toidentifier@1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+
   toml@5.0.0:
     resolution: {integrity: sha512-bsqEd+g7fzlrw7LEynQ6W6aOK/lTOlepz5x1sJyIV9fTZVJS2Q76nuju6FK+gZhW5bUpvB7mCEqdR0u4WziMFw==}
     engines: {node: '>=20'}
@@ -4032,6 +5331,9 @@ packages:
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
@@ -4042,6 +5344,12 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-mixer@6.0.4:
+    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -4054,6 +5362,12 @@ packages:
   turbo@2.10.5:
     resolution: {integrity: sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ==}
     hasBin: true
+
+  tweetnacl-util@0.15.1:
+    resolution: {integrity: sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
@@ -4085,8 +5399,17 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
+  uint8arrays@3.1.1:
+    resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@7.29.1:
+    resolution: {integrity: sha512-2xO3p6gANwOmhSFwNy2MMYISbHTtM+K3bY0bqpD1gOGpUPIe+yFXCobxbz0s2jm7E0faMxIFcZUcCKa+N6Ozlg==}
 
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
@@ -4163,6 +5486,68 @@ packages:
       webpack:
         optional: true
 
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
   update-browserslist-db@1.3.2:
     resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
@@ -4176,12 +5561,31 @@ packages:
   urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
 
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid4@2.0.3:
+    resolution: {integrity: sha512-CTpAkEVXMNJl2ojgtpLXHgz23dh8z81u6/HEPiQFOvBc/c2pde6TVHmH4uwY0d/GLF3tb7+VDAj4+2eJaQSdZQ==}
 
   uuid@14.0.2:
     resolution: {integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==}
     hasBin: true
+
+  valtio@2.1.7:
+    resolution: {integrity: sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   vellar-sdk@0.6.2:
     resolution: {integrity: sha512-YZUX8SkKk5HjxQ3uLlqwWcBn1UbZhVM41Xs1ik0MUVU+nGdqwqZtzdmsa38wY0E68srnxHeRVO3Tbx98pLgBzA==}
@@ -4197,6 +5601,14 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  viem@2.56.3:
+    resolution: {integrity: sha512-vUObq3GO7D3lz9gPNEE/xd5jIUnMbeVDWewh252o54pDEDlW4pDe6FEd/qTGL5RyK52cGHMM7kQ3wjxhilEvkQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -4331,6 +5743,9 @@ packages:
     resolution: {integrity: sha512-rQicL7OwuqWdQWI33JkSXKcp7cuv1mJG8u3jRQwx/8aDsmhbTHs9ZRmNYOL+LX0wX8edIEQX8jj4bB60GoXtKA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -4351,11 +5766,17 @@ packages:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   when@3.7.7:
     resolution: {integrity: sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw==}
+
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
   which-typed-array@1.1.22:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
@@ -4386,6 +5807,10 @@ packages:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
     engines: {node: '>=20'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -4396,6 +5821,30 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
@@ -4458,6 +5907,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -4465,9 +5917,17 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
@@ -4476,11 +5936,35 @@ packages:
   zip-dir@2.0.0:
     resolution: {integrity: sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==}
 
+  zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
+  zustand@5.0.3:
+    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -4513,6 +5997,8 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
+  '@adraffy/ens-normalize@1.11.1': {}
+
   '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@4.62.2)':
     dependencies:
       open: 8.4.2
@@ -4521,6 +6007,8 @@ snapshots:
       yargs: 17.7.3
     optionalDependencies:
       rollup: 4.62.2
+
+  '@albedo-link/intent@0.12.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -4647,6 +6135,148 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@base-org/account@2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@coinbase/cdp-sdk': 1.55.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@4.4.3)
+      preact: 10.24.2
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      zustand: 5.0.3(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - bufferutil
+      - debug
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - react
+      - supports-color
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@bufbuild/protobuf@2.14.1': {}
+
+  '@coinbase/cdp-sdk@1.55.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
+      axios: 1.18.1
+      axios-retry: 4.5.0(axios@1.18.1)
+      bs58: 6.0.0
+      jose: 6.2.12
+      md5: 2.3.0
+      uncrypto: 0.1.3
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+    optional: true
+
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@4.4.3)
+      preact: 10.24.2
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      zustand: 5.0.3(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@creit.tech/stellar-wallets-kit@2.6.0(@types/react@19.2.17)(bufferutil@4.1.0)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@albedo-link/intent': 0.12.0
+      '@creit.tech/xbull-wallet-connect': 0.4.0
+      '@hot-wallet/sdk': 1.0.11(bufferutil@4.1.0)(near-api-js@5.1.1)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@ledgerhq/hw-app-str': 7.2.8
+      '@ledgerhq/hw-transport': 6.31.12
+      '@ledgerhq/hw-transport-webusb': 6.29.12
+      '@lobstrco/signer-extension-api': 2.0.0
+      '@preact/signals': 2.9.0(preact@10.29.8)
+      '@reown/appkit': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@stellar/freighter-api': 6.0.0
+      '@stellar/stellar-sdk': 17.0.1
+      '@trezor/connect-web': 10.0.0-beta.1(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
+      '@twind/core': 1.1.3(typescript@5.9.3)
+      '@twind/preset-autoprefix': 1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
+      '@twind/preset-tailwind': 1.1.4(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
+      '@walletconnect/sign-client': 2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@walletconnect/types': 2.23.9
+      htm: 3.1.1
+      preact: 10.29.8
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - near-api-js
+      - preact-render-to-string
+      - react
+      - supports-color
+      - tslib
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@creit.tech/xbull-wallet-connect@0.4.0':
+    dependencies:
+      rxjs: 7.8.2
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -4795,6 +6425,10 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.20.0
@@ -4819,12 +6453,12 @@ snapshots:
       fastify-plugin: 6.0.0
       helmet: 8.3.0
 
-  '@fastify/http-proxy@11.5.0':
+  '@fastify/http-proxy@11.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@fastify/reply-from': 12.6.3
       fast-querystring: 1.1.2
       fastify-plugin: 5.1.0
-      ws: 8.21.1
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4859,6 +6493,24 @@ snapshots:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.81.0(react@19.2.7)
       zod: 4.4.3
+
+  '@hot-wallet/sdk@1.0.11(bufferutil@4.1.0)(near-api-js@5.1.1)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@near-js/crypto': 1.4.2
+      '@near-js/utils': 1.1.0
+      '@near-wallet-selector/core': 8.10.2(near-api-js@5.1.1)
+      '@solana/wallet-adapter-base': 0.9.28(@solana/web3.js@1.99.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/web3.js': 1.99.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      borsh: 2.0.0
+      js-sha256: 0.11.1
+      sha1: 1.1.1
+      uuid4: 2.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - near-api-js
+      - typescript
+      - utf-8-validate
 
   '@img/colour@1.1.0':
     optional: true
@@ -4986,7 +6638,55 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@ledgerhq/devices@8.6.1':
+    dependencies:
+      '@ledgerhq/errors': 6.37.0
+      '@ledgerhq/logs': 6.19.0
+      rxjs: 7.8.2
+      semver: 7.8.5
+
+  '@ledgerhq/errors@6.37.0': {}
+
+  '@ledgerhq/hw-app-str@7.2.8':
+    dependencies:
+      '@ledgerhq/errors': 6.37.0
+      '@ledgerhq/hw-transport': 6.31.12
+      bip32-path: 0.4.2
+
+  '@ledgerhq/hw-transport-webusb@6.29.12':
+    dependencies:
+      '@ledgerhq/devices': 8.6.1
+      '@ledgerhq/errors': 6.37.0
+      '@ledgerhq/hw-transport': 6.31.12
+      '@ledgerhq/logs': 6.19.0
+
+  '@ledgerhq/hw-transport@6.31.12':
+    dependencies:
+      '@ledgerhq/devices': 8.6.1
+      '@ledgerhq/errors': 6.37.0
+      '@ledgerhq/logs': 6.19.0
+      events: 3.3.0
+
+  '@ledgerhq/logs@6.19.0': {}
+
+  '@lit-labs/ssr-dom-shim@1.6.0': {}
+
+  '@lit/react@1.0.8(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+    optional: true
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+
+  '@lobstrco/signer-extension-api@2.0.0': {}
+
   '@lukeed/ms@2.0.2': {}
+
+  '@msgpack/msgpack@3.1.2': {}
+
+  '@msgpack/msgpack@3.1.3': {}
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -4994,6 +6694,105 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@near-js/accounts@1.4.1':
+    dependencies:
+      '@near-js/crypto': 1.4.2
+      '@near-js/providers': 1.0.3
+      '@near-js/signers': 0.2.2
+      '@near-js/transactions': 1.3.3
+      '@near-js/types': 0.3.1
+      '@near-js/utils': 1.1.0
+      '@noble/hashes': 1.7.1
+      borsh: 1.0.0
+      depd: 2.0.0
+      is-my-json-valid: 2.20.6
+      lru_map: 0.4.1
+      near-abi: 0.2.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@near-js/crypto@1.4.2':
+    dependencies:
+      '@near-js/types': 0.3.1
+      '@near-js/utils': 1.1.0
+      '@noble/curves': 1.8.1
+      borsh: 1.0.0
+      randombytes: 2.1.0
+      secp256k1: 5.0.1
+
+  '@near-js/keystores-browser@0.2.2':
+    dependencies:
+      '@near-js/crypto': 1.4.2
+      '@near-js/keystores': 0.2.2
+
+  '@near-js/keystores-node@0.1.2':
+    dependencies:
+      '@near-js/crypto': 1.4.2
+      '@near-js/keystores': 0.2.2
+
+  '@near-js/keystores@0.2.2':
+    dependencies:
+      '@near-js/crypto': 1.4.2
+      '@near-js/types': 0.3.1
+
+  '@near-js/providers@1.0.3':
+    dependencies:
+      '@near-js/transactions': 1.3.3
+      '@near-js/types': 0.3.1
+      '@near-js/utils': 1.1.0
+      borsh: 1.0.0
+      exponential-backoff: 3.1.3
+    optionalDependencies:
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+
+  '@near-js/signers@0.2.2':
+    dependencies:
+      '@near-js/crypto': 1.4.2
+      '@near-js/keystores': 0.2.2
+      '@noble/hashes': 1.3.3
+
+  '@near-js/transactions@1.3.3':
+    dependencies:
+      '@near-js/crypto': 1.4.2
+      '@near-js/signers': 0.2.2
+      '@near-js/types': 0.3.1
+      '@near-js/utils': 1.1.0
+      '@noble/hashes': 1.7.1
+      borsh: 1.0.0
+
+  '@near-js/types@0.3.1': {}
+
+  '@near-js/utils@1.1.0':
+    dependencies:
+      '@near-js/types': 0.3.1
+      '@scure/base': 1.2.6
+      depd: 2.0.0
+      mustache: 4.0.0
+
+  '@near-js/wallet-account@1.3.3':
+    dependencies:
+      '@near-js/accounts': 1.4.1
+      '@near-js/crypto': 1.4.2
+      '@near-js/keystores': 0.2.2
+      '@near-js/providers': 1.0.3
+      '@near-js/signers': 0.2.2
+      '@near-js/transactions': 1.3.3
+      '@near-js/types': 0.3.1
+      '@near-js/utils': 1.1.0
+      borsh: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@near-wallet-selector/core@8.10.2(near-api-js@5.1.1)':
+    dependencies:
+      borsh: 1.0.0
+      events: 3.3.0
+      js-sha256: 0.9.0
+      near-api-js: 5.1.1
+      rxjs: 7.8.1
 
   '@next/env@16.3.0': {}
 
@@ -5021,11 +6820,34 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.8.0':
+    dependencies:
+      '@noble/hashes': 1.7.0
+
+  '@noble/curves@1.8.1':
+    dependencies:
+      '@noble/hashes': 1.7.1
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
 
   '@noble/ed25519@3.1.0': {}
+
+  '@noble/hashes@1.3.3': {}
+
+  '@noble/hashes@1.4.0':
+    optional: true
+
+  '@noble/hashes@1.7.0': {}
+
+  '@noble/hashes@1.7.1': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -5052,6 +6874,10 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@phosphor-icons/webcomponents@2.1.5':
+    dependencies:
+      lit: 3.3.0
+
   '@pinojs/redact@0.4.0': {}
 
   '@playwright/test@1.61.1':
@@ -5069,6 +6895,320 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@preact/signals-core@1.14.4': {}
+
+  '@preact/signals@2.9.0(preact@10.29.8)':
+    dependencies:
+      '@preact/signals-core': 1.14.4
+      preact: 10.29.8
+
+  '@reown/appkit-common@1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)':
+    dependencies:
+      big.js: 6.2.2
+      dayjs: 1.11.13
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-common@1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      big.js: 6.2.2
+      dayjs: 1.11.13
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-controllers@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-pay@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))(zod@4.4.3)
+      lit: 3.3.0
+      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-polyfills@1.8.21':
+    dependencies:
+      buffer: 6.0.3
+
+  '@reown/appkit-scaffold-ui@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))(zod@4.4.3)':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-pay': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))(zod@4.4.3)
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      lit: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - valtio
+      - zod
+
+  '@reown/appkit-ui@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@phosphor-icons/webcomponents': 2.1.5
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      lit: 3.3.0
+      qrcode: 1.5.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-utils@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))(zod@4.4.3)':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-polyfills': 1.8.21
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@wallet-standard/wallet': 1.1.0
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+    optionalDependencies:
+      '@base-org/account': 2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-wallet@1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      '@reown/appkit-polyfills': 1.8.21
+      '@walletconnect/logger': 3.0.2
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@reown/appkit@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-pay': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-polyfills': 1.8.21
+      '@reown/appkit-scaffold-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))(zod@4.4.3)
+      '@reown/appkit-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))(zod@4.4.3)
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      bs58: 6.0.0
+      semver: 7.7.2
+      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+    optionalDependencies:
+      '@lit/react': 1.0.8(@types/react@19.2.17)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@x402/core'
+      - '@x402/evm'
+      - '@x402/extensions'
+      - '@x402/svm'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -5198,13 +7338,570 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@safe-global/safe-gateway-typescript-sdk': 3.23.1
+      viem: 2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@safe-global/safe-gateway-typescript-sdk@3.23.1':
+    optional: true
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
   '@simplewebauthn/browser@13.3.0': {}
 
+  '@sinclair/typebox@0.34.52': {}
+
+  '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    optional: true
+
+  '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    optional: true
+
+  '@solana/accounts@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/addresses@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/assertions@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/buffer-layout@4.0.1':
+    dependencies:
+      buffer: 6.0.3
+
+  '@solana/codecs-core@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-data-structures@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/codecs-numbers@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/codecs@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/options': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/errors@5.5.1(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.2
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/fast-stable-stringify@5.5.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/functional@5.5.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/instruction-plans@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/promises': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/instructions@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/keys@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/accounts': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/instruction-plans': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/offchain-messages': 5.5.1(typescript@5.9.3)
+      '@solana/plugin-core': 5.5.1(typescript@5.9.3)
+      '@solana/programs': 5.5.1(typescript@5.9.3)
+      '@solana/rpc': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-api': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/signers': 5.5.1(typescript@5.9.3)
+      '@solana/sysvars': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-confirmation': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+    optional: true
+
+  '@solana/nominal-types@5.5.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/offchain-messages@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/options@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/plugin-core@5.5.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/programs@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/promises@5.5.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/rpc-api@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/rpc-parsed-types@5.5.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/rpc-spec-types@5.5.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/rpc-spec@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/rpc-subscriptions-api@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/rpc-subscriptions-channel-websocket@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
+      '@solana/subscribable': 5.5.1(typescript@5.9.3)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
+
+  '@solana/rpc-subscriptions-spec@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/promises': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/subscribable': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/rpc-subscriptions@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/promises': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/subscribable': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+    optional: true
+
+  '@solana/rpc-transformers@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/rpc-transport-http@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      undici-types: 7.29.1
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/rpc-types@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/rpc@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-api': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transport-http': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/signers@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/offchain-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/subscribable@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  '@solana/sysvars@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 5.5.1(typescript@5.9.3)
+      '@solana/codecs': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/transaction-confirmation@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/promises': 5.5.1(typescript@5.9.3)
+      '@solana/rpc': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+    optional: true
+
+  '@solana/transaction-messages@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/transactions@5.5.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    optional: true
+
+  '@solana/wallet-adapter-base@0.9.28(@solana/web3.js@1.99.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/wallet-standard-features': 1.5.0
+      '@solana/web3.js': 1.99.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@wallet-standard/base': 1.1.1
+      '@wallet-standard/features': 1.1.1
+      eventemitter3: 5.0.4
+
+  '@solana/wallet-standard-features@1.5.0':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+      '@wallet-standard/features': 1.1.1
+
+  '@solana/web3.js@1.99.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@solana/buffer-layout': 4.0.1
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      agentkeepalive: 4.6.0
+      bn.js: 5.2.5
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      node-fetch: 2.7.0
+      rpc-websockets: 9.3.9
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
   '@standard-schema/utils@0.3.0': {}
+
+  '@stellar/freighter-api@6.0.0':
+    dependencies:
+      buffer: 6.0.3
+      semver: 7.7.1
 
   '@stellar/js-xdr@3.1.2': {}
 
   '@stellar/js-xdr@4.0.0': {}
+
+  '@stellar/js-xdr@5.0.0': {}
 
   '@stellar/stellar-base@14.1.0':
     dependencies:
@@ -5239,6 +7936,24 @@ snapshots:
       base32.js: 0.1.0
       bignumber.js: 11.1.5
       buffer: 6.0.3
+      commander: 14.0.3
+      eventsource: 4.1.0
+      feaxios: 0.0.23
+      smol-toml: 1.7.0
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@stellar/stellar-sdk@17.0.1':
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      '@noble/ed25519': 3.1.0
+      '@noble/hashes': 2.2.0
+      '@stellar/js-xdr': 5.0.0
+      '@types/json-schema': 7.0.15
+      axios: 1.18.0
+      bignumber.js: 11.1.5
       commander: 14.0.3
       eventsource: 4.1.0
       feaxios: 0.0.23
@@ -5349,6 +8064,67 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@trezor/connect-common@10.0.0-beta.1(tslib@2.8.1)':
+    dependencies:
+      '@trezor/crypto-utils': 10.0.0-beta.1(tslib@2.8.1)
+      '@trezor/device-utils': 10.0.0-beta.1
+      '@trezor/protobuf': 10.0.0-beta.1(tslib@2.8.1)
+      '@trezor/protocol': 10.0.0-beta.1(tslib@2.8.1)
+      '@trezor/schema-utils': 10.0.0-beta.1(tslib@2.8.1)
+      '@trezor/type-utils': 10.0.0-beta.1
+      '@trezor/utils': 10.0.0-beta.1(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@trezor/connect-web@10.0.0-beta.1(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@trezor/connect-common': 10.0.0-beta.1(tslib@2.8.1)
+      '@trezor/utils': 10.0.0-beta.1(tslib@2.8.1)
+      '@trezor/websocket-client': 10.0.0-beta.1(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@trezor/crypto-utils@10.0.0-beta.1(tslib@2.8.1)':
+    dependencies:
+      '@trezor/type-utils': 10.0.0-beta.1
+      tslib: 2.8.1
+
+  '@trezor/device-utils@10.0.0-beta.1': {}
+
+  '@trezor/protobuf@10.0.0-beta.1(tslib@2.8.1)':
+    dependencies:
+      '@bufbuild/protobuf': 2.14.1
+      '@trezor/schema-utils': 10.0.0-beta.1(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@trezor/protocol@10.0.0-beta.1(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@trezor/schema-utils@10.0.0-beta.1(tslib@2.8.1)':
+    dependencies:
+      '@sinclair/typebox': 0.34.52
+      '@trezor/utils': 10.0.0-beta.1(tslib@2.8.1)
+      ts-mixer: 6.0.4
+      tslib: 2.8.1
+
+  '@trezor/type-utils@10.0.0-beta.1': {}
+
+  '@trezor/utils@10.0.0-beta.1(tslib@2.8.1)':
+    dependencies:
+      bignumber.js: 11.1.5
+      tslib: 2.8.1
+
+  '@trezor/websocket-client@10.0.0-beta.1(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@trezor/utils': 10.0.0-beta.1(tslib@2.8.1)
+      tslib: 2.8.1
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@turbo/darwin-64@2.10.5':
     optional: true
 
@@ -5366,6 +8142,25 @@ snapshots:
 
   '@turbo/windows-arm64@2.10.5':
     optional: true
+
+  '@twind/core@1.1.3(typescript@5.9.3)':
+    dependencies:
+      csstype: 3.2.3
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@twind/preset-autoprefix@1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@twind/core': 1.1.3(typescript@5.9.3)
+      style-vendorizer: 2.2.3
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@twind/preset-tailwind@1.1.4(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@twind/core': 1.1.3(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -5400,6 +8195,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -5424,6 +8223,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -5431,6 +8232,8 @@ snapshots:
   '@types/minimatch@3.0.5': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@12.20.55': {}
 
   '@types/node@24.13.3':
     dependencies:
@@ -5450,11 +8253,23 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7': {}
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
+  '@types/uuid@10.0.0': {}
+
   '@types/webextension-polyfill@0.12.5': {}
+
+  '@types/ws@7.4.7':
+    dependencies:
+      '@types/node': 24.13.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.13.3
 
   '@ungap/structured-clone@1.3.3': {}
 
@@ -5512,6 +8327,507 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@wallet-standard/base@1.1.1': {}
+
+  '@wallet-standard/features@1.1.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+
+  '@wallet-standard/wallet@1.1.0':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+
+  '@walletconnect/core@2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.0
+      '@walletconnect/utils': 2.23.0(typescript@5.9.3)(zod@4.4.3)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.39.3
+      events: 3.3.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/core@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7
+      '@walletconnect/utils': 2.23.7(typescript@5.9.3)(zod@4.4.3)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.44.0
+      events: 3.3.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/environment@1.0.1':
+    dependencies:
+      tslib: 1.14.1
+
+  '@walletconnect/events@1.0.1':
+    dependencies:
+      keyvaluestorage-interface: 1.0.0
+      tslib: 1.14.1
+
+  '@walletconnect/heartbeat@1.2.2':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/time': 1.0.2
+      events: 3.3.0
+
+  '@walletconnect/jsonrpc-http-connection@1.0.8':
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      cross-fetch: 3.2.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@walletconnect/jsonrpc-provider@1.0.14':
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      events: 3.3.0
+
+  '@walletconnect/jsonrpc-types@1.0.4':
+    dependencies:
+      events: 3.3.0
+      keyvaluestorage-interface: 1.0.0
+
+  '@walletconnect/jsonrpc-utils@1.0.8':
+    dependencies:
+      '@walletconnect/environment': 1.0.1
+      '@walletconnect/jsonrpc-types': 1.0.4
+      tslib: 1.14.1
+
+  '@walletconnect/jsonrpc-ws-connection@1.0.16(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      events: 3.3.0
+      ws: 7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@walletconnect/keyvaluestorage@1.1.1':
+    dependencies:
+      '@walletconnect/safe-json': 1.0.2
+      idb-keyval: 6.3.0
+      unstorage: 1.17.5(idb-keyval@6.3.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/logger@3.0.0':
+    dependencies:
+      '@walletconnect/safe-json': 1.0.2
+      pino: 10.0.0
+
+  '@walletconnect/logger@3.0.2':
+    dependencies:
+      '@walletconnect/safe-json': 1.0.2
+      pino: 10.0.0
+
+  '@walletconnect/relay-api@1.0.11':
+    dependencies:
+      '@walletconnect/jsonrpc-types': 1.0.4
+
+  '@walletconnect/relay-auth@1.1.0':
+    dependencies:
+      '@noble/curves': 1.8.0
+      '@noble/hashes': 1.7.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      uint8arrays: 3.1.1
+
+  '@walletconnect/safe-json@1.0.2':
+    dependencies:
+      tslib: 1.14.1
+
+  '@walletconnect/sign-client@2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@walletconnect/core': 2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.0
+      '@walletconnect/utils': 2.23.0(typescript@5.9.3)(zod@4.4.3)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/sign-client@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@walletconnect/core': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7
+      '@walletconnect/utils': 2.23.7(typescript@5.9.3)(zod@4.4.3)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/time@1.0.2':
+    dependencies:
+      tslib: 1.14.1
+
+  '@walletconnect/types@2.23.0':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/types@2.23.7':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.2
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/types@2.23.9':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.2
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/universal-provider@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/sign-client': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      '@walletconnect/types': 2.23.7
+      '@walletconnect/utils': 2.23.7(typescript@5.9.3)(zod@4.4.3)
+      es-toolkit: 1.44.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/utils@2.23.0(typescript@5.9.3)(zod@4.4.3)':
+    dependencies:
+      '@msgpack/msgpack': 3.1.2
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.0
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      blakejs: 1.2.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
+      ox: 0.9.3(typescript@5.9.3)(zod@4.4.3)
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - zod
+
+  '@walletconnect/utils@2.23.7(typescript@5.9.3)(zod@4.4.3)':
+    dependencies:
+      '@msgpack/msgpack': 3.1.3
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      blakejs: 1.2.1
+      detect-browser: 5.3.0
+      ox: 0.9.3(typescript@5.9.3)(zod@4.4.3)
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - zod
+
+  '@walletconnect/window-getters@1.0.1':
+    dependencies:
+      tslib: 1.14.1
+
+  '@walletconnect/window-metadata@1.0.1':
+    dependencies:
+      '@walletconnect/window-getters': 1.0.1
+      tslib: 1.14.1
+
   '@webext-core/fake-browser@1.5.2':
     dependencies:
       '@types/webextension-polyfill': 0.12.5
@@ -5547,6 +8863,33 @@ snapshots:
       async-mutex: 0.5.0
       dequal: 2.0.3
 
+  abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.25.76
+    optional: true
+
+  abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.22.4
+
+  abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.25.76
+    optional: true
+
+  abitype@1.2.3(typescript@5.9.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.4.3
+
+  abitype@1.3.0(typescript@5.9.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.4.3
+
   abstract-logging@2.0.1: {}
 
   acorn@8.17.0: {}
@@ -5560,6 +8903,10 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -5591,6 +8938,11 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
 
   aria-query@5.3.0:
     dependencies:
@@ -5626,6 +8978,22 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
+  axios-retry@4.5.0(axios@1.18.1):
+    dependencies:
+      axios: 1.18.1
+      is-retry-allowed: 2.2.0
+    optional: true
+
+  axios@1.18.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
@@ -5640,6 +9008,12 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  base-x@5.0.1: {}
+
   base32.js@0.1.0: {}
 
   base64-js@1.5.1: {}
@@ -5650,15 +9024,35 @@ snapshots:
 
   baseline-browser-mapping@2.11.20: {}
 
+  big.js@6.2.2: {}
+
   bignumber.js@11.1.5: {}
 
   bignumber.js@9.3.1: {}
 
   bintrees@1.0.2: {}
 
+  bip32-path@0.4.2: {}
+
+  blakejs@1.2.1: {}
+
   bluebird@3.7.2: {}
 
+  bn.js@4.12.5: {}
+
+  bn.js@5.2.5: {}
+
   boolbase@2.0.0: {}
+
+  borsh@0.7.0:
+    dependencies:
+      bn.js: 5.2.5
+      bs58: 4.0.1
+      text-encoding-utf-8: 1.0.2
+
+  borsh@1.0.0: {}
+
+  borsh@2.0.0: {}
 
   boxen@8.0.1:
     dependencies:
@@ -5675,6 +9069,8 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  brorand@1.1.0: {}
+
   browserslist@4.28.9:
     dependencies:
       baseline-browser-mapping: 2.11.20
@@ -5682,6 +9078,14 @@ snapshots:
       electron-to-chromium: 1.5.422
       node-releases: 2.0.54
       update-browserslist-db: 1.3.2(browserslist@4.28.9)
+
+  bs58@4.0.1:
+    dependencies:
+      base-x: 3.0.11
+
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -5691,6 +9095,11 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -5734,6 +9143,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  camelcase@5.3.1: {}
+
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001805: {}
@@ -5759,6 +9170,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  charenc@0.0.2: {}
 
   check-error@2.1.3: {}
 
@@ -5792,11 +9205,20 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@1.2.1:
+    optional: true
 
   color-convert@2.0.1:
     dependencies:
@@ -5810,7 +9232,11 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@14.0.2: {}
+
   commander@14.0.3: {}
+
+  commander@2.20.3: {}
 
   commander@2.9.0:
     dependencies:
@@ -5845,9 +9271,23 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@1.2.3: {}
+
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
+
+  crypt@0.0.2: {}
 
   css-select@7.0.0:
     dependencies:
@@ -5873,6 +9313,8 @@ snapshots:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
 
+  dayjs@1.11.13: {}
+
   debounce@1.2.1: {}
 
   debug@4.3.7:
@@ -5882,6 +9324,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decamelize@1.2.0: {}
 
   decimal.js@10.6.0: {}
 
@@ -5912,17 +9356,27 @@ snapshots:
 
   defu@6.1.7: {}
 
+  delay@5.0.0: {}
+
   delayed-stream@1.0.0: {}
+
+  depd@1.1.2: {}
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
+
+  detect-browser@5.3.0: {}
 
   detect-libc@2.1.2: {}
 
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dijkstrajs@1.0.3: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -5999,9 +9453,21 @@ snapshots:
 
   electron-to-chromium@1.5.422: {}
 
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.5
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  encode-utf8@1.0.3: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -6045,7 +9511,17 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
+  es-toolkit@1.39.3: {}
+
+  es-toolkit@1.44.0: {}
+
   es6-error@4.1.1: {}
+
+  es6-promise@4.2.8: {}
+
+  es6-promisify@5.0.0:
+    dependencies:
+      es6-promise: 4.2.8
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -6090,7 +9566,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  eventemitter3@5.0.1: {}
+
   eventemitter3@5.0.4: {}
+
+  events@3.3.0: {}
 
   eventsource-parser@3.1.0: {}
 
@@ -6102,9 +9582,13 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   exsolve@1.1.0: {}
 
   extend@3.0.2: {}
+
+  eyes@0.1.8: {}
 
   fast-content-type-parse@3.0.0: {}
 
@@ -6126,6 +9610,8 @@ snapshots:
       fast-decode-uri-component: 1.0.1
 
   fast-redact@3.5.0: {}
+
+  fast-stable-stringify@1.0.0: {}
 
   fast-uri@4.1.4: {}
 
@@ -6175,6 +9661,11 @@ snapshots:
       fast-querystring: 1.1.2
       safe-regex2: 5.1.1
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   firefox-profile@4.7.0:
     dependencies:
       adm-zip: 0.6.0
@@ -6223,6 +9714,14 @@ snapshots:
       when: 3.7.7
       which: 1.2.4
       winreg: 0.0.12
+
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
+  generate-object-property@1.2.0:
+    dependencies:
+      is-property: 1.0.2
 
   gensync@1.0.0-beta.2: {}
 
@@ -6274,6 +9773,18 @@ snapshots:
 
   gsap@3.15.0: {}
 
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.5
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -6283,6 +9794,11 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
 
   hasown@2.0.4:
     dependencies:
@@ -6314,7 +9830,15 @@ snapshots:
 
   helmet@8.3.0: {}
 
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
   hookable@6.1.1: {}
+
+  htm@3.1.1: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -6330,6 +9854,14 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 7.0.1
+
+  http-errors@1.7.2:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.3
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -6352,15 +9884,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  idb-keyval@6.2.1:
+    optional: true
+
+  idb-keyval@6.3.0: {}
 
   ieee754@1.2.1: {}
 
   immediate@3.0.6: {}
 
   import-meta-resolve@4.2.0: {}
+
+  inherits@2.0.3: {}
 
   inherits@2.0.4: {}
 
@@ -6374,6 +9917,8 @@ snapshots:
 
   ipaddr.js@2.4.0: {}
 
+  iron-webcrypto@1.2.1: {}
+
   is-absolute@0.1.7:
     dependencies:
       is-relative: 0.1.3
@@ -6386,6 +9931,9 @@ snapshots:
       is-decimal: 2.0.1
 
   is-arrayish@0.2.1: {}
+
+  is-buffer@1.1.6:
+    optional: true
 
   is-callable@1.2.7: {}
 
@@ -6416,6 +9964,16 @@ snapshots:
       global-directory: 4.0.1
       is-path-inside: 4.0.0
 
+  is-my-ip-valid@1.0.1: {}
+
+  is-my-json-valid@2.20.6:
+    dependencies:
+      generate-function: 2.3.1
+      generate-object-property: 1.2.0
+      is-my-ip-valid: 1.0.1
+      jsonpointer: 5.0.1
+      xtend: 4.0.2
+
   is-npm@6.1.0: {}
 
   is-path-inside@4.0.0: {}
@@ -6430,7 +9988,12 @@ snapshots:
 
   is-primitive@3.0.1: {}
 
+  is-property@1.0.2: {}
+
   is-relative@0.1.3: {}
+
+  is-retry-allowed@2.2.0:
+    optional: true
 
   is-retry-allowed@3.0.0: {}
 
@@ -6456,13 +10019,46 @@ snapshots:
 
   isobject@3.0.1: {}
 
+  isomorphic-ws@4.0.1(ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      json-stringify-safe: 5.0.1
+      stream-json: 1.9.1
+      uuid: 14.0.2
+      ws: 7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   jiti@2.7.0: {}
+
+  jose@6.2.12:
+    optional: true
+
+  js-sha256@0.11.1: {}
+
+  js-sha256@0.9.0: {}
 
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
@@ -6482,7 +10078,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.21.3
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -6499,6 +10095,8 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-stringify-safe@5.0.1: {}
+
   json5@2.2.3: {}
 
   jsonfile@6.2.1:
@@ -6506,6 +10104,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonpointer@5.0.1: {}
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -6537,6 +10137,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  keyvaluestorage-interface@1.0.0: {}
 
   kleur@3.0.3: {}
 
@@ -6683,11 +10285,31 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 10.0.0
 
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.3
+
+  lit-html@3.3.3:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.0:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.3
+
   local-pkg@1.2.1:
     dependencies:
       mlly: 1.8.2
       pkg-types: 2.3.1
       quansync: 0.2.11
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
 
   lodash.includes@4.3.0: {}
 
@@ -6719,9 +10341,13 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru_map@0.4.1: {}
 
   lz-string@1.5.0: {}
 
@@ -6744,6 +10370,13 @@ snapshots:
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+    optional: true
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -7097,6 +10730,10 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 5.0.9
@@ -7112,12 +10749,16 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multiformats@9.9.0: {}
+
   multimatch@6.0.0:
     dependencies:
       '@types/minimatch': 3.0.5
       array-differ: 4.0.0
       array-union: 3.0.1
       minimatch: 3.1.5
+
+  mustache@4.0.0: {}
 
   nano-spawn@2.1.0: {}
 
@@ -7128,6 +10769,32 @@ snapshots:
   nanospinner@1.2.2:
     dependencies:
       picocolors: 1.1.1
+
+  near-abi@0.2.0:
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  near-api-js@5.1.1:
+    dependencies:
+      '@near-js/accounts': 1.4.1
+      '@near-js/crypto': 1.4.2
+      '@near-js/keystores': 0.2.2
+      '@near-js/keystores-browser': 0.2.2
+      '@near-js/keystores-node': 0.1.2
+      '@near-js/providers': 1.0.3
+      '@near-js/signers': 0.2.2
+      '@near-js/transactions': 1.3.3
+      '@near-js/types': 0.3.1
+      '@near-js/utils': 1.1.0
+      '@near-js/wallet-account': 1.3.3
+      '@noble/curves': 1.8.1
+      borsh: 1.0.0
+      depd: 2.0.0
+      http-errors: 1.7.2
+      near-abi: 0.2.0
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
 
   next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -7156,9 +10823,23 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
+  node-addon-api@5.1.0: {}
+
   node-fetch-native@1.6.7: {}
 
+  node-fetch@2.6.7:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-forge@1.4.0: {}
+
+  node-gyp-build@4.8.4: {}
+
+  node-mock-http@1.0.5: {}
 
   node-notifier@10.0.1:
     dependencies:
@@ -7224,6 +10905,92 @@ snapshots:
 
   os-shim@0.1.3: {}
 
+  ox@0.14.44(typescript@5.9.3)(zod@3.22.4):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.22.4)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.44(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+    optional: true
+
+  ox@0.14.44(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.6.9(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.3.0(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+    optional: true
+
+  ox@0.9.3(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.3.0(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
   package-json@10.0.1:
     dependencies:
       ky: 1.14.3
@@ -7272,6 +11039,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  path-exists@4.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -7332,6 +11101,20 @@ snapshots:
 
   pino-std-serializers@7.1.0: {}
 
+  pino@10.0.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      slow-redact: 0.3.2
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
+
   pino@10.3.1:
     dependencies:
       '@pinojs/redact': 0.4.0
@@ -7380,6 +11163,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  pngjs@5.0.0: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.23:
@@ -7405,6 +11190,11 @@ snapshots:
       xtend: 4.0.2
 
   powershell-utils@0.1.0: {}
+
+  preact@10.24.2:
+    optional: true
+
+  preact@10.29.8: {}
 
   prettier@3.9.5: {}
 
@@ -7438,6 +11228,8 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  proxy-compare@3.0.1: {}
+
   proxy-from-env@2.1.0: {}
 
   publish-browser-extension@4.0.5:
@@ -7458,9 +11250,18 @@ snapshots:
     dependencies:
       escape-goat: 4.0.0
 
+  qrcode@1.5.3:
+    dependencies:
+      dijkstrajs: 1.0.3
+      encode-utf8: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
   quansync@0.2.11: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  radix3@1.1.2: {}
 
   randombytes@2.1.0:
     dependencies:
@@ -7573,6 +11374,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-main-filename@2.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
@@ -7638,9 +11441,30 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  rpc-websockets@9.3.9:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      '@types/uuid': 10.0.0
+      '@types/ws': 8.18.1
+      buffer: 6.0.3
+      eventemitter3: 5.0.4
+      uuid: 14.0.2
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
   rrweb-cssom@0.8.0: {}
 
   run-applescript@7.1.0: {}
+
+  rxjs@7.8.1:
+    dependencies:
+      tslib: 2.8.1
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   sac-sdk@0.4.3:
     dependencies:
@@ -7672,11 +11496,23 @@ snapshots:
 
   scule@1.3.0: {}
 
+  secp256k1@5.0.1:
+    dependencies:
+      elliptic: 6.6.1
+      node-addon-api: 5.1.0
+      node-gyp-build: 4.8.4
+
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
+  semver@7.7.1: {}
+
+  semver@7.7.2: {}
+
   semver@7.8.5: {}
+
+  set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.2: {}
 
@@ -7696,11 +11532,18 @@ snapshots:
 
   setimmediate@1.0.5: {}
 
+  setprototypeof@1.1.1: {}
+
   sha.js@2.4.12:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
+
+  sha1@1.1.1:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
 
   sharp@0.35.3(@types/node@24.13.3):
     dependencies:
@@ -7756,6 +11599,8 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  slow-redact@0.3.2: {}
+
   smol-toml@1.7.0: {}
 
   sonic-boom@4.2.1:
@@ -7788,7 +11633,15 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@1.5.0: {}
+
   std-env@3.10.0: {}
+
+  stream-chain@2.2.5: {}
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
 
   string-width@4.2.3:
     dependencies:
@@ -7848,10 +11701,14 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  style-vendorizer@2.2.3: {}
+
   styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
+
+  superstruct@2.0.2: {}
 
   symbol-tree@3.2.4: {}
 
@@ -7862,6 +11719,8 @@ snapshots:
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
+
+  text-encoding-utf-8@1.0.2: {}
 
   thread-stream@3.2.0:
     dependencies:
@@ -7906,11 +11765,15 @@ snapshots:
 
   toad-cache@3.7.4: {}
 
+  toidentifier@1.0.0: {}
+
   toml@5.0.0: {}
 
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
+
+  tr46@0.0.3: {}
 
   tr46@5.1.1:
     dependencies:
@@ -7919,6 +11782,10 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-mixer@6.0.4: {}
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
@@ -7936,6 +11803,10 @@ snapshots:
       '@turbo/linux-arm64': 2.10.5
       '@turbo/windows-64': 2.10.5
       '@turbo/windows-arm64': 2.10.5
+
+  tweetnacl-util@0.15.1: {}
+
+  tweetnacl@1.0.3: {}
 
   type-fest@3.13.1: {}
 
@@ -7957,7 +11828,16 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
+  uint8arrays@3.1.1:
+    dependencies:
+      multiformats: 9.9.0
+
+  uncrypto@0.1.3: {}
+
   undici-types@7.18.2: {}
+
+  undici-types@7.29.1:
+    optional: true
 
   undici@7.29.0: {}
 
@@ -8040,6 +11920,19 @@ snapshots:
       rollup: 4.62.2
       vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)
 
+  unstorage@1.17.5(idb-keyval@6.3.0):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.2
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    optionalDependencies:
+      idb-keyval: 6.3.0
+
   update-browserslist-db@1.3.2(browserslist@4.28.9):
     dependencies:
       browserslist: 4.28.9
@@ -8061,9 +11954,23 @@ snapshots:
 
   urijs@1.19.11: {}
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   util-deprecate@1.0.2: {}
 
+  uuid4@2.0.3: {}
+
   uuid@14.0.2: {}
+
+  valtio@2.1.7(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      proxy-compare: 3.0.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   vellar-sdk@0.6.2(@stellar/stellar-sdk@16.0.1)(@types/react@19.2.17)(passkey-kit@0.14.0(@stellar/stellar-sdk@16.0.1))(react@19.2.7):
     dependencies:
@@ -8086,6 +11993,58 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  viem@2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.22.4)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.14.44(typescript@5.9.3)(zod@3.22.4)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.14.44(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    optional: true
+
+  viem@2.56.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.14.44(typescript@5.9.3)(zod@4.4.3)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
   vite-node@3.2.4(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1):
     dependencies:
@@ -8158,7 +12117,7 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.1
 
-  vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.33.0)(tsx@4.23.1):
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -8186,7 +12145,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 24.13.3
-      jsdom: 26.1.0
+      jsdom: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - jiti
       - less
@@ -8235,6 +12194,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -8250,9 +12211,16 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   when-exit@2.1.5: {}
 
   when@3.7.7: {}
+
+  which-module@2.0.1: {}
 
   which-typed-array@1.1.22:
     dependencies:
@@ -8290,6 +12258,12 @@ snapshots:
       string-width: 8.2.2
       strip-ansi: 7.2.0
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -8304,9 +12278,25 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.21.1: {}
+  ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
-  ws@8.21.3: {}
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   wsl-utils@0.3.1:
     dependencies:
@@ -8395,11 +12385,32 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.3:
     dependencies:
@@ -8416,11 +12427,22 @@ snapshots:
       async: 3.2.6
       jszip: 3.10.1
 
+  zod@3.22.4: {}
+
+  zod@3.25.76:
+    optional: true
+
   zod@4.4.3: {}
 
   zustand@5.0.14(@types/react@19.2.17)(react@19.2.7):
     optionalDependencies:
       '@types/react': 19.2.17
       react: 19.2.7
+
+  zustand@5.0.3(@types/react@19.2.17)(react@19.2.7):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
+    optional: true
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   esbuild@<0.28.1: '>=0.28.1'
   uuid@<11.1.1: '>=11.1.1'
   toml@<4.2.0: '>=4.2.0'
+  smol-toml@<1.7.1: '>=1.7.1'
 
 packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
 
@@ -5168,8 +5169,8 @@ packages:
   slow-redact@0.3.2:
     resolution: {integrity: sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==}
 
-  smol-toml@1.7.0:
-    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   sonic-boom@4.2.1:
@@ -7982,7 +7983,7 @@ snapshots:
       commander: 14.0.3
       eventsource: 4.1.0
       feaxios: 0.0.23
-      smol-toml: 1.7.0
+      smol-toml: 1.8.0
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - debug
@@ -8000,7 +8001,7 @@ snapshots:
       commander: 14.0.3
       eventsource: 4.1.0
       feaxios: 0.0.23
-      smol-toml: 1.7.0
+      smol-toml: 1.8.0
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - debug
@@ -11644,7 +11645,7 @@ snapshots:
 
   slow-redact@0.3.2: {}
 
-  smol-toml@1.7.0: {}
+  smol-toml@1.8.0: {}
 
   sonic-boom@4.2.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   axios@>=1.0.0 <1.18.0: '>=1.18.1'
   fast-uri: '>=4.1.3'
   shell-quote@<=1.8.4: '>=1.9.0'
-  sharp@<0.35.0: '>=0.35.0'
+  sharp@<0.35.4: '>=0.35.4'
   find-my-way@<9.6.1: '>=9.6.1'
   undici@>=7.0.0 <7.29.0: '>=7.29.0 <8'
   tmp@<0.2.6: '>=0.2.6'
@@ -129,8 +129,8 @@ importers:
         specifier: ^1.3.26
         version: 1.3.26(react@19.2.7)
       next:
-        specifier: ^16.2.11
-        version: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^16.3.4
+        version: 16.3.4(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ogl:
         specifier: ^1.0.11
         version: 1.0.11
@@ -806,8 +806,8 @@ packages:
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -826,8 +826,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -838,8 +850,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -850,8 +874,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.28.1':
     resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -862,8 +898,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.28.1':
     resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -874,8 +922,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.28.1':
     resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -886,8 +946,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.28.1':
     resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -898,8 +970,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.28.1':
     resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -910,8 +994,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.28.1':
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -922,8 +1018,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -934,8 +1042,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -946,8 +1066,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -958,8 +1090,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -970,8 +1114,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.28.1':
     resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1031,160 +1187,160 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.35.3':
-    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.3':
-    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.35.3':
-    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.35.3':
-    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.3':
-    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.35.3':
-    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.3':
-    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.35.3':
-    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.35.3':
-    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
     engines: {node: '>=20.9.0'}
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.35.3':
-    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.3':
-    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
     engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.35.3':
-    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
@@ -1294,57 +1450,57 @@ packages:
     peerDependencies:
       near-api-js: ^4.0.0 || ^5.0.0
 
-  '@next/env@16.3.0':
-    resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
+  '@next/env@16.3.4':
+    resolution: {integrity: sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==}
 
-  '@next/swc-darwin-arm64@16.3.0':
-    resolution: {integrity: sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==}
+  '@next/swc-darwin-arm64@16.3.4':
+    resolution: {integrity: sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0':
-    resolution: {integrity: sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==}
+  '@next/swc-darwin-x64@16.3.4':
+    resolution: {integrity: sha512-2dpiSyl2Jw/NrBPaU2MAKGSa+2MR82pJIn4Sm5Rjr+gxAeuh0z158Su3Z2O8zn7UNNq+ej4bToed6RcRN/Lydg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.0':
-    resolution: {integrity: sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==}
+  '@next/swc-linux-arm64-gnu@16.3.4':
+    resolution: {integrity: sha512-+t+U8HZT+fApePCS5h89CSH3datz29MkzyfCn+6fpsZBG/oiEOhINcb9rtkv6sdpToLGFn2e6146NzaKCXkqrA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.3.0':
-    resolution: {integrity: sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==}
+  '@next/swc-linux-arm64-musl@16.3.4':
+    resolution: {integrity: sha512-mx03GNs1ocQA5JQ4FxDMmIsNkdrZh8cuezKCrId28e5/gIPU/l7Kcy2+vmCCzdjnnmXJy+iOAu+7K0QppO6Urg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.3.0':
-    resolution: {integrity: sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==}
+  '@next/swc-linux-x64-gnu@16.3.4':
+    resolution: {integrity: sha512-YIhGY6fSMfha52bnVxnzc9zaVBzJg+cqQTOD8tXIBSx4fuv0pVMxQTE0PaS59YhnMOiYiG09IMwxJAf/CFm/Dw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.3.0':
-    resolution: {integrity: sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==}
+  '@next/swc-linux-x64-musl@16.3.4':
+    resolution: {integrity: sha512-+eaaX6axpDb0yF1GCpiERe6njplvdC+nks/fKfcHu3XPGRrald8P3/X7yv7QLdjA51knnxwl9pxdIJsg+w1L+Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.3.0':
-    resolution: {integrity: sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==}
+  '@next/swc-win32-arm64-msvc@16.3.4':
+    resolution: {integrity: sha512-0jcXW7Xs/uzICrmgV3MhDYDeRy++1CqnpDIerlPIqYO4bhzB4WNbX/aRnQclustsAyTkFKB0z6rbcjmNg5tR8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0':
-    resolution: {integrity: sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==}
+  '@next/swc-win32-x64-msvc@16.3.4':
+    resolution: {integrity: sha512-vvBzwu1pYQCp92maZCFCIw/XgOTMR5tur9GjakwIo2cmwRTMKajRZZDS9+e4KsUZWKu1E007WUeAFXRRjZeuzw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2155,8 +2311,8 @@ packages:
     engines: {node: '>=22.12.0'}
     hasBin: true
 
-  '@swc/helpers@0.5.15':
-    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
@@ -2814,13 +2970,8 @@ packages:
     resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
     engines: {node: '>=6.0.0'}
 
-  baseline-browser-mapping@2.10.43:
-    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  baseline-browser-mapping@2.11.20:
-    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
+  baseline-browser-mapping@2.11.22:
+    resolution: {integrity: sha512-pWc4w51fBFd7mav43/zKRC+RI6f4yfzQoVlfvE8dECePyfkn1bzLp01Fj0QACcyCZyFhiEMyD2qScfKRWgWibA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2938,9 +3089,6 @@ packages:
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
-
-  caniuse-lite@1.0.30001805:
-    resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
 
   caniuse-lite@1.0.30001810:
     resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
@@ -3451,6 +3599,11 @@ packages:
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4499,8 +4652,8 @@ packages:
     resolution: {integrity: sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==}
     engines: {node: '>=20.17'}
 
-  nanoid@3.3.18:
-    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+  nanoid@3.3.19:
+    resolution: {integrity: sha512-Y2tUNy4ouw6tq5oDSKeQYGOyhkUBhNOcGV/02KC+6kd9eDGqdZd++mjMiIDilrBYvjEnCYvVtsuHCuP+okSfug==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4518,8 +4671,8 @@ packages:
   near-api-js@5.1.1:
     resolution: {integrity: sha512-h23BGSKxNv8ph+zU6snicstsVK1/CTXsQz4LuGGwoRE24Hj424nSe4+/1tzoiC285Ljf60kPAqRCmsfv9etF2g==}
 
-  next@16.3.0:
-    resolution: {integrity: sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==}
+  next@16.3.4:
+    resolution: {integrity: sha512-/Ztf6CeRH+ejEXUrYtqI4gkS66eFIHuSwqi60RgcpWKodxFZx2/dqVCMKBwILfAHXQ+F1b1vAudgj3mnxqtoIA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5132,8 +5285,8 @@ packages:
   sha1@1.1.1:
     resolution: {integrity: sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==}
 
-  sharp@0.35.3:
-    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       '@types/node': '*'
@@ -6371,7 +6524,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6394,79 +6547,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
   '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
@@ -6559,108 +6790,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.35.3':
+  '@img/sharp-darwin-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.3':
+  '@img/sharp-darwin-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.3
     optional: true
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
+  '@img/sharp-freebsd-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.3
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
+  '@img/sharp-libvips-darwin-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
+  '@img/sharp-libvips-linux-arm@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
+  '@img/sharp-libvips-linux-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
     optional: true
 
-  '@img/sharp-linux-arm64@0.35.3':
+  '@img/sharp-linux-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-arm@0.35.3':
+  '@img/sharp-linux-arm@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.3':
+  '@img/sharp-linux-ppc64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-riscv64@0.35.3':
+  '@img/sharp-linux-riscv64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.3':
+  '@img/sharp-linux-s390x@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.3
     optional: true
 
-  '@img/sharp-linux-x64@0.35.3':
+  '@img/sharp-linux-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
+  '@img/sharp-linuxmusl-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
+  '@img/sharp-linuxmusl-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
     optional: true
 
-  '@img/sharp-wasm32@0.35.3':
+  '@img/sharp-wasm32@0.35.4':
     dependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.11.3
     optional: true
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
+  '@img/sharp-webcontainers-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.3
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.3':
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.3':
+  '@img/sharp-win32-ia32@0.35.4':
     optional: true
 
-  '@img/sharp-win32-x64@0.35.3':
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -6838,30 +7069,30 @@ snapshots:
       near-api-js: 5.1.1
       rxjs: 7.8.1
 
-  '@next/env@16.3.0': {}
+  '@next/env@16.3.4': {}
 
-  '@next/swc-darwin-arm64@16.3.0':
+  '@next/swc-darwin-arm64@16.3.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0':
+  '@next/swc-darwin-x64@16.3.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0':
+  '@next/swc-linux-arm64-gnu@16.3.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0':
+  '@next/swc-linux-arm64-musl@16.3.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0':
+  '@next/swc-linux-x64-gnu@16.3.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0':
+  '@next/swc-linux-x64-musl@16.3.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0':
+  '@next/swc-win32-arm64-msvc@16.3.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0':
+  '@next/swc-win32-x64-msvc@16.3.4':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -8007,7 +8238,7 @@ snapshots:
       - debug
       - supports-color
 
-  '@swc/helpers@0.5.15':
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -9064,9 +9295,7 @@ snapshots:
 
   base64url@3.0.1: {}
 
-  baseline-browser-mapping@2.10.43: {}
-
-  baseline-browser-mapping@2.11.20: {}
+  baseline-browser-mapping@2.11.22: {}
 
   big.js@6.2.2: {}
 
@@ -9117,7 +9346,7 @@ snapshots:
 
   browserslist@4.28.9:
     dependencies:
-      baseline-browser-mapping: 2.11.20
+      baseline-browser-mapping: 2.11.22
       caniuse-lite: 1.0.30001810
       electron-to-chromium: 1.5.422
       node-releases: 2.0.54
@@ -9190,8 +9419,6 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@8.0.0: {}
-
-  caniuse-lite@1.0.30001805: {}
 
   caniuse-lite@1.0.30001810: {}
 
@@ -9595,6 +9822,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -10806,7 +11062,7 @@ snapshots:
 
   nano-spawn@2.1.0: {}
 
-  nanoid@3.3.18: {}
+  nanoid@3.3.19: {}
 
   nanoid@6.0.1: {}
 
@@ -10840,28 +11096,28 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.3.4(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.3.0
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.43
-      caniuse-lite: 1.0.30001805
+      '@next/env': 16.3.4
+      '@swc/helpers': 0.5.23
+      baseline-browser-mapping: 2.11.22
+      caniuse-lite: 1.0.30001810
       postcss: 8.5.23
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0
-      '@next/swc-darwin-x64': 16.3.0
-      '@next/swc-linux-arm64-gnu': 16.3.0
-      '@next/swc-linux-arm64-musl': 16.3.0
-      '@next/swc-linux-x64-gnu': 16.3.0
-      '@next/swc-linux-x64-musl': 16.3.0
-      '@next/swc-win32-arm64-msvc': 16.3.0
-      '@next/swc-win32-x64-msvc': 16.3.0
+      '@next/swc-darwin-arm64': 16.3.4
+      '@next/swc-darwin-x64': 16.3.4
+      '@next/swc-linux-arm64-gnu': 16.3.4
+      '@next/swc-linux-arm64-musl': 16.3.4
+      '@next/swc-linux-x64-gnu': 16.3.4
+      '@next/swc-linux-x64-musl': 16.3.4
+      '@next/swc-win32-arm64-msvc': 16.3.4
+      '@next/swc-win32-x64-msvc': 16.3.4
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
-      sharp: 0.35.3(@types/node@24.13.3)
+      sharp: 0.35.4(@types/node@24.13.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -11219,7 +11475,7 @@ snapshots:
 
   postcss@8.5.28:
     dependencies:
-      nanoid: 3.3.18
+      nanoid: 3.3.19
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -11487,7 +11743,7 @@ snapshots:
 
   rpc-websockets@9.3.9:
     dependencies:
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.23
       '@types/uuid': 10.0.0
       '@types/ws': 8.18.1
       buffer: 6.0.3
@@ -11589,37 +11845,37 @@ snapshots:
       charenc: 0.0.2
       crypt: 0.0.2
 
-  sharp@0.35.3(@types/node@24.13.3):
+  sharp@0.35.4(@types/node@24.13.3):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
       '@types/node': 24.13.3
     optional: true
 
@@ -11835,7 +12091,7 @@ snapshots:
 
   tsx@4.23.1:
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
     optionalDependencies:
       fsevents: 2.3.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       '@vellar/lifecycle-service':
         specifier: workspace:*
         version: link:../lifecycle-service
+      '@vellar/marketplace-service':
+        specifier: workspace:*
+        version: link:../marketplace-service
       '@vellar/policy-service':
         specifier: workspace:*
         version: link:../policy-service
@@ -378,6 +381,46 @@ importers:
         specifier: ^4.0.0
         version: 4.4.3
     devDependencies:
+      tsx:
+        specifier: ^4.20.0
+        version: 4.23.1
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.33.0)(tsx@4.23.1)
+
+  services/marketplace-service:
+    dependencies:
+      '@stellar/stellar-sdk':
+        specifier: ^16.0.1
+        version: 16.0.1
+      '@vellar/service-kit':
+        specifier: workspace:*
+        version: link:../../packages/service-kit
+      '@vellar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+      fastify:
+        specifier: ^5.12.3
+        version: 5.12.3
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       tsx:
         specifier: ^4.20.0
         version: 4.23.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,17 @@ allowBuilds:
   sharp: true
   spawn-sync: false
   "@tailwindcss/oxide": true
+  # Pulled in transitively by @creit.tech/stellar-wallets-kit's WalletConnect
+  # module (2026-09-11, marketplace step 1). None needs its build script for the
+  # four wallets we register (Freighter, Albedo, xBull, LOBSTR): bufferutil and
+  # utf-8-validate are optional native speedups for `ws` with pure-JS fallbacks,
+  # secp256k1 likewise falls back to its JS implementation, and @reown/appkit's
+  # postinstall is only telemetry/asset setup. Left unbuilt to keep the install
+  # free of native toolchain requirements.
+  '@reown/appkit': false
+  bufferutil: false
+  secp256k1: false
+  utf-8-validate: false
 minimumReleaseAgeExclude:
   - vellar-sdk@0.6.2
 # Security overrides: force patched versions of vulnerable TRANSITIVE deps

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,10 @@ overrides:
   # 4.1.2 anyway. The bare key forces every resolution in the graph.
   fast-uri: ">=4.1.3"
   shell-quote@<=1.8.4: ">=1.9.0"
-  sharp@<0.35.0: ">=0.35.0"
+  # Raised 0.35.0 -> 0.35.4 (2026-09-12): libheif advisories
+  # GHSA-g89c-p67h-r497 / GHSA-2jg2-4ch7-h545 land in <0.35.4, and the old
+  # floor left 0.35.3 resolving. sharp reaches us via apps/web > next.
+  sharp@<0.35.4: ">=0.35.4"
   # Backend-runtime highs (2026-08): both are in the live services' HTTP stack.
   # find-my-way is fastify's router (service-kit>fastify); the advisory is an
   # HTTP/2 request DoS (only reachable if http2 is ever enabled, but cheap to

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,6 +78,11 @@ overrides:
   # of a transitive we do not control, so it is verified two ways below rather
   # than assumed: the export surface stays `parse`, and the full suite is green.
   toml@<4.2.0: ">=4.2.0"
+  # smol-toml reaches runtime through @stellar/stellar-sdk's TOML parsing, on 27
+  # paths spanning apps/web, apps/extension, packages/provider-sdk and five
+  # services. 1.7.0 carries a DoS via malformed TOML documents
+  # (GHSA-7w5x-hrqm-74c2); 1.7.1 is the advisory's own floor and a patch bump.
+  "smol-toml@<1.7.1": ">=1.7.1"
 
 # @hookform/resolvers 5.x imports `zod/v4/core` at runtime but declares only
 # react-hook-form as a peer. Under pnpm's strict linking zod is never placed

--- a/services/all-in-one/package.json
+++ b/services/all-in-one/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "tsx --env-file-if-exists=../../.env src/index.ts",
-    "dev": "NODE_ENV=development tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "dev": "NODE_ENV=development STELLAR_NETWORK=testnet tsx watch --env-file-if-exists=../../.env src/index.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/services/all-in-one/package.json
+++ b/services/all-in-one/package.json
@@ -15,6 +15,7 @@
     "@vellar/lifecycle-service": "workspace:*",
     "@vellar/policy-service": "workspace:*",
     "@vellar/verification-service": "workspace:*",
+    "@vellar/marketplace-service": "workspace:*",
     "tsx": "^4.20.0"
   },
   "devDependencies": {

--- a/services/all-in-one/src/index.ts
+++ b/services/all-in-one/src/index.ts
@@ -5,6 +5,7 @@
 //   - lifecycle-service    on LIFECYCLE_SERVICE_PORT    (default 4002)
 //   - policy-service       on POLICY_SERVICE_PORT       (default 4003)
 //   - verification-service on VERIFICATION_SERVICE_PORT (default 4004)
+//   - marketplace-service  on MARKETPLACE_PORT           (default 4006)
 //   - api-gateway          on PORT                      (the PUBLIC port — $PORT)
 //
 // The gateway is the only publicly-exposed service; it proxies to the others
@@ -28,6 +29,7 @@ await import("@vellar/wallet-service");
 await import("@vellar/lifecycle-service");
 await import("@vellar/policy-service");
 await import("@vellar/verification-service");
+await import("@vellar/marketplace-service");
 await import("@vellar/api-gateway");
 
 // eslint-disable-next-line no-console

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -21,6 +21,7 @@ export interface GatewayOptions {
   lifecycleServiceUrl?: string;
   policyServiceUrl?: string;
   verificationServiceUrl?: string;
+  marketplaceServiceUrl?: string;
   corsOrigin?: string;
   /** Max requests per IP per window. Default 120/min; env RATE_LIMIT_MAX. */
   rateLimitMax?: number;
@@ -81,7 +82,8 @@ export function buildServer(options: GatewayOptions = {}): FastifyInstance {
   // only the configured origin(s) are allowed (technical-doc.md §8.3). DELETE
   // must be listed explicitly — the plugin's default (GET,HEAD,POST) fails
   // session revocation at preflight.
-  app.register(cors, { origin: corsOrigin, methods: ["GET", "POST", "DELETE"] });
+  // PATCH added for marketplace listings updates (Step 2).
+  app.register(cors, { origin: corsOrigin, methods: ["GET", "POST", "PATCH", "DELETE"] });
 
   // Boundary checks that must run BEFORE proxying. @fastify/http-proxy streams
   // the body straight through, so Fastify's own `bodyLimit` (which only applies
@@ -149,6 +151,14 @@ export function buildServer(options: GatewayOptions = {}): FastifyInstance {
     upstream: verificationServiceUrl,
     prefix: "/verification",
     rewritePrefix: "/verification",
+  });
+
+  const marketplaceServiceUrl =
+    options.marketplaceServiceUrl ?? process.env.MARKETPLACE_SERVICE_URL ?? "http://localhost:4006";
+  app.register(proxy, {
+    upstream: marketplaceServiceUrl,
+    prefix: "/marketplace",
+    rewritePrefix: "/marketplace",
   });
 
   return app;

--- a/services/marketplace-service/drizzle.config.ts
+++ b/services/marketplace-service/drizzle.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+});

--- a/services/marketplace-service/drizzle/0000_init.sql
+++ b/services/marketplace-service/drizzle/0000_init.sql
@@ -1,0 +1,45 @@
+CREATE TABLE "marketplace_listings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"seller_address" text NOT NULL,
+	"resource_url" text NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"description" text,
+	"price_atomic" bigint NOT NULL,
+	"asset" text NOT NULL,
+	"scheme" varchar(20) DEFAULT 'exact' NOT NULL,
+	"status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"first_settled_at" timestamp with time zone,
+	"total_settlements" bigint DEFAULT 0 NOT NULL,
+	"total_revenue" bigint DEFAULT 0 NOT NULL,
+	CONSTRAINT "marketplace_listings_resource_url_unique" UNIQUE("resource_url")
+);
+--> statement-breakpoint
+CREATE TABLE "marketplace_nonces" (
+	"nonce" text PRIMARY KEY NOT NULL,
+	"address" text NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"used_at" timestamp with time zone,
+	"expires_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "marketplace_settlements" (
+	"id" text PRIMARY KEY NOT NULL,
+	"listing_id" text,
+	"tx_hash" varchar(64) NOT NULL,
+	"buyer_address" text,
+	"amount_atomic" bigint NOT NULL,
+	"settled_at" timestamp with time zone NOT NULL,
+	"ledger" integer NOT NULL,
+	CONSTRAINT "marketplace_settlements_tx_hash_unique" UNIQUE("tx_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "marketplace_settlements" ADD CONSTRAINT "marketplace_settlements_listing_id_marketplace_listings_id_fk" FOREIGN KEY ("listing_id") REFERENCES "public"."marketplace_listings"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "marketplace_listings_seller_address_idx" ON "marketplace_listings" USING btree ("seller_address");--> statement-breakpoint
+CREATE INDEX "marketplace_listings_status_idx" ON "marketplace_listings" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "marketplace_listings_resource_url_idx" ON "marketplace_listings" USING btree ("resource_url");--> statement-breakpoint
+CREATE INDEX "marketplace_nonces_address_idx" ON "marketplace_nonces" USING btree ("address");--> statement-breakpoint
+CREATE INDEX "marketplace_nonces_expires_at_idx" ON "marketplace_nonces" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "marketplace_settlements_listing_id_idx" ON "marketplace_settlements" USING btree ("listing_id");--> statement-breakpoint
+CREATE INDEX "marketplace_settlements_settled_at_idx" ON "marketplace_settlements" USING btree ("settled_at");

--- a/services/marketplace-service/drizzle/meta/0000_snapshot.json
+++ b/services/marketplace-service/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,356 @@
+{
+  "id": "674a0fd8-3d50-41ce-afaf-a189b7f07080",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.marketplace_listings": {
+      "name": "marketplace_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "seller_address": {
+          "name": "seller_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_url": {
+          "name": "resource_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_atomic": {
+          "name": "price_atomic",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset": {
+          "name": "asset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_settled_at": {
+          "name": "first_settled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_settlements": {
+          "name": "total_settlements",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_revenue": {
+          "name": "total_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        }
+      },
+      "indexes": {
+        "marketplace_listings_seller_address_idx": {
+          "name": "marketplace_listings_seller_address_idx",
+          "columns": [
+            {
+              "expression": "seller_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_listings_status_idx": {
+          "name": "marketplace_listings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_listings_resource_url_idx": {
+          "name": "marketplace_listings_resource_url_idx",
+          "columns": [
+            {
+              "expression": "resource_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "marketplace_listings_resource_url_unique": {
+          "name": "marketplace_listings_resource_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resource_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketplace_nonces": {
+      "name": "marketplace_nonces",
+      "schema": "",
+      "columns": {
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "marketplace_nonces_address_idx": {
+          "name": "marketplace_nonces_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_nonces_expires_at_idx": {
+          "name": "marketplace_nonces_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketplace_settlements": {
+      "name": "marketplace_settlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyer_address": {
+          "name": "buyer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_atomic": {
+          "name": "amount_atomic",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ledger": {
+          "name": "ledger",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "marketplace_settlements_listing_id_idx": {
+          "name": "marketplace_settlements_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_settlements_settled_at_idx": {
+          "name": "marketplace_settlements_settled_at_idx",
+          "columns": [
+            {
+              "expression": "settled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "marketplace_settlements_listing_id_marketplace_listings_id_fk": {
+          "name": "marketplace_settlements_listing_id_marketplace_listings_id_fk",
+          "tableFrom": "marketplace_settlements",
+          "tableTo": "marketplace_listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "marketplace_settlements_tx_hash_unique": {
+          "name": "marketplace_settlements_tx_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tx_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/marketplace-service/drizzle/meta/_journal.json
+++ b/services/marketplace-service/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1789169402915,
+      "tag": "0000_init",
+      "breakpoints": true
+    }
+  ]
+}

--- a/services/marketplace-service/package.json
+++ b/services/marketplace-service/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@vellar/marketplace-service",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Marketplace catalog/search proxy, seller listings, and x402 payment orchestration against vellar-facilitator",
+  "type": "module",
+  "scripts": {
+    "dev": "NODE_ENV=development STELLAR_NETWORK=testnet tsx watch --env-file-if-exists=../../.env src/index.ts",
+    "start": "tsx --env-file-if-exists=../../.env src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^16.0.1",
+    "@vellar/service-kit": "workspace:*",
+    "@vellar/types": "workspace:*",
+    "drizzle-orm": "^0.45.2",
+    "fastify": "^5.12.3",
+    "pg": "^8.22.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.20.0",
+    "drizzle-kit": "^0.31.10",
+    "tsx": "^4.20.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.0"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server.ts"
+  }
+}

--- a/services/marketplace-service/src/config.ts
+++ b/services/marketplace-service/src/config.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+// Environment configuration for marketplace-service
+// (new-build-technical-doc.md §10).
+
+export const DEFAULTS = {
+  facilitatorUrl: "https://vellar-facilitator.onrender.com",
+  facilitatorTimeoutMs: 30_000,
+  /** §5.2: the registration nonce is time-limited to five minutes. */
+  nonceTtlMs: 5 * 60_000,
+  /** Expired nonces are swept on boot and then on this interval. */
+  nonceCleanupIntervalMs: 10 * 60_000,
+} as const;
+
+export interface MarketplaceConfig {
+  databaseUrl?: string;
+  facilitatorUrl: string;
+  facilitatorTimeoutMs: number;
+  nonceTtlMs: number;
+  nonceCleanupIntervalMs: number;
+  /** Passphrase used to parse submitted XDR for signature verification. Keyed
+   * off SERVER config, never a request body (security-audit V5) — otherwise a
+   * caller could present a mainnet-signed tx and have it validated as testnet. */
+  networkPassphrase: string;
+}
+
+const positiveInt = (fallback: number) => (raw: string | undefined) => {
+  const parsed = z.coerce.number().int().positive().safeParse(raw);
+  return parsed.success ? parsed.data : fallback;
+};
+
+export function configFromEnv(env: NodeJS.ProcessEnv = process.env): MarketplaceConfig {
+  return {
+    databaseUrl: env.DATABASE_URL || undefined,
+    facilitatorUrl: (env.FACILITATOR_URL || DEFAULTS.facilitatorUrl).replace(/\/+$/, ""),
+    facilitatorTimeoutMs: positiveInt(DEFAULTS.facilitatorTimeoutMs)(env.FACILITATOR_TIMEOUT_MS),
+    nonceTtlMs: positiveInt(DEFAULTS.nonceTtlMs)(env.MARKETPLACE_NONCE_TTL_MS),
+    nonceCleanupIntervalMs: positiveInt(DEFAULTS.nonceCleanupIntervalMs)(
+      env.MARKETPLACE_NONCE_CLEANUP_INTERVAL_MS,
+    ),
+    networkPassphrase: env.STELLAR_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015",
+  };
+}

--- a/services/marketplace-service/src/db/client.ts
+++ b/services/marketplace-service/src/db/client.ts
@@ -1,0 +1,52 @@
+import { fileURLToPath } from "node:url";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import pg from "pg";
+
+export type Db = NodePgDatabase;
+
+export interface DbHandle {
+  db: Db;
+  close(): Promise<void>;
+  /** Cheap liveness check for the DB-aware /health probe (FIX 7). Resolves true
+   * when the pool can round-trip a query, false when the connection is down —
+   * so /health returns 503 if Postgres drops AFTER boot, not just at boot. */
+  ping(): Promise<boolean>;
+}
+
+/** Advisory-lock key shared by ALL Vellar services' db clients: every migrator
+ * hitting one database must serialize globally, because concurrent CREATE TABLE
+ * (including drizzle's own IF NOT EXISTS journal bootstrap) aborts with 23505
+ * on pg_type_typname_nsp_index even though each migration runs in its own
+ * transaction. Covers parallel vitest workers in CI and multi-replica boots. */
+const MIGRATION_LOCK_KEY = 0x56454c41; // "VELA"
+
+/** Connects and applies pending migrations (idempotent) before returning. */
+export async function connectDb(databaseUrl: string): Promise<DbHandle> {
+  const pool = new pg.Pool({ connectionString: databaseUrl });
+  const db = drizzle(pool);
+  // Session-level lock on a dedicated connection: pg_advisory_lock blocks
+  // until any concurrent migrator finishes, then we migrate and release.
+  const lockConn = await pool.connect();
+  try {
+    await lockConn.query("SELECT pg_advisory_lock($1)", [MIGRATION_LOCK_KEY]);
+    await migrate(db, {
+      migrationsFolder: fileURLToPath(new URL("../../drizzle", import.meta.url)),
+    });
+  } finally {
+    await lockConn.query("SELECT pg_advisory_unlock($1)", [MIGRATION_LOCK_KEY]).catch(() => {});
+    lockConn.release();
+  }
+  return {
+    db,
+    close: () => pool.end(),
+    ping: async () => {
+      try {
+        await pool.query("SELECT 1");
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}

--- a/services/marketplace-service/src/db/pg-repository.ts
+++ b/services/marketplace-service/src/db/pg-repository.ts
@@ -1,0 +1,159 @@
+import { and, desc, eq, gt, isNull, lt } from "drizzle-orm";
+import type { Db } from "./client";
+import { marketplaceListings, marketplaceNonces } from "./schema";
+import {
+  DuplicateListingError,
+  type ListingRecord,
+  type ListingRepository,
+  type ListingScheme,
+  type ListingStatus,
+  type ListingUpdate,
+  type NonceRepository,
+} from "../repository";
+
+// Postgres implementations of the marketplace seams. Rows carry Date and
+// bigint; the domain interfaces use ISO strings and decimal strings, so the
+// conversion lives here and nowhere else.
+
+type ListingRow = typeof marketplaceListings.$inferSelect;
+
+function toRecord(row: ListingRow): ListingRecord {
+  return {
+    id: row.id,
+    sellerAddress: row.sellerAddress,
+    resourceUrl: row.resourceUrl,
+    title: row.title,
+    description: row.description,
+    priceAtomic: row.priceAtomic.toString(),
+    asset: row.asset,
+    scheme: row.scheme as ListingScheme,
+    status: row.status as ListingStatus,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    firstSettledAt: row.firstSettledAt ? row.firstSettledAt.toISOString() : null,
+    totalSettlements: row.totalSettlements.toString(),
+    totalRevenue: row.totalRevenue.toString(),
+  };
+}
+
+/** Postgres unique-violation. Raised when two sellers race for one URL. */
+function isUniqueViolation(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "23505";
+}
+
+export function createPgListingRepository(db: Db): ListingRepository {
+  return {
+    async insert(record) {
+      try {
+        await db.insert(marketplaceListings).values({
+          id: record.id,
+          sellerAddress: record.sellerAddress,
+          resourceUrl: record.resourceUrl,
+          title: record.title,
+          description: record.description,
+          priceAtomic: BigInt(record.priceAtomic),
+          asset: record.asset,
+          scheme: record.scheme,
+          status: record.status,
+          createdAt: new Date(record.createdAt),
+          updatedAt: new Date(record.updatedAt),
+          firstSettledAt: record.firstSettledAt ? new Date(record.firstSettledAt) : null,
+          totalSettlements: BigInt(record.totalSettlements),
+          totalRevenue: BigInt(record.totalRevenue),
+        });
+      } catch (err) {
+        // The UNIQUE index on resource_url is the real arbiter of §14 Q4's
+        // "first registrant wins" — a pre-check would race.
+        if (isUniqueViolation(err)) throw new DuplicateListingError(record.resourceUrl);
+        throw err;
+      }
+    },
+
+    async findById(id) {
+      const [row] = await db
+        .select()
+        .from(marketplaceListings)
+        .where(eq(marketplaceListings.id, id))
+        .limit(1);
+      return row ? toRecord(row) : undefined;
+    },
+
+    async findByResourceUrl(resourceUrl) {
+      const [row] = await db
+        .select()
+        .from(marketplaceListings)
+        .where(eq(marketplaceListings.resourceUrl, resourceUrl))
+        .limit(1);
+      return row ? toRecord(row) : undefined;
+    },
+
+    async listBySeller(sellerAddress) {
+      const rows = await db
+        .select()
+        .from(marketplaceListings)
+        .where(eq(marketplaceListings.sellerAddress, sellerAddress))
+        .orderBy(desc(marketplaceListings.createdAt));
+      return rows.map(toRecord);
+    },
+
+    async update(id, patch, updatedAt) {
+      const values: Partial<typeof marketplaceListings.$inferInsert> = { updatedAt };
+      if (patch.title !== undefined) values.title = patch.title;
+      if (patch.description !== undefined) values.description = patch.description;
+      if (patch.priceAtomic !== undefined) values.priceAtomic = BigInt(patch.priceAtomic);
+      if (patch.scheme !== undefined) values.scheme = patch.scheme;
+      if (patch.status !== undefined) values.status = patch.status;
+      const [row] = await db
+        .update(marketplaceListings)
+        .set(values)
+        .where(eq(marketplaceListings.id, id))
+        .returning();
+      return row ? toRecord(row) : undefined;
+    },
+  };
+}
+
+export function createPgNonceRepository(db: Db): NonceRepository {
+  return {
+    async insert(record) {
+      await db.insert(marketplaceNonces).values({
+        nonce: record.nonce,
+        address: record.address,
+        createdAt: new Date(record.createdAt),
+        usedAt: record.usedAt ? new Date(record.usedAt) : null,
+        expiresAt: new Date(record.expiresAt),
+      });
+    },
+
+    /**
+     * One conditional UPDATE does the whole check-and-consume: the WHERE clause
+     * carries every precondition (right address, unused, unexpired), so two
+     * concurrent registrations racing the same nonce produce exactly one
+     * updated row — the loser sees zero rows and is refused. A SELECT-then-
+     * UPDATE would let both through.
+     */
+    async consume(nonce, address, asOf) {
+      const updated = await db
+        .update(marketplaceNonces)
+        .set({ usedAt: asOf })
+        .where(
+          and(
+            eq(marketplaceNonces.nonce, nonce),
+            eq(marketplaceNonces.address, address),
+            isNull(marketplaceNonces.usedAt),
+            gt(marketplaceNonces.expiresAt, asOf),
+          ),
+        )
+        .returning({ nonce: marketplaceNonces.nonce });
+      return updated.length === 1;
+    },
+
+    async deleteExpired(asOf) {
+      const deleted = await db
+        .delete(marketplaceNonces)
+        .where(lt(marketplaceNonces.expiresAt, asOf))
+        .returning({ nonce: marketplaceNonces.nonce });
+      return deleted.length;
+    },
+  };
+}

--- a/services/marketplace-service/src/db/schema.ts
+++ b/services/marketplace-service/src/db/schema.ts
@@ -1,0 +1,78 @@
+import { sql } from "drizzle-orm";
+import { bigint, index, integer, pgTable, text, timestamp, varchar } from "drizzle-orm/pg-core";
+
+// Postgres schema for marketplace-service (new-build-technical-doc.md §5.1).
+// Timestamps are timestamptz; repos convert to/from the ISO strings the domain
+// interfaces use. Ids are text, not uuid: a junk id in a lookup must 404, not
+// 500 on a failed cast (same rule as wallet_sessions.id).
+
+export const marketplaceListings = pgTable(
+  "marketplace_listings",
+  {
+    id: text("id").primaryKey(),
+    sellerAddress: text("seller_address").notNull(),
+    resourceUrl: text("resource_url").notNull().unique(),
+    title: varchar("title", { length: 255 }).notNull(),
+    description: text("description"),
+    // Money is bigint-mode: base units can exceed Number.MAX_SAFE_INTEGER for
+    // 7-decimal assets, and JS number rounding on a price is a correctness bug.
+    priceAtomic: bigint("price_atomic", { mode: "bigint" }).notNull(),
+    asset: text("asset").notNull(),
+    scheme: varchar("scheme", { length: 20 }).notNull().default("exact"),
+    // pending | active | paused | removed. A listing becomes active on its
+    // first settlement (§5.2), never at registration time.
+    status: varchar("status", { length: 20 }).notNull().default("pending"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull(),
+    firstSettledAt: timestamp("first_settled_at", { withTimezone: true, mode: "date" }),
+    totalSettlements: bigint("total_settlements", { mode: "bigint" })
+      .notNull()
+      // SQL default, not `.default(0n)`: drizzle-kit 0.31.10 throws
+      // "Do not know how to serialize a BigInt" when snapshotting a JS bigint.
+      .default(sql`0`),
+    totalRevenue: bigint("total_revenue", { mode: "bigint" }).notNull().default(sql`0`),
+  },
+  (table) => [
+    index("marketplace_listings_seller_address_idx").on(table.sellerAddress),
+    index("marketplace_listings_status_idx").on(table.status),
+    index("marketplace_listings_resource_url_idx").on(table.resourceUrl),
+  ],
+);
+
+export const marketplaceSettlements = pgTable(
+  "marketplace_settlements",
+  {
+    id: text("id").primaryKey(),
+    listingId: text("listing_id").references(() => marketplaceListings.id),
+    txHash: varchar("tx_hash", { length: 64 }).notNull().unique(),
+    buyerAddress: text("buyer_address"),
+    amountAtomic: bigint("amount_atomic", { mode: "bigint" }).notNull(),
+    settledAt: timestamp("settled_at", { withTimezone: true, mode: "date" }).notNull(),
+    ledger: integer("ledger").notNull(),
+  },
+  (table) => [
+    index("marketplace_settlements_listing_id_idx").on(table.listingId),
+    index("marketplace_settlements_settled_at_idx").on(table.settledAt),
+  ],
+);
+
+// Seller-registration nonces (new-build-technical-doc.md §5.2). The spec
+// assumed Redis; this repo has no Redis anywhere, so the store is Postgres
+// (docs/decisions.md). A nonce is SINGLE-USE (used_at stamped on first
+// successful use; a second use is refused) and TIME-LIMITED (expires_at =
+// created_at + 5 min). Both properties are enforced in one conditional UPDATE
+// so two concurrent requests cannot both consume the same nonce.
+export const marketplaceNonces = pgTable(
+  "marketplace_nonces",
+  {
+    nonce: text("nonce").primaryKey(),
+    address: text("address").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull(),
+    usedAt: timestamp("used_at", { withTimezone: true, mode: "date" }),
+    expiresAt: timestamp("expires_at", { withTimezone: true, mode: "date" }).notNull(),
+  },
+  (table) => [
+    index("marketplace_nonces_address_idx").on(table.address),
+    index("marketplace_nonces_expires_at_idx").on(table.expiresAt),
+  ],
+);

--- a/services/marketplace-service/src/index.ts
+++ b/services/marketplace-service/src/index.ts
@@ -1,0 +1,85 @@
+import {
+  hostFromEnv,
+  portFromEnv,
+  resolvePersistencePolicy,
+  startService,
+  tryConnectDb,
+} from "@vellar/service-kit";
+import { configFromEnv } from "./config";
+import { FacilitatorClient } from "./lib/facilitator";
+import { startNonceSweeper } from "./nonce-sweeper";
+import { buildServer, type MarketplaceServiceDeps } from "./server";
+import type { DbHandle } from "./db/client";
+
+const config = configFromEnv();
+
+const deps: MarketplaceServiceDeps = {
+  facilitator: new FacilitatorClient({
+    baseUrl: config.facilitatorUrl,
+    timeoutMs: config.facilitatorTimeoutMs,
+  }),
+  networkPassphrase: config.networkPassphrase,
+  nonceTtlMs: config.nonceTtlMs,
+};
+
+let closeDb: (() => Promise<void>) | undefined;
+let dbHandle: DbHandle | undefined;
+
+if (config.databaseUrl) {
+  const databaseUrl = config.databaseUrl;
+  const { connectDb } = await import("./db/client");
+  const { createPgListingRepository, createPgNonceRepository } = await import("./db/pg-repository");
+  const handle = await tryConnectDb(() => connectDb(databaseUrl), {
+    databaseUrl,
+    log: { warn: (message) => console.warn(message) },
+  });
+  if (handle) {
+    dbHandle = handle;
+    deps.listings = createPgListingRepository(handle.db);
+    deps.nonces = createPgNonceRepository(handle.db);
+    closeDb = handle.close;
+  }
+}
+
+// Fail closed in production BEFORE building the server (FIX 7): a marketplace
+// holding seller registrations in memory would silently lose them on restart.
+const policy = resolvePersistencePolicy({
+  databaseUrl: config.databaseUrl,
+  nodeEnv: process.env.NODE_ENV,
+  connected: config.databaseUrl ? dbHandle !== undefined : undefined,
+  allowInmemory: process.env.ALLOW_INMEMORY === "1",
+});
+if (policy.action === "fail") {
+  console.error(`[marketplace-service] ${policy.reason}`);
+  process.exit(1);
+}
+deps.isReady = dbHandle ? () => dbHandle!.ping() : () => policy.action === "allow-inmemory";
+
+const app = buildServer(deps);
+
+if (closeDb) {
+  app.addHook("onClose", async () => closeDb?.());
+  app.log.info("Postgres connected, migrations applied");
+} else {
+  app.log.warn(
+    "DATABASE_URL not set — using in-memory repositories; listings and nonces will NOT survive a restart. " +
+      "(ALLOW_INMEMORY explicitly permits this; production without it refuses to boot.)",
+  );
+}
+
+// Expired nonces are swept on boot and on an interval, in the background — a
+// request must never pay for this (§5.2 cleanup job).
+if (deps.nonces) {
+  const stopSweeper = startNonceSweeper({
+    nonces: deps.nonces,
+    intervalMs: config.nonceCleanupIntervalMs,
+    log: app.log,
+  });
+  app.addHook("onClose", async () => stopSweeper());
+}
+
+await startService(app, {
+  port: portFromEnv("MARKETPLACE_PORT", 4006),
+  // Downstream services bind loopback only; the gateway is the public surface.
+  host: hostFromEnv("127.0.0.1"),
+});

--- a/services/marketplace-service/src/lib/errors.ts
+++ b/services/marketplace-service/src/lib/errors.ts
@@ -1,0 +1,69 @@
+// Typed errors for marketplace-service. Every route funnels failures through
+// these so the HTTP surface is uniform: one `{ error, message }` body shape and
+// one status mapping, rather than per-route ad-hoc replies.
+
+export class MarketplaceError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "MarketplaceError";
+  }
+
+  /** The JSON body sent to the client. Deliberately excludes stack/cause. */
+  toBody(): { error: string; message: string } {
+    return { error: this.code, message: this.message };
+  }
+}
+
+export class NotFoundError extends MarketplaceError {
+  constructor(message = "Not found", code = "not_found") {
+    super(404, code, message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ValidationError extends MarketplaceError {
+  constructor(message = "Invalid request", code = "invalid_request") {
+    super(400, code, message);
+    this.name = "ValidationError";
+  }
+}
+
+/**
+ * An upstream failure from vellar-facilitator. `upstreamStatus` is the status
+ * the facilitator returned (0 for a transport/timeout failure); `status` is what
+ * WE return to the client. A facilitator 4xx is a bad gateway from our side —
+ * the client's request to us was well-formed — so anything that isn't a 5xx or
+ * a transport error still surfaces as 502 unless explicitly overridden.
+ */
+export class FacilitatorError extends MarketplaceError {
+  constructor(
+    readonly upstreamStatus: number,
+    message: string,
+    status = 502,
+    code = "facilitator_error",
+  ) {
+    super(status, code, message);
+    this.name = "FacilitatorError";
+  }
+}
+
+export class SignatureError extends MarketplaceError {
+  constructor(message = "Signature verification failed", code = "invalid_signature") {
+    super(401, code, message);
+    this.name = "SignatureError";
+  }
+}
+
+/** Invalid, expired, already-used, or wrong-address nonce. Deliberately 400 and
+ * deliberately one class: the response must not tell a caller WHICH of those it
+ * was, or it becomes an oracle for probing live nonces. */
+export class NonceError extends MarketplaceError {
+  constructor(message = "Invalid or expired nonce", code = "invalid_nonce") {
+    super(400, code, message);
+    this.name = "NonceError";
+  }
+}

--- a/services/marketplace-service/src/lib/facilitator.test.ts
+++ b/services/marketplace-service/src/lib/facilitator.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+import { FacilitatorClient } from "./facilitator";
+import { FacilitatorError } from "./errors";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function client(fetchImpl: unknown) {
+  return new FacilitatorClient({
+    baseUrl: "https://facilitator.test/",
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+}
+
+describe("FacilitatorClient", () => {
+  it("strips a trailing slash from the base URL", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { items: [] }));
+    await client(fetchImpl).getResources({ limit: 5 });
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+      "https://facilitator.test/discovery/resources?limit=5",
+    );
+  });
+
+  it.each([
+    ["items", { items: [{ resource: "https://a.test/x" }] }],
+    ["resources", { resources: [{ resource: "https://a.test/x" }] }],
+    ["data", { data: [{ resource: "https://a.test/x" }] }],
+  ])("accepts the %s list envelope", async (_label, body) => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, body));
+    const result = await client(fetchImpl).getResources({});
+    expect(result.resources).toHaveLength(1);
+    expect(result.resources[0]?.resourceUrl).toBe("https://a.test/x");
+  });
+
+  it.each([
+    ["resource", { resource: "https://a.test/x" }],
+    ["resourceUrl", { resourceUrl: "https://a.test/x" }],
+    ["url", { url: "https://a.test/x" }],
+  ])("reads the resource URL from %s", async (_label, entry) => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { items: [entry] }));
+    const { resources } = await client(fetchImpl).getResources({});
+    expect(resources[0]?.resourceUrl).toBe("https://a.test/x");
+  });
+
+  it.each([
+    ["price", { resource: "u", price: "500" }],
+    ["amount", { resource: "u", amount: "500" }],
+    ["maxAmountRequired", { resource: "u", maxAmountRequired: "500" }],
+    ["a numeric price", { resource: "u", price: 500 }],
+  ])("normalizes the amount from %s", async (_label, entry) => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { items: [entry] }));
+    const { resources } = await client(fetchImpl).getResources({});
+    expect(resources[0]?.priceAtomic).toBe("500");
+  });
+
+  // Locks in the shape the LIVE facilitator actually serves — captured from
+  // vellar-facilitator.onrender.com/discovery/resources on 2026-09-12. x402 v2
+  // nests payment details inside accepts[], not at the top level.
+  it("normalizes a real x402 v2 entry with a nested accepts[] array", async () => {
+    const live = {
+      x402Version: 2,
+      items: [
+        {
+          resource: "https://vellar-seller-demo.onrender.com/lorem",
+          type: "http",
+          x402Version: 2,
+          accepts: [
+            {
+              scheme: "exact",
+              network: "stellar:testnet",
+              asset: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+              amount: "100000",
+              payTo: "GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC",
+              maxTimeoutSeconds: 120,
+              extra: { areFeesSponsored: true },
+            },
+          ],
+          lastUpdated: "2026-09-08T15:39:17.726Z",
+          description: "Generate placeholder lorem ipsum text.",
+        },
+      ],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, live));
+    const { resources } = await client(fetchImpl).getResources({});
+    expect(resources[0]).toMatchObject({
+      resourceUrl: "https://vellar-seller-demo.onrender.com/lorem",
+      scheme: "exact",
+      network: "stellar:testnet",
+      asset: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+      priceAtomic: "100000",
+      payTo: "GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC",
+      areFeesSponsored: true,
+    });
+  });
+
+  it("prefers a top-level amount when there is no accepts[]", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { items: [{ resource: "u", amount: "7", asset: "A" }] }));
+    const { resources } = await client(fetchImpl).getResources({});
+    expect(resources[0]).toMatchObject({ priceAtomic: "7", asset: "A" });
+  });
+
+  it("prefers nextCursor but falls back to next", async () => {
+    const withNext = vi.fn().mockResolvedValue(jsonResponse(200, { items: [], next: "n1" }));
+    expect((await client(withNext).getResources({})).nextCursor).toBe("n1");
+    const withCursor = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { items: [], nextCursor: "n2", next: "n1" }));
+    expect((await client(withCursor).getResources({})).nextCursor).toBe("n2");
+  });
+
+  it("sends the search query as ?query=", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { items: [] }));
+    await client(fetchImpl).searchResources("cheap weather", 3);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+      "https://facilitator.test/discovery/search?query=cheap+weather&limit=3",
+    );
+  });
+
+  it("reports partialResults when the upstream flags it", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { items: [], partialResults: true }));
+    expect((await client(fetchImpl).searchResources("x")).partialResults).toBe(true);
+  });
+
+  it("matches getResource on an EXACT url, never a prefix", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(200, { items: [{ resource: "https://a.test/paid" }] }),
+    );
+    const c = client(fetchImpl);
+    await expect(c.getResource("https://a.test/paid")).resolves.toMatchObject({
+      resourceUrl: "https://a.test/paid",
+    });
+    await expect(c.getResource("https://a.test/pai")).rejects.toBeInstanceOf(FacilitatorError);
+  });
+
+  it("raises a 404-status FacilitatorError for an unknown resource", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { items: [] }));
+    await expect(client(fetchImpl).getResource("https://a.test/missing")).rejects.toMatchObject({
+      status: 404,
+      code: "not_found",
+    });
+  });
+
+  it("maps an upstream 5xx to a 502 with the upstream status retained", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("boom", { status: 503 }));
+    await expect(client(fetchImpl).getResources({})).rejects.toMatchObject({
+      status: 502,
+      upstreamStatus: 503,
+    });
+  });
+
+  it("maps a transport failure to 502 with upstreamStatus 0", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ETIMEDOUT"));
+    await expect(client(fetchImpl).getResources({})).rejects.toMatchObject({
+      status: 502,
+      upstreamStatus: 0,
+    });
+  });
+
+  it("rejects a non-JSON body", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("<html>", { status: 200 }));
+    await expect(client(fetchImpl).getResources({})).rejects.toBeInstanceOf(FacilitatorError);
+  });
+
+  it("POSTs JSON to verify and settle", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { isValid: true }));
+    await client(fetchImpl).verify({ a: 1 });
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(url).toBe("https://facilitator.test/verify");
+    expect(init.method).toBe("POST");
+    expect(init.headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({ a: 1 });
+  });
+});

--- a/services/marketplace-service/src/lib/facilitator.ts
+++ b/services/marketplace-service/src/lib/facilitator.ts
@@ -1,0 +1,259 @@
+import { z } from "zod";
+import { FacilitatorError } from "./errors";
+
+// Typed HTTP client for vellar-facilitator (new-build-technical-doc.md §4.3).
+// The frontend NEVER talks to the facilitator directly — every call goes
+// through this client so timeouts, error normalization, and response shape are
+// enforced in exactly one place (§4.1).
+//
+// SHAPE TOLERANCE: the facilitator is a separate repo on its own release
+// cadence, and §2.2 documents its endpoints but not its exact field names. The
+// schemas below are therefore permissive — unknown keys pass through, and the
+// fields we depend on accept the common spellings (price/amount/maxAmountRequired,
+// resource/resourceUrl/url). A rename upstream degrades to a missing optional
+// rather than a hard 502 on every catalog request.
+
+const looseObject = z.looseObject({});
+
+const amountish = z.union([z.string(), z.number()]).optional();
+
+/** One payment option. The live facilitator serves x402 v2, which nests these
+ * inside `accepts[]` rather than at the top level (verified against
+ * vellar-facilitator.onrender.com/discovery/resources, 2026-09-12). */
+const acceptSchema = z.looseObject({
+  scheme: z.string().optional(),
+  network: z.string().optional(),
+  asset: z.string().optional(),
+  amount: amountish,
+  maxAmountRequired: amountish,
+  price: amountish,
+  payTo: z.string().optional(),
+  extra: z.looseObject({ areFeesSponsored: z.boolean().optional() }).optional(),
+});
+
+/** One catalog entry, normalized to the marketplace resource format (§4.4).
+ * Payment fields are read from the first `accepts[]` entry when present and
+ * fall back to top-level keys, so both the v2 shape and a flat one work. */
+export const resourceSchema = z
+  .looseObject({
+    resource: z.string().optional(),
+    resourceUrl: z.string().optional(),
+    url: z.string().optional(),
+    scheme: z.string().optional(),
+    asset: z.string().optional(),
+    network: z.string().optional(),
+    description: z.string().optional(),
+    title: z.string().optional(),
+    name: z.string().optional(),
+    price: amountish,
+    amount: amountish,
+    maxAmountRequired: amountish,
+    accepts: z.array(acceptSchema).optional(),
+    lastUpdated: z.union([z.string(), z.number()]).optional(),
+  })
+  .transform((raw) => {
+    const accept = raw.accepts?.[0];
+    return {
+      resourceUrl: raw.resource ?? raw.resourceUrl ?? raw.url ?? "",
+      title: raw.title ?? raw.name,
+      description: raw.description,
+      scheme: accept?.scheme ?? raw.scheme,
+      asset: accept?.asset ?? raw.asset,
+      network: accept?.network ?? raw.network,
+      priceAtomic: normalizeAmount(
+        accept?.amount ??
+          accept?.maxAmountRequired ??
+          accept?.price ??
+          raw.price ??
+          raw.amount ??
+          raw.maxAmountRequired,
+      ),
+      payTo: accept?.payTo,
+      areFeesSponsored: accept?.extra?.areFeesSponsored,
+      lastUpdated: raw.lastUpdated === undefined ? undefined : String(raw.lastUpdated),
+      raw: raw as Record<string, unknown>,
+    };
+  });
+
+export type FacilitatorResource = z.infer<typeof resourceSchema>;
+
+function normalizeAmount(value: string | number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === "number" ? String(value) : value;
+}
+
+/** The facilitator has used both `items` and `resources` for the list body and
+ * both `next`/`nextCursor` for the cursor; accept either without failing. */
+const resourceListSchema = z.looseObject({
+  items: z.array(resourceSchema).optional(),
+  resources: z.array(resourceSchema).optional(),
+  data: z.array(resourceSchema).optional(),
+  total: z.number().optional(),
+  next: z.string().nullish(),
+  nextCursor: z.string().nullish(),
+});
+
+export interface ResourceListParams {
+  scheme?: string;
+  asset?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ResourceListResponse {
+  resources: FacilitatorResource[];
+  total?: number;
+  nextCursor?: string;
+}
+
+export interface SearchResponse extends ResourceListResponse {
+  query: string;
+  /** True when the upstream signalled the result set was truncated or degraded
+   * — surfaced so the UI can say "showing partial results" (§4.4). */
+  partialResults: boolean;
+}
+
+export interface VerifyPayload {
+  [key: string]: unknown;
+}
+
+export interface SettlePayload {
+  [key: string]: unknown;
+}
+
+export type VerifyResponse = Record<string, unknown>;
+export type SettleResponse = Record<string, unknown>;
+
+export interface FacilitatorClientOptions {
+  baseUrl: string;
+  timeoutMs?: number;
+  /** Test seam: inject a fetch implementation. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/** The subset of the client the routes depend on — routes take this interface,
+ * so tests can supply a stub without constructing a real HTTP client. */
+export interface FacilitatorApi {
+  getResources(params: ResourceListParams): Promise<ResourceListResponse>;
+  searchResources(query: string, limit?: number): Promise<SearchResponse>;
+  getResource(resourceUrl: string): Promise<FacilitatorResource>;
+  verify(payload: VerifyPayload): Promise<VerifyResponse>;
+  settle(payload: SettlePayload): Promise<SettleResponse>;
+}
+
+export class FacilitatorClient implements FacilitatorApi {
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: FacilitatorClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.timeoutMs = options.timeoutMs ?? 30_000;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  private async request(path: string, init: RequestInit = {}): Promise<unknown> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        ...init,
+        // Native timeout: a hung facilitator must not hold our connection open
+        // for the whole gateway request budget.
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (err) {
+      // Transport failure or timeout — upstreamStatus 0 marks "never answered".
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new FacilitatorError(0, `Facilitator request failed: ${reason}`, 502);
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new FacilitatorError(
+        response.status,
+        `Facilitator responded ${response.status}${body ? `: ${truncate(body)}` : ""}`,
+        // 5xx upstream and 4xx upstream both read as 502 to our client: the
+        // caller's request to US was valid, the dependency failed.
+        502,
+      );
+    }
+
+    try {
+      return await response.json();
+    } catch {
+      throw new FacilitatorError(response.status, "Facilitator returned a non-JSON body", 502);
+    }
+  }
+
+  private parseList(payload: unknown): ResourceListResponse {
+    const parsed = resourceListSchema.safeParse(payload);
+    if (!parsed.success) {
+      throw new FacilitatorError(200, "Facilitator returned an unrecognized response shape", 502);
+    }
+    const { items, resources, data, total, next, nextCursor } = parsed.data;
+    return {
+      resources: items ?? resources ?? data ?? [],
+      total,
+      nextCursor: nextCursor ?? next ?? undefined,
+    };
+  }
+
+  async getResources(params: ResourceListParams): Promise<ResourceListResponse> {
+    const query = new URLSearchParams();
+    if (params.scheme) query.set("scheme", params.scheme);
+    if (params.asset) query.set("asset", params.asset);
+    if (params.limit !== undefined) query.set("limit", String(params.limit));
+    if (params.cursor) query.set("cursor", params.cursor);
+    const suffix = query.toString();
+    return this.parseList(await this.request(`/discovery/resources${suffix ? `?${suffix}` : ""}`));
+  }
+
+  async searchResources(query: string, limit?: number): Promise<SearchResponse> {
+    const params = new URLSearchParams({ query });
+    if (limit !== undefined) params.set("limit", String(limit));
+    const payload = await this.request(`/discovery/search?${params.toString()}`);
+    const list = this.parseList(payload);
+    const envelope = looseObject.safeParse(payload);
+    const partial =
+      envelope.success && "partialResults" in envelope.data
+        ? Boolean((envelope.data as Record<string, unknown>).partialResults)
+        : false;
+    return { ...list, query, partialResults: partial };
+  }
+
+  /**
+   * The facilitator exposes no by-URL detail endpoint (§2.2), so this filters
+   * the catalog for an EXACT url match. Exact, never prefix: a caller must not
+   * be able to fetch `…/paid` by asking for `…/pai`.
+   */
+  async getResource(resourceUrl: string): Promise<FacilitatorResource> {
+    const { resources } = await this.getResources({ limit: 100 });
+    const match = resources.find((r) => r.resourceUrl === resourceUrl);
+    if (!match) {
+      throw new FacilitatorError(404, `No catalog entry for ${resourceUrl}`, 404, "not_found");
+    }
+    return match;
+  }
+
+  async verify(payload: VerifyPayload): Promise<VerifyResponse> {
+    const body = await this.request("/verify", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    return (body ?? {}) as VerifyResponse;
+  }
+
+  async settle(payload: SettlePayload): Promise<SettleResponse> {
+    const body = await this.request("/settle", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    return (body ?? {}) as SettleResponse;
+  }
+}
+
+function truncate(text: string, max = 200): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}

--- a/services/marketplace-service/src/lib/signature.ts
+++ b/services/marketplace-service/src/lib/signature.ts
@@ -1,0 +1,151 @@
+import {
+  FeeBumpTransaction,
+  Keypair,
+  StrKey,
+  Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { SignatureError, ValidationError } from "./errors";
+
+// Proof-of-address-control for seller registration and listing updates
+// (new-build-technical-doc.md §5.2). The client signs a transaction that is
+// NEVER submitted — it exists only so we can check a signature against a
+// claimed G-address.
+//
+// Why a transaction and not a bare message: SEP-43 `signMessage` is not
+// implemented consistently across the wallets we support (Albedo's is
+// explicitly non-SEP-43, LOBSTR's signAuthEntry takes no argument), but every
+// one of them signs transactions. A ManageData op carrying the nonce is the
+// portable option.
+
+/** The ManageData key the registration transaction must carry (§5.2). */
+export const REGISTRATION_DATA_KEY = "vellar-register";
+
+export interface VerifiedSignature {
+  /** The G-address whose signature was verified. */
+  address: string;
+  /** The ManageData value, decoded as UTF-8 (the nonce for registration). */
+  dataValue?: string;
+}
+
+/** True for a well-formed ed25519 public key (G...). Rejects contract (C) and
+ * muxed (M) addresses: only a classic keypair can sign these transactions. */
+export function isValidStellarAddress(address: string): boolean {
+  return StrKey.isValidEd25519PublicKey(address);
+}
+
+function parseTransaction(signedXdr: string, networkPassphrase: string): Transaction {
+  let parsed: Transaction | FeeBumpTransaction;
+  try {
+    parsed = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+  } catch {
+    throw new ValidationError("signedXdr is not a valid transaction envelope", "invalid_xdr");
+  }
+  // A fee-bump envelope has no operations of its own and its inner signatures
+  // cover a different hash — refuse rather than silently inspect the wrong tx.
+  if (parsed instanceof FeeBumpTransaction) {
+    throw new ValidationError("Fee-bump transactions are not accepted here", "invalid_xdr");
+  }
+  return parsed;
+}
+
+/**
+ * Confirms the transaction carries a valid signature from `address`.
+ *
+ * The transaction hash is computed with the SERVER's configured passphrase
+ * (security-audit V5): a signature is only valid for the network it was made
+ * on, so a mainnet-signed proof cannot be replayed at a testnet service.
+ *
+ * Checks every signature rather than only the first — a wallet may add its
+ * signature after others, and hint collisions are possible (a hint is only 4
+ * bytes), so the hint is used as a filter, never as the proof.
+ */
+function assertSignedBy(tx: Transaction, address: string): void {
+  if (!isValidStellarAddress(address)) {
+    throw new ValidationError("walletAddress must be a valid Stellar G-address", "invalid_address");
+  }
+  const keypair = Keypair.fromPublicKey(address);
+  const hash = tx.hash();
+  const signed = tx.signatures.some((sig) => {
+    try {
+      return keypair.verify(hash, sig.signature());
+    } catch {
+      return false;
+    }
+  });
+  if (!signed) {
+    throw new SignatureError(`No valid signature from ${address} on the supplied transaction`);
+  }
+}
+
+/**
+ * Lighter check used by payment and listing-update flows: prove the caller
+ * controls `address`, without consuming a registration nonce.
+ *
+ * NOTE (deliberate limitation, documented rather than hidden): with no nonce,
+ * this proves control of the key but NOT freshness — a previously seen signed
+ * envelope replays successfully until its own timebounds expire. It is
+ * therefore used only for operations that are idempotent or separately
+ * authorized, never to establish ownership of a listing for the first time.
+ * Registration — the one flow that grants ownership — uses the full
+ * nonce-consuming path below.
+ */
+export function verifySignedBy(
+  signedXdr: string,
+  address: string,
+  networkPassphrase: string,
+): VerifiedSignature {
+  const tx = parseTransaction(signedXdr, networkPassphrase);
+  assertSignedBy(tx, address);
+  return { address, dataValue: readRegistrationValue(tx) };
+}
+
+/** Extracts the ManageData value when the tx is a registration-shaped one. */
+function readRegistrationValue(tx: Transaction): string | undefined {
+  const op = tx.operations[0];
+  if (tx.operations.length === 1 && op?.type === "manageData" && op.name === REGISTRATION_DATA_KEY) {
+    return op.value ? Buffer.from(op.value).toString("utf8") : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Full registration check (§5.2 steps a–e). Structural validation plus
+ * signature; the caller then consumes the returned nonce (step f) against the
+ * nonce store, which is what makes the proof single-use.
+ */
+export function verifyRegistrationSignature(
+  signedXdr: string,
+  address: string,
+  networkPassphrase: string,
+): { address: string; nonce: string } {
+  const tx = parseTransaction(signedXdr, networkPassphrase);
+
+  // (b) exactly one operation — extra operations could carry side effects if
+  // this envelope were ever submitted, and they muddy what the signature covers.
+  if (tx.operations.length !== 1) {
+    throw new ValidationError(
+      "Registration transaction must contain exactly one operation",
+      "invalid_registration_tx",
+    );
+  }
+
+  // (c) it must be ManageData("vellar-register", <nonce>).
+  const op = tx.operations[0];
+  if (!op || op.type !== "manageData" || op.name !== REGISTRATION_DATA_KEY) {
+    throw new ValidationError(
+      `Registration operation must be ManageData("${REGISTRATION_DATA_KEY}", nonce)`,
+      "invalid_registration_tx",
+    );
+  }
+  if (!op.value || op.value.length === 0) {
+    throw new ValidationError("Registration nonce value is missing", "invalid_registration_tx");
+  }
+  const nonce = Buffer.from(op.value).toString("utf8");
+
+  // (e) signature from the claimed address. Checked AFTER the structural
+  // checks so a malformed tx never reaches the crypto path.
+  assertSignedBy(tx, address);
+
+  return { address, nonce };
+}

--- a/services/marketplace-service/src/nonce-sweeper.test.ts
+++ b/services/marketplace-service/src/nonce-sweeper.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { startNonceSweeper } from "./nonce-sweeper";
+import { createMemoryNonceRepository } from "./repository";
+
+describe("startNonceSweeper", () => {
+  it("sweeps expired nonces on start and leaves live ones alone", async () => {
+    const nonces = createMemoryNonceRepository();
+    const now = new Date("2026-03-01T12:00:00.000Z");
+    await nonces.insert({
+      nonce: "expired",
+      address: "GA",
+      createdAt: "2026-03-01T11:00:00.000Z",
+      usedAt: null,
+      expiresAt: "2026-03-01T11:05:00.000Z",
+    });
+    await nonces.insert({
+      nonce: "live",
+      address: "GA",
+      createdAt: now.toISOString(),
+      usedAt: null,
+      expiresAt: "2026-03-01T12:05:00.000Z",
+    });
+
+    const stop = startNonceSweeper({ nonces, intervalMs: 60_000, now: () => now });
+    await vi.waitFor(async () => {
+      expect(await nonces.consume("live", "GA", now)).toBe(true);
+    });
+    // The expired row is gone; the live one was consumable above.
+    expect(await nonces.consume("expired", "GA", now)).toBe(false);
+    stop();
+  });
+
+  it("survives a failing sweep and keeps the service alive", async () => {
+    const failing = {
+      ...createMemoryNonceRepository(),
+      deleteExpired: vi.fn().mockRejectedValue(new Error("postgres down")),
+    };
+    const warn = vi.fn();
+    const stop = startNonceSweeper({
+      nonces: failing,
+      intervalMs: 60_000,
+      log: { info: vi.fn(), warn },
+    });
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(warn.mock.calls[0]?.[1]).toContain("nonce sweep failed");
+    stop();
+  });
+
+  it("stops sweeping once stopped", async () => {
+    const nonces = createMemoryNonceRepository();
+    const deleteExpired = vi.spyOn(nonces, "deleteExpired");
+    const stop = startNonceSweeper({ nonces, intervalMs: 5 });
+    await vi.waitFor(() => expect(deleteExpired).toHaveBeenCalled());
+    stop();
+    const callsAtStop = deleteExpired.mock.calls.length;
+    await new Promise((r) => setTimeout(r, 30));
+    expect(deleteExpired.mock.calls.length).toBe(callsAtStop);
+  });
+});

--- a/services/marketplace-service/src/nonce-sweeper.ts
+++ b/services/marketplace-service/src/nonce-sweeper.ts
@@ -1,0 +1,46 @@
+import type { NonceRepository } from "./repository";
+
+// Background cleanup for expired registration nonces (§5.2). Rows are already
+// unusable once expired — `consume` checks expiry — so this is housekeeping to
+// stop the table growing without bound, never a correctness guarantee.
+
+export interface NonceSweeperOptions {
+  nonces: NonceRepository;
+  intervalMs: number;
+  log?: { info(obj: object, msg: string): void; warn(obj: object, msg: string): void };
+  now?: () => Date;
+}
+
+/**
+ * Sweeps on start and then every `intervalMs`. Returns a stop function.
+ *
+ * Failures are logged and swallowed: a sweep that throws (Postgres briefly
+ * down) must not take the service with it, and the next tick retries. The
+ * timer is unref'd so it never holds the process open on shutdown.
+ */
+export function startNonceSweeper(options: NonceSweeperOptions): () => void {
+  const now = options.now ?? (() => new Date());
+  let stopped = false;
+
+  const sweep = async () => {
+    if (stopped) return;
+    try {
+      const deleted = await options.nonces.deleteExpired(now());
+      if (deleted > 0) options.log?.info({ deleted }, "swept expired marketplace nonces");
+    } catch (err) {
+      options.log?.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "marketplace nonce sweep failed; will retry on the next interval",
+      );
+    }
+  };
+
+  void sweep();
+  const timer = setInterval(() => void sweep(), options.intervalMs);
+  timer.unref?.();
+
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
+}

--- a/services/marketplace-service/src/repository.ts
+++ b/services/marketplace-service/src/repository.ts
@@ -1,0 +1,142 @@
+// Persistence seams for marketplace-service (new-build-technical-doc.md §5.1).
+// In-memory implementations back tests and DB-less local dev; the Postgres
+// implementations in db/pg-repository.ts satisfy the same interfaces.
+
+export type ListingStatus = "pending" | "active" | "paused" | "removed";
+export type ListingScheme = "exact" | "upto";
+
+export interface ListingRecord {
+  id: string;
+  sellerAddress: string;
+  resourceUrl: string;
+  title: string;
+  description: string | null;
+  /** Base units. Stringly-typed at the boundary so a 7-decimal asset's amount
+   * never round-trips through a lossy JS number. */
+  priceAtomic: string;
+  asset: string;
+  scheme: ListingScheme;
+  status: ListingStatus;
+  createdAt: string;
+  updatedAt: string;
+  firstSettledAt: string | null;
+  totalSettlements: string;
+  totalRevenue: string;
+}
+
+export interface ListingUpdate {
+  title?: string;
+  description?: string;
+  priceAtomic?: string;
+  scheme?: ListingScheme;
+  status?: ListingStatus;
+}
+
+export class DuplicateListingError extends Error {
+  constructor(resourceUrl: string) {
+    super(`A listing already exists for ${resourceUrl}`);
+    this.name = "DuplicateListingError";
+  }
+}
+
+export interface ListingRepository {
+  /** Rejects with DuplicateListingError when resourceUrl is already listed —
+   * §14 Q4: first registrant with a valid signature wins. */
+  insert(record: ListingRecord): Promise<void>;
+  findById(id: string): Promise<ListingRecord | undefined>;
+  findByResourceUrl(resourceUrl: string): Promise<ListingRecord | undefined>;
+  listBySeller(sellerAddress: string): Promise<ListingRecord[]>;
+  update(id: string, patch: ListingUpdate, updatedAt: Date): Promise<ListingRecord | undefined>;
+}
+
+export interface NonceRecord {
+  nonce: string;
+  address: string;
+  createdAt: string;
+  usedAt: string | null;
+  expiresAt: string;
+}
+
+export interface NonceRepository {
+  insert(record: NonceRecord): Promise<void>;
+  /**
+   * Atomically consume a nonce: succeeds ONLY if the nonce exists, belongs to
+   * `address`, is unused, and has not expired as of `asOf` — and marks it used
+   * in the same operation. Returns false otherwise.
+   *
+   * Single statement by design: a read-then-write would let two concurrent
+   * registrations both observe an unused nonce and both succeed.
+   */
+  consume(nonce: string, address: string, asOf: Date): Promise<boolean>;
+  /** Deletes expired rows; returns how many. Called by the background sweep. */
+  deleteExpired(asOf: Date): Promise<number>;
+}
+
+export function createMemoryListingRepository(): ListingRepository {
+  const byId = new Map<string, ListingRecord>();
+  return {
+    async insert(record) {
+      for (const existing of byId.values()) {
+        if (existing.resourceUrl === record.resourceUrl) {
+          throw new DuplicateListingError(record.resourceUrl);
+        }
+      }
+      byId.set(record.id, { ...record });
+    },
+    async findById(id) {
+      const found = byId.get(id);
+      return found ? { ...found } : undefined;
+    },
+    async findByResourceUrl(resourceUrl) {
+      for (const existing of byId.values()) {
+        if (existing.resourceUrl === resourceUrl) return { ...existing };
+      }
+      return undefined;
+    },
+    async listBySeller(sellerAddress) {
+      return [...byId.values()]
+        .filter((l) => l.sellerAddress === sellerAddress)
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+        .map((l) => ({ ...l }));
+    },
+    async update(id, patch, updatedAt) {
+      const existing = byId.get(id);
+      if (!existing) return undefined;
+      const next: ListingRecord = {
+        ...existing,
+        ...Object.fromEntries(Object.entries(patch).filter(([, v]) => v !== undefined)),
+        updatedAt: updatedAt.toISOString(),
+      };
+      byId.set(id, next);
+      return { ...next };
+    },
+  };
+}
+
+export function createMemoryNonceRepository(): NonceRepository {
+  const byNonce = new Map<string, NonceRecord>();
+  return {
+    async insert(record) {
+      byNonce.set(record.nonce, { ...record });
+    },
+    async consume(nonce, address, asOf) {
+      const found = byNonce.get(nonce);
+      if (!found) return false;
+      if (found.address !== address) return false;
+      if (found.usedAt !== null) return false;
+      if (new Date(found.expiresAt).getTime() <= asOf.getTime()) return false;
+      byNonce.set(nonce, { ...found, usedAt: asOf.toISOString() });
+      return true;
+    },
+    async deleteExpired(asOf) {
+      let deleted = 0;
+      for (const [key, record] of byNonce) {
+        if (new Date(record.expiresAt).getTime() < asOf.getTime()) {
+          byNonce.delete(key);
+          deleted += 1;
+        }
+      }
+      return deleted;
+    },
+  };
+}

--- a/services/marketplace-service/src/routes/catalog.test.ts
+++ b/services/marketplace-service/src/routes/catalog.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildServer } from "../server";
+import { FacilitatorError } from "../lib/errors";
+import { decodeResourceId, encodeResourceId } from "./catalog";
+import { resource, stubFacilitator, TEST_PASSPHRASE } from "../test-support";
+import { createMemoryListingRepository } from "../repository";
+
+let app: FastifyInstance | undefined;
+
+function build(facilitator = stubFacilitator(), listings = createMemoryListingRepository()) {
+  app = buildServer({ facilitator, listings, networkPassphrase: TEST_PASSPHRASE });
+  return app;
+}
+
+afterEach(async () => {
+  await app?.close();
+  app = undefined;
+});
+
+describe("resource id encoding", () => {
+  it("round-trips a URL through base64url", () => {
+    const url = "https://api.example.com/a?b=c&d=e";
+    expect(decodeResourceId(encodeResourceId(url))).toBe(url);
+  });
+
+  it.each([
+    ["non-base64url characters", "not a valid id!"],
+    ["padding", "aGVsbG8="],
+    ["empty", ""],
+  ])("rejects %s", (_label, id) => {
+    expect(() => decodeResourceId(id)).toThrow();
+  });
+});
+
+describe("GET /marketplace/catalog", () => {
+  it("returns resources from the facilitator", async () => {
+    const res = await build().inject({ method: "GET", url: "/marketplace/catalog" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.resources).toHaveLength(1);
+    expect(body.resources[0].resourceUrl).toBe("https://api.example.com/weather");
+    expect(body.resources[0].id).toBe(encodeResourceId("https://api.example.com/weather"));
+  });
+
+  it("passes filters and the limit through to the facilitator", async () => {
+    const getResources = vi.fn().mockResolvedValue({ resources: [], nextCursor: "c2" });
+    const res = await build(stubFacilitator({ getResources })).inject({
+      method: "GET",
+      url: "/marketplace/catalog?scheme=upto&asset=USDC&limit=5&cursor=c1",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(getResources).toHaveBeenCalledWith({
+      scheme: "upto",
+      asset: "USDC",
+      limit: 5,
+      cursor: "c1",
+    });
+    expect(res.json().pagination).toEqual({ limit: 5, cursor: "c1", nextCursor: "c2" });
+  });
+
+  it("defaults the limit to 20 and rejects one above the 100 cap", async () => {
+    const getResources = vi.fn().mockResolvedValue({ resources: [] });
+    const built = build(stubFacilitator({ getResources }));
+    await built.inject({ method: "GET", url: "/marketplace/catalog" });
+    expect(getResources.mock.calls[0]?.[0]).toMatchObject({ limit: 20 });
+
+    const over = await built.inject({ method: "GET", url: "/marketplace/catalog?limit=101" });
+    expect(over.statusCode).toBe(400);
+  });
+
+  it("enriches an entry with the local listing when one is registered", async () => {
+    const listings = createMemoryListingRepository();
+    await listings.insert({
+      id: "listing-1",
+      sellerAddress: "GSELLER",
+      resourceUrl: "https://api.example.com/weather",
+      title: "Seller title",
+      description: "Seller description",
+      priceAtomic: "2500",
+      asset: "USDC",
+      scheme: "exact",
+      status: "active",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      firstSettledAt: "2026-01-02T00:00:00.000Z",
+      totalSettlements: "7",
+      totalRevenue: "17500",
+    });
+    const res = await build(stubFacilitator(), listings).inject({
+      method: "GET",
+      url: "/marketplace/catalog",
+    });
+    const entry = res.json().resources[0];
+    // The seller-registered metadata wins over the facilitator's.
+    expect(entry.title).toBe("Seller title");
+    expect(entry.priceAtomic).toBe("2500");
+    expect(entry.listing.sellerAddress).toBe("GSELLER");
+    expect(entry.trust).toEqual({
+      settlementCount: "7",
+      firstSeen: "2026-01-02T00:00:00.000Z",
+      isRegistered: true,
+    });
+  });
+
+  it("marks an unregistered entry as untrusted-by-registration", async () => {
+    const res = await build().inject({ method: "GET", url: "/marketplace/catalog" });
+    expect(res.json().resources[0].trust).toEqual({
+      settlementCount: "0",
+      firstSeen: null,
+      isRegistered: false,
+    });
+  });
+
+  it("surfaces a facilitator outage as 502", async () => {
+    const getResources = vi.fn().mockRejectedValue(new FacilitatorError(0, "upstream down", 502));
+    const res = await build(stubFacilitator({ getResources })).inject({
+      method: "GET",
+      url: "/marketplace/catalog",
+    });
+    expect(res.statusCode).toBe(502);
+    expect(res.json().error).toBe("facilitator_error");
+  });
+});
+
+describe("GET /marketplace/catalog/search", () => {
+  it("returns search results for a query", async () => {
+    const searchResources = vi
+      .fn()
+      .mockResolvedValue({ resources: [resource()], query: "weather", partialResults: true });
+    const res = await build(stubFacilitator({ searchResources })).inject({
+      method: "GET",
+      url: "/marketplace/catalog/search?q=weather&limit=3",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(searchResources).toHaveBeenCalledWith("weather", 3);
+    expect(res.json()).toMatchObject({ query: "weather", partialResults: true });
+    expect(res.json().resources).toHaveLength(1);
+  });
+
+  it("requires q", async () => {
+    const res = await build().inject({ method: "GET", url: "/marketplace/catalog/search" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_query");
+  });
+});
+
+describe("GET /marketplace/catalog/:id", () => {
+  it("decodes the base64url id and returns the detail", async () => {
+    const url = "https://api.example.com/weather";
+    const getResource = vi.fn().mockResolvedValue(resource());
+    const res = await build(stubFacilitator({ getResource })).inject({
+      method: "GET",
+      url: `/marketplace/catalog/${encodeResourceId(url)}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(getResource).toHaveBeenCalledWith(url);
+    expect(res.json().resource.resourceUrl).toBe(url);
+  });
+
+  it("returns 400 for an id that is not base64url", async () => {
+    const res = await build().inject({ method: "GET", url: "/marketplace/catalog/!!!not-valid!!!" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_resource_id");
+  });
+
+  it("returns 404 when the facilitator has no such resource", async () => {
+    const getResource = vi
+      .fn()
+      .mockRejectedValue(new FacilitatorError(404, "No catalog entry", 404, "not_found"));
+    const res = await build(stubFacilitator({ getResource })).inject({
+      method: "GET",
+      url: `/marketplace/catalog/${encodeResourceId("https://api.example.com/missing")}`,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe("not_found");
+  });
+});

--- a/services/marketplace-service/src/routes/catalog.ts
+++ b/services/marketplace-service/src/routes/catalog.ts
@@ -1,0 +1,164 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import type { FacilitatorApi, FacilitatorResource } from "../lib/facilitator";
+import { ValidationError } from "../lib/errors";
+import type { ListingRepository } from "../repository";
+
+// Catalog routes (new-build-technical-doc.md §4.4). These proxy the
+// facilitator's discovery endpoints and enrich each entry with the marketplace
+// listing metadata we hold locally.
+
+const listQuerySchema = z.object({
+  scheme: z.string().min(1).optional(),
+  asset: z.string().min(1).optional(),
+  // Capped at 100 per §4.4 so one request can't ask the facilitator for the
+  // entire catalog.
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  cursor: z.string().min(1).optional(),
+});
+
+const searchQuerySchema = z.object({
+  q: z.string().min(1, "q is required"),
+  limit: z.coerce.number().int().positive().max(100).default(10),
+});
+
+export interface MarketplaceResource {
+  id: string;
+  resourceUrl: string;
+  title?: string;
+  description?: string;
+  priceAtomic?: string;
+  asset?: string;
+  scheme?: string;
+  network?: string;
+  payTo?: string;
+  areFeesSponsored?: boolean;
+  listing?: {
+    id: string;
+    sellerAddress: string;
+    status: string;
+    totalSettlements: string;
+    totalRevenue: string;
+    firstSettledAt: string | null;
+  };
+  trust?: {
+    settlementCount: string;
+    firstSeen: string | null;
+    isRegistered: boolean;
+  };
+}
+
+/** base64url of the resource URL — the `:id` in §4.4's detail route. */
+export function encodeResourceId(resourceUrl: string): string {
+  return Buffer.from(resourceUrl, "utf8").toString("base64url");
+}
+
+export function decodeResourceId(id: string): string {
+  // base64url uses [A-Za-z0-9_-]; anything else is malformed, and Buffer would
+  // silently ignore it rather than fail, so reject explicitly (§4.4 → 400).
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+    throw new ValidationError("id must be base64url of the resource URL", "invalid_resource_id");
+  }
+  const decoded = Buffer.from(id, "base64url").toString("utf8");
+  if (!decoded) {
+    throw new ValidationError("id must be base64url of the resource URL", "invalid_resource_id");
+  }
+  // Round-trip check: base64url is not injective over arbitrary input (padding
+  // and stray characters both decode), so confirm the id is the canonical
+  // encoding of what it decoded to.
+  if (encodeResourceId(decoded) !== id) {
+    throw new ValidationError("id must be base64url of the resource URL", "invalid_resource_id");
+  }
+  return decoded;
+}
+
+/** Merge a facilitator catalog entry with our listing row, when we have one. */
+export function toMarketplaceResource(
+  resource: FacilitatorResource,
+  listing?: Awaited<ReturnType<ListingRepository["findByResourceUrl"]>>,
+): MarketplaceResource {
+  return {
+    id: encodeResourceId(resource.resourceUrl),
+    resourceUrl: resource.resourceUrl,
+    // A seller-registered title/description outranks the facilitator's, which
+    // is derived from whatever the resource advertised at settlement time.
+    title: listing?.title ?? resource.title,
+    description: listing?.description ?? resource.description,
+    priceAtomic: listing?.priceAtomic ?? resource.priceAtomic,
+    asset: listing?.asset ?? resource.asset,
+    scheme: listing?.scheme ?? resource.scheme,
+    network: resource.network,
+    payTo: resource.payTo,
+    areFeesSponsored: resource.areFeesSponsored,
+    listing: listing
+      ? {
+          id: listing.id,
+          sellerAddress: listing.sellerAddress,
+          status: listing.status,
+          totalSettlements: listing.totalSettlements,
+          totalRevenue: listing.totalRevenue,
+          firstSettledAt: listing.firstSettledAt,
+        }
+      : undefined,
+    trust: {
+      settlementCount: listing?.totalSettlements ?? "0",
+      firstSeen: listing?.firstSettledAt ?? null,
+      // §14 Q2: trust is settlement history + registration, not identity.
+      isRegistered: Boolean(listing),
+    },
+  };
+}
+
+export interface CatalogRouteDeps {
+  facilitator: FacilitatorApi;
+  listings: ListingRepository;
+}
+
+export function registerCatalogRoutes(app: FastifyInstance, deps: CatalogRouteDeps): void {
+  /** Look up local listings for a page of catalog entries. */
+  const enrich = async (resources: FacilitatorResource[]): Promise<MarketplaceResource[]> =>
+    Promise.all(
+      resources.map(async (resource) =>
+        toMarketplaceResource(
+          resource,
+          resource.resourceUrl
+            ? await deps.listings.findByResourceUrl(resource.resourceUrl)
+            : undefined,
+        ),
+      ),
+    );
+
+  app.get("/marketplace/catalog", async (request, reply) => {
+    const parsed = listQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_query", details: parsed.error.issues });
+    }
+    const { scheme, asset, limit, cursor } = parsed.data;
+    const result = await deps.facilitator.getResources({ scheme, asset, limit, cursor });
+    return reply.send({
+      resources: await enrich(result.resources),
+      pagination: { limit, cursor: cursor ?? null, nextCursor: result.nextCursor ?? null },
+    });
+  });
+
+  app.get("/marketplace/catalog/search", async (request, reply) => {
+    const parsed = searchQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_query", details: parsed.error.issues });
+    }
+    const { q, limit } = parsed.data;
+    const result = await deps.facilitator.searchResources(q, limit);
+    return reply.send({
+      resources: await enrich(result.resources),
+      query: q,
+      partialResults: result.partialResults,
+    });
+  });
+
+  app.get<{ Params: { id: string } }>("/marketplace/catalog/:id", async (request, reply) => {
+    const resourceUrl = decodeResourceId(request.params.id);
+    const resource = await deps.facilitator.getResource(resourceUrl);
+    const listing = await deps.listings.findByResourceUrl(resourceUrl);
+    return reply.send({ resource: toMarketplaceResource(resource, listing) });
+  });
+}

--- a/services/marketplace-service/src/routes/listings.test.ts
+++ b/services/marketplace-service/src/routes/listings.test.ts
@@ -1,0 +1,432 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { Keypair } from "@stellar/stellar-sdk";
+import { buildServer } from "../server";
+import {
+  createMemoryListingRepository,
+  createMemoryNonceRepository,
+  type ListingRepository,
+  type NonceRepository,
+} from "../repository";
+import { signedProofXdr, signedRegistrationXdr, stubFacilitator, TEST_PASSPHRASE } from "../test-support";
+
+let app: FastifyInstance | undefined;
+
+interface Harness {
+  app: FastifyInstance;
+  listings: ListingRepository;
+  nonces: NonceRepository;
+  now: () => Date;
+  setNow: (d: Date) => void;
+}
+
+function build(overrides: { nonceTtlMs?: number } = {}): Harness {
+  const listings = createMemoryListingRepository();
+  const nonces = createMemoryNonceRepository();
+  let current = new Date("2026-03-01T12:00:00.000Z");
+  const now = () => current;
+  let counter = 0;
+  app = buildServer({
+    facilitator: stubFacilitator(),
+    listings,
+    nonces,
+    networkPassphrase: TEST_PASSPHRASE,
+    nonceTtlMs: overrides.nonceTtlMs ?? 5 * 60_000,
+    now,
+    newId: () => `listing-${++counter}`,
+  });
+  return { app, listings, nonces, now, setNow: (d) => (current = d) };
+}
+
+afterEach(async () => {
+  await app?.close();
+  app = undefined;
+});
+
+/** Issue a nonce and return it, as a client would. */
+async function getNonce(h: Harness, address: string): Promise<string> {
+  const res = await h.app.inject({
+    method: "GET",
+    url: `/marketplace/listings/nonce?address=${address}`,
+  });
+  expect(res.statusCode).toBe(200);
+  return res.json().nonce;
+}
+
+function listingBody(seller: Keypair, signedXdr: string, overrides: Record<string, unknown> = {}) {
+  return {
+    resourceUrl: "https://api.example.com/weather",
+    title: "Weather API",
+    description: "Forecast data",
+    priceAtomic: "1000",
+    asset: "USDC",
+    scheme: "exact",
+    signedXdr,
+    walletAddress: seller.publicKey(),
+    ...overrides,
+  };
+}
+
+describe("GET /marketplace/listings/nonce", () => {
+  it("returns a nonce with an expiry and stores it", async () => {
+    const h = build();
+    const address = Keypair.random().publicKey();
+    const res = await h.app.inject({
+      method: "GET",
+      url: `/marketplace/listings/nonce?address=${address}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const { nonce, expiresAt } = res.json();
+    // 32 bytes hex.
+    expect(nonce).toMatch(/^[0-9a-f]{64}$/);
+    expect(expiresAt).toBe("2026-03-01T12:05:00.000Z");
+    // Stored and consumable exactly once.
+    expect(await h.nonces.consume(nonce, address, h.now())).toBe(true);
+  });
+
+  it("issues a distinct nonce per call", async () => {
+    const h = build();
+    const address = Keypair.random().publicKey();
+    expect(await getNonce(h, address)).not.toBe(await getNonce(h, address));
+  });
+
+  it("rejects a non-Stellar address", async () => {
+    const res = await build().app.inject({
+      method: "GET",
+      url: "/marketplace/listings/nonce?address=not-an-address",
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("is not shadowed by the /:id route", async () => {
+    const h = build();
+    const res = await h.app.inject({
+      method: "GET",
+      url: `/marketplace/listings/nonce?address=${Keypair.random().publicKey()}`,
+    });
+    expect(res.json().nonce).toBeDefined();
+  });
+});
+
+describe("POST /marketplace/listings", () => {
+  it("creates a pending listing from a valid signed nonce", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const nonce = await getNonce(h, seller.publicKey());
+    const res = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(seller, signedRegistrationXdr(seller, nonce)),
+    });
+    expect(res.statusCode).toBe(201);
+    const { listing } = res.json();
+    expect(listing).toMatchObject({
+      sellerAddress: seller.publicKey(),
+      title: "Weather API",
+      priceAtomic: "1000",
+      // Activation is earned by a settlement, never granted at registration.
+      status: "pending",
+      totalSettlements: "0",
+      firstSettledAt: null,
+    });
+  });
+
+  it("rejects an expired nonce", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const nonce = await getNonce(h, seller.publicKey());
+    // Past the 5-minute TTL.
+    h.setNow(new Date("2026-03-01T12:05:01.000Z"));
+    const res = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(seller, signedRegistrationXdr(seller, nonce)),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_nonce");
+  });
+
+  it("rejects a nonce that was already used", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const nonce = await getNonce(h, seller.publicKey());
+    const signedXdr = signedRegistrationXdr(seller, nonce);
+    const first = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(seller, signedXdr),
+    });
+    expect(first.statusCode).toBe(201);
+    // Replaying the exact same envelope must fail.
+    const replay = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(seller, signedXdr, {
+        resourceUrl: "https://api.example.com/other",
+      }),
+    });
+    expect(replay.statusCode).toBe(400);
+    expect(replay.json().error).toBe("invalid_nonce");
+  });
+
+  it("rejects a nonce issued to a different address", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const attacker = Keypair.random();
+    // Nonce belongs to the seller; the attacker signs it with their own key.
+    const nonce = await getNonce(h, seller.publicKey());
+    const res = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(attacker, signedRegistrationXdr(attacker, nonce)),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_nonce");
+  });
+
+  it("rejects an unknown nonce", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const res = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(seller, signedRegistrationXdr(seller, "f".repeat(64))),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a transaction signed by someone else", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const impostor = Keypair.random();
+    const nonce = await getNonce(h, seller.publicKey());
+    const res = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      // Impostor signs, but claims to be the seller.
+      payload: listingBody(seller, signedRegistrationXdr(impostor, nonce)),
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe("invalid_signature");
+  });
+
+  it("rejects the wrong ManageData key", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const nonce = await getNonce(h, seller.publicKey());
+    const res = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(seller, signedRegistrationXdr(seller, nonce, { dataKey: "other-key" })),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_registration_tx");
+  });
+
+  it("rejects a transaction carrying extra operations", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const nonce = await getNonce(h, seller.publicKey());
+    const res = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(seller, signedRegistrationXdr(seller, nonce, { extraOp: true })),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 409 when the resource URL is already listed (first registrant wins)", async () => {
+    const h = build();
+    const first = Keypair.random();
+    const second = Keypair.random();
+    await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(first, signedRegistrationXdr(first, await getNonce(h, first.publicKey()))),
+    });
+    const res = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(
+        second,
+        signedRegistrationXdr(second, await getNonce(h, second.publicKey())),
+      ),
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe("listing_exists");
+  });
+});
+
+describe("GET /marketplace/listings/:id", () => {
+  it("returns the listing", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const created = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(
+        seller,
+        signedRegistrationXdr(seller, await getNonce(h, seller.publicKey())),
+      ),
+    });
+    const id = created.json().listing.id;
+    const res = await h.app.inject({ method: "GET", url: `/marketplace/listings/${id}` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().listing.id).toBe(id);
+  });
+
+  it("returns 404 for an unknown id", async () => {
+    const res = await build().app.inject({ method: "GET", url: "/marketplace/listings/nope" });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe("listing_not_found");
+  });
+});
+
+describe("PATCH /marketplace/listings/:id", () => {
+  async function seed(h: Harness, seller: Keypair) {
+    const created = await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(
+        seller,
+        signedRegistrationXdr(seller, await getNonce(h, seller.publicKey())),
+      ),
+    });
+    return created.json().listing.id as string;
+  }
+
+  it("updates fields for the owning seller", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const id = await seed(h, seller);
+    h.setNow(new Date("2026-03-02T00:00:00.000Z"));
+    const res = await h.app.inject({
+      method: "PATCH",
+      url: `/marketplace/listings/${id}`,
+      payload: {
+        title: "Better Weather API",
+        priceAtomic: "2000",
+        status: "paused",
+        signedXdr: signedProofXdr(seller),
+        walletAddress: seller.publicKey(),
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().listing).toMatchObject({
+      title: "Better Weather API",
+      priceAtomic: "2000",
+      status: "paused",
+      updatedAt: "2026-03-02T00:00:00.000Z",
+    });
+  });
+
+  it("returns 401 when a different address signs", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const attacker = Keypair.random();
+    const id = await seed(h, seller);
+    const res = await h.app.inject({
+      method: "PATCH",
+      url: `/marketplace/listings/${id}`,
+      payload: {
+        title: "Hijacked",
+        signedXdr: signedProofXdr(attacker),
+        walletAddress: attacker.publicKey(),
+      },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe("not_listing_owner");
+    // And the listing is untouched.
+    const after = await h.app.inject({ method: "GET", url: `/marketplace/listings/${id}` });
+    expect(after.json().listing.title).toBe("Weather API");
+  });
+
+  it("returns 401 when the signature does not match the claimed address", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const id = await seed(h, seller);
+    const res = await h.app.inject({
+      method: "PATCH",
+      url: `/marketplace/listings/${id}`,
+      payload: {
+        title: "Hijacked",
+        // Claims to be the seller but signed by someone else.
+        signedXdr: signedProofXdr(Keypair.random()),
+        walletAddress: seller.publicKey(),
+      },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe("invalid_signature");
+  });
+
+  it("refuses to set status back to pending", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const id = await seed(h, seller);
+    const res = await h.app.inject({
+      method: "PATCH",
+      url: `/marketplace/listings/${id}`,
+      payload: {
+        status: "pending",
+        signedXdr: signedProofXdr(seller),
+        walletAddress: seller.publicKey(),
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 for an unknown listing", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const res = await h.app.inject({
+      method: "PATCH",
+      url: "/marketplace/listings/nope",
+      payload: {
+        title: "x",
+        signedXdr: signedProofXdr(seller),
+        walletAddress: seller.publicKey(),
+      },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /marketplace/listings", () => {
+  it("returns every listing for a seller and excludes others", async () => {
+    const h = build();
+    const seller = Keypair.random();
+    const other = Keypair.random();
+    for (const url of ["https://a.example.com/x", "https://b.example.com/y"]) {
+      await h.app.inject({
+        method: "POST",
+        url: "/marketplace/listings",
+        payload: listingBody(
+          seller,
+          signedRegistrationXdr(seller, await getNonce(h, seller.publicKey())),
+          { resourceUrl: url },
+        ),
+      });
+    }
+    await h.app.inject({
+      method: "POST",
+      url: "/marketplace/listings",
+      payload: listingBody(other, signedRegistrationXdr(other, await getNonce(h, other.publicKey())), {
+        resourceUrl: "https://c.example.com/z",
+      }),
+    });
+
+    const res = await h.app.inject({
+      method: "GET",
+      url: `/marketplace/listings?seller=${seller.publicKey()}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const { listings } = res.json();
+    expect(listings).toHaveLength(2);
+    expect(listings.every((l: { sellerAddress: string }) => l.sellerAddress === seller.publicKey())).toBe(true);
+  });
+
+  it("requires a valid seller address", async () => {
+    const res = await build().app.inject({ method: "GET", url: "/marketplace/listings?seller=xyz" });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/services/marketplace-service/src/routes/listings.ts
+++ b/services/marketplace-service/src/routes/listings.ts
@@ -1,0 +1,193 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { NonceError, NotFoundError, SignatureError } from "../lib/errors";
+import { isValidStellarAddress, verifyRegistrationSignature, verifySignedBy } from "../lib/signature";
+import {
+  DuplicateListingError,
+  type ListingRecord,
+  type ListingRepository,
+  type NonceRepository,
+} from "../repository";
+
+// Seller listing routes (new-build-technical-doc.md §5.2).
+
+const addressSchema = z
+  .string()
+  .refine(isValidStellarAddress, "must be a valid Stellar G-address");
+
+const nonceQuerySchema = z.object({ address: addressSchema });
+
+const createListingSchema = z.object({
+  resourceUrl: z.url(),
+  title: z.string().min(1).max(255),
+  description: z.string().max(10_000).optional(),
+  priceAtomic: z.string().regex(/^\d+$/, "priceAtomic must be base units as a decimal string"),
+  asset: z.string().min(1),
+  scheme: z.enum(["exact", "upto"]).default("exact"),
+  signedXdr: z.string().min(1),
+  walletAddress: addressSchema,
+});
+
+const patchListingSchema = z.object({
+  title: z.string().min(1).max(255).optional(),
+  description: z.string().max(10_000).optional(),
+  priceAtomic: z.string().regex(/^\d+$/).optional(),
+  scheme: z.enum(["exact", "upto"]).optional(),
+  // "pending" is omitted deliberately: pending→active is earned by a real
+  // settlement (§5.2), never self-declared by the seller.
+  status: z.enum(["active", "paused", "removed"]).optional(),
+  signedXdr: z.string().min(1),
+  walletAddress: addressSchema,
+});
+
+const listQuerySchema = z.object({ seller: addressSchema });
+
+export interface ListingRouteDeps {
+  listings: ListingRepository;
+  nonces: NonceRepository;
+  networkPassphrase: string;
+  nonceTtlMs: number;
+  now?: () => Date;
+  newId?: () => string;
+  newNonce?: () => string;
+}
+
+/** The public listing shape. Identical to the stored record today, but kept as
+ * an explicit projection so an added internal column is never leaked by
+ * accident. */
+function toPublicListing(listing: ListingRecord) {
+  return {
+    id: listing.id,
+    sellerAddress: listing.sellerAddress,
+    resourceUrl: listing.resourceUrl,
+    title: listing.title,
+    description: listing.description,
+    priceAtomic: listing.priceAtomic,
+    asset: listing.asset,
+    scheme: listing.scheme,
+    status: listing.status,
+    createdAt: listing.createdAt,
+    updatedAt: listing.updatedAt,
+    firstSettledAt: listing.firstSettledAt,
+    totalSettlements: listing.totalSettlements,
+    totalRevenue: listing.totalRevenue,
+  };
+}
+
+export function registerListingRoutes(app: FastifyInstance, deps: ListingRouteDeps): void {
+  const now = deps.now ?? (() => new Date());
+  const newId = deps.newId ?? (() => randomUUID());
+  // 32 bytes of CSPRNG, hex-encoded — the nonce is an unguessable challenge,
+  // so it must not come from Math.random or a timestamp.
+  const newNonce = deps.newNonce ?? (() => randomBytes(32).toString("hex"));
+
+  app.get("/marketplace/listings/nonce", async (request, reply) => {
+    const parsed = nonceQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_query", details: parsed.error.issues });
+    }
+    const issuedAt = now();
+    const expiresAt = new Date(issuedAt.getTime() + deps.nonceTtlMs);
+    const nonce = newNonce();
+    await deps.nonces.insert({
+      nonce,
+      address: parsed.data.address,
+      createdAt: issuedAt.toISOString(),
+      usedAt: null,
+      expiresAt: expiresAt.toISOString(),
+    });
+    return reply.send({ nonce, expiresAt: expiresAt.toISOString() });
+  });
+
+  app.post("/marketplace/listings", async (request, reply) => {
+    const parsed = createListingSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_body", details: parsed.error.issues });
+    }
+    const body = parsed.data;
+
+    // Full proof: structure + signature (throws 400/401), then single-use
+    // consumption of the nonce, which is what makes registration unreplayable.
+    const { nonce } = verifyRegistrationSignature(
+      body.signedXdr,
+      body.walletAddress,
+      deps.networkPassphrase,
+    );
+    const consumed = await deps.nonces.consume(nonce, body.walletAddress, now());
+    if (!consumed) {
+      // One message for unknown / expired / already-used / wrong-address, so
+      // the response cannot be used to probe which nonces exist.
+      throw new NonceError();
+    }
+
+    const at = now().toISOString();
+    const record: ListingRecord = {
+      id: newId(),
+      sellerAddress: body.walletAddress,
+      resourceUrl: body.resourceUrl,
+      title: body.title,
+      description: body.description ?? null,
+      priceAtomic: body.priceAtomic,
+      asset: body.asset,
+      scheme: body.scheme,
+      // §5.2: a listing is born pending and is promoted by its first settlement.
+      status: "pending",
+      createdAt: at,
+      updatedAt: at,
+      firstSettledAt: null,
+      totalSettlements: "0",
+      totalRevenue: "0",
+    };
+
+    try {
+      await deps.listings.insert(record);
+    } catch (err) {
+      if (err instanceof DuplicateListingError) {
+        // §14 Q4: first valid registrant owns the URL.
+        return reply.code(409).send({ error: "listing_exists", message: err.message });
+      }
+      throw err;
+    }
+
+    return reply.code(201).send({ listing: toPublicListing(record) });
+  });
+
+  app.get<{ Params: { id: string } }>("/marketplace/listings/:id", async (request, reply) => {
+    const listing = await deps.listings.findById(request.params.id);
+    if (!listing) throw new NotFoundError("Listing not found", "listing_not_found");
+    return reply.send({ listing: toPublicListing(listing) });
+  });
+
+  app.patch<{ Params: { id: string } }>("/marketplace/listings/:id", async (request, reply) => {
+    const parsed = patchListingSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_body", details: parsed.error.issues });
+    }
+    const { signedXdr, walletAddress, ...patch } = parsed.data;
+
+    const listing = await deps.listings.findById(request.params.id);
+    if (!listing) throw new NotFoundError("Listing not found", "listing_not_found");
+
+    // Prove key control (throws 400/401)…
+    verifySignedBy(signedXdr, walletAddress, deps.networkPassphrase);
+    // …then prove it is THIS listing's seller. Both are required: a valid
+    // signature from some other address must not edit this row.
+    if (listing.sellerAddress !== walletAddress) {
+      throw new SignatureError("Signer is not the seller of this listing", "not_listing_owner");
+    }
+
+    const updated = await deps.listings.update(request.params.id, patch, now());
+    if (!updated) throw new NotFoundError("Listing not found", "listing_not_found");
+    return reply.send({ listing: toPublicListing(updated) });
+  });
+
+  app.get("/marketplace/listings", async (request, reply) => {
+    const parsed = listQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_query", details: parsed.error.issues });
+    }
+    const listings = await deps.listings.listBySeller(parsed.data.seller);
+    return reply.send({ listings: listings.map(toPublicListing) });
+  });
+}

--- a/services/marketplace-service/src/routes/payments.test.ts
+++ b/services/marketplace-service/src/routes/payments.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { Keypair } from "@stellar/stellar-sdk";
+import { buildServer } from "../server";
+import { FacilitatorError } from "../lib/errors";
+import { signedProofXdr, stubFacilitator, TEST_PASSPHRASE } from "../test-support";
+import type { FacilitatorApi } from "../lib/facilitator";
+
+let app: FastifyInstance | undefined;
+
+function build(facilitator: FacilitatorApi = stubFacilitator(), fetchImpl?: typeof fetch) {
+  app = buildServer({ facilitator, networkPassphrase: TEST_PASSPHRASE, fetchImpl });
+  return app;
+}
+
+afterEach(async () => {
+  await app?.close();
+  app = undefined;
+});
+
+const RESOURCE = "https://api.example.com/weather";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("POST /marketplace/payments/quote", () => {
+  it("returns the challenge for a 402 resource", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(402, {
+        x402Version: 1,
+        accepts: [
+          { scheme: "exact", asset: "USDC", maxAmountRequired: "1000", payTo: "GSELLER" },
+        ],
+      }),
+    ) as unknown as typeof fetch;
+    const res = await build(stubFacilitator(), fetchImpl).inject({
+      method: "POST",
+      url: "/marketplace/payments/quote",
+      payload: { resourceUrl: RESOURCE, walletAddress: Keypair.random().publicKey() },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      free: false,
+      price: "1000",
+      asset: "USDC",
+      scheme: "exact",
+      payTo: "GSELLER",
+      areFeesSponsored: true,
+    });
+  });
+
+  it("reports a free resource when it answers 200", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { ok: true })) as unknown as typeof fetch;
+    const res = await build(stubFacilitator(), fetchImpl).inject({
+      method: "POST",
+      url: "/marketplace/payments/quote",
+      payload: { resourceUrl: RESOURCE, walletAddress: Keypair.random().publicKey() },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ free: true, areFeesSponsored: true });
+  });
+
+  it("signs nothing — the quote is read-only", async () => {
+    const settle = vi.fn();
+    const verify = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(402, { accepts: [] })) as unknown as typeof fetch;
+    await build(stubFacilitator({ settle, verify }), fetchImpl).inject({
+      method: "POST",
+      url: "/marketplace/payments/quote",
+      payload: { resourceUrl: RESOURCE, walletAddress: Keypair.random().publicKey() },
+    });
+    expect(verify).not.toHaveBeenCalled();
+    expect(settle).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an unreachable resource as 502", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new Error("ECONNREFUSED")) as unknown as typeof fetch;
+    const res = await build(stubFacilitator(), fetchImpl).inject({
+      method: "POST",
+      url: "/marketplace/payments/quote",
+      payload: { resourceUrl: RESOURCE, walletAddress: Keypair.random().publicKey() },
+    });
+    expect(res.statusCode).toBe(502);
+  });
+
+  it("rejects a non-URL resourceUrl", async () => {
+    const res = await build().inject({
+      method: "POST",
+      url: "/marketplace/payments/quote",
+      payload: { resourceUrl: "not-a-url", walletAddress: Keypair.random().publicKey() },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("POST /marketplace/payments/pay", () => {
+  const payer = Keypair.random();
+
+  function payload(overrides: Record<string, unknown> = {}) {
+    return {
+      resourceUrl: RESOURCE,
+      signedXdr: signedProofXdr(payer),
+      walletAddress: payer.publicKey(),
+      maxAmount: "1000",
+      ...overrides,
+    };
+  }
+
+  it("verifies then settles, and returns the content and hash", async () => {
+    const verify = vi.fn().mockResolvedValue({ isValid: true });
+    const settle = vi.fn().mockResolvedValue({
+      content: "sunny",
+      txHash: "hash-1",
+      ledger: 99,
+      amountPaid: "900",
+      asset: "USDC",
+    });
+    const res = await build(stubFacilitator({ verify, settle })).inject({
+      method: "POST",
+      url: "/marketplace/payments/pay",
+      payload: payload(),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(verify).toHaveBeenCalledOnce();
+    expect(settle).toHaveBeenCalledOnce();
+    expect(res.json()).toEqual({
+      content: "sunny",
+      txHash: "hash-1",
+      ledger: 99,
+      amountPaid: "900",
+      asset: "USDC",
+    });
+  });
+
+  it("returns 401 when the XDR is not signed by walletAddress", async () => {
+    const settle = vi.fn();
+    const other = Keypair.random();
+    const res = await build(stubFacilitator({ settle })).inject({
+      method: "POST",
+      url: "/marketplace/payments/pay",
+      // Signed by `payer`, but claiming to be `other`.
+      payload: payload({ walletAddress: other.publicKey() }),
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe("invalid_signature");
+    // Crucially: an unverified payment never reaches the facilitator.
+    expect(settle).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a signature made on a different network", async () => {
+    const res = await build().inject({
+      method: "POST",
+      url: "/marketplace/payments/pay",
+      payload: payload({
+        signedXdr: signedProofXdr(payer, "Public Global Stellar Network ; September 2015"),
+      }),
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("does not settle when the facilitator rejects the authorization", async () => {
+    const settle = vi.fn();
+    const verify = vi.fn().mockResolvedValue({ isValid: false, invalidReason: "insufficient_funds" });
+    const res = await build(stubFacilitator({ verify, settle })).inject({
+      method: "POST",
+      url: "/marketplace/payments/pay",
+      payload: payload(),
+    });
+    expect(res.statusCode).toBe(402);
+    expect(res.json().message).toBe("insufficient_funds");
+    expect(settle).not.toHaveBeenCalled();
+  });
+
+  it("propagates a facilitator failure", async () => {
+    const settle = vi
+      .fn()
+      .mockRejectedValue(new FacilitatorError(500, "settle exploded", 502));
+    const res = await build(stubFacilitator({ settle })).inject({
+      method: "POST",
+      url: "/marketplace/payments/pay",
+      payload: payload(),
+    });
+    expect(res.statusCode).toBe(502);
+    expect(res.json().error).toBe("facilitator_error");
+  });
+
+  it("rejects a non-numeric maxAmount", async () => {
+    const res = await build().inject({
+      method: "POST",
+      url: "/marketplace/payments/pay",
+      payload: payload({ maxAmount: "1.5" }),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/services/marketplace-service/src/routes/payments.ts
+++ b/services/marketplace-service/src/routes/payments.ts
@@ -1,0 +1,137 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import type { FacilitatorApi } from "../lib/facilitator";
+import { FacilitatorError } from "../lib/errors";
+import { verifySignedBy } from "../lib/signature";
+
+// Payment routes (new-build-technical-doc.md §4.5).
+
+const quoteBodySchema = z.object({
+  resourceUrl: z.url(),
+  walletAddress: z.string().min(1),
+});
+
+const payBodySchema = z.object({
+  resourceUrl: z.url(),
+  signedXdr: z.string().min(1),
+  walletAddress: z.string().min(1),
+  maxAmount: z.string().regex(/^\d+$/, "maxAmount must be base units as a decimal string"),
+});
+
+/** The x402 challenge fields we surface to the client. Kept permissive: the
+ * challenge is authored by the seller's resource, not by us. */
+const challengeSchema = z.looseObject({
+  accepts: z.array(z.looseObject({})).optional(),
+  x402Version: z.number().optional(),
+});
+
+export interface PaymentRouteDeps {
+  facilitator: FacilitatorApi;
+  networkPassphrase: string;
+  /** Test seam: how the service fetches the seller's resource URL directly
+   * (the 402 challenge does not come from the facilitator). */
+  fetchImpl?: typeof fetch;
+  /** Timeout for the direct resource fetch. */
+  resourceTimeoutMs?: number;
+}
+
+export function registerPaymentRoutes(app: FastifyInstance, deps: PaymentRouteDeps): void {
+  const doFetch = deps.fetchImpl ?? fetch;
+  const timeoutMs = deps.resourceTimeoutMs ?? 15_000;
+
+  app.post("/marketplace/payments/quote", async (request, reply) => {
+    const parsed = quoteBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_body", details: parsed.error.issues });
+    }
+    const { resourceUrl } = parsed.data;
+
+    // Read-only: this fetches the challenge, it never signs or submits (§4.5).
+    let response: Response;
+    try {
+      response = await doFetch(resourceUrl, {
+        method: "GET",
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new FacilitatorError(0, `Could not reach the resource: ${reason}`, 502);
+    }
+
+    if (response.status === 402) {
+      const body = await response.json().catch(() => ({}));
+      const challenge = challengeSchema.safeParse(body);
+      const accepts = challenge.success ? (challenge.data.accepts ?? []) : [];
+      const first = (accepts[0] ?? {}) as Record<string, unknown>;
+      return reply.send({
+        free: false,
+        // §14 Q5: the live 402 challenge is the authoritative price at payment
+        // time — the catalog's listed price is only indicative.
+        price: first.maxAmountRequired ?? first.amount ?? first.price ?? null,
+        asset: first.asset ?? null,
+        scheme: first.scheme ?? null,
+        network: first.network ?? null,
+        payTo: first.payTo ?? null,
+        // Vellar sponsors the network fee so buyers need no XLM (§5 "Fees are
+        // sponsored"). Settlement is sponsor-funded on the facilitator side.
+        areFeesSponsored: true,
+        challenge: challenge.success ? challenge.data : body,
+      });
+    }
+
+    if (response.ok) {
+      return reply.send({ free: true, price: null, asset: null, areFeesSponsored: true });
+    }
+
+    throw new FacilitatorError(
+      response.status,
+      `Resource responded ${response.status} to the quote request`,
+      502,
+    );
+  });
+
+  app.post("/marketplace/payments/pay", async (request, reply) => {
+    const parsed = payBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_body", details: parsed.error.issues });
+    }
+    const { resourceUrl, signedXdr, walletAddress, maxAmount } = parsed.data;
+
+    // Confirm the payer actually signed this envelope before spending an
+    // upstream call on it. Throws SignatureError (401) / ValidationError (400).
+    verifySignedBy(signedXdr, walletAddress, deps.networkPassphrase);
+
+    // §4.5: verify the authorization, and only then settle. A failure in either
+    // surfaces as the FacilitatorError the client should see.
+    const verification = await deps.facilitator.verify({
+      resourceUrl,
+      signedXdr,
+      walletAddress,
+      maxAmount,
+    });
+
+    const isValid = verification.isValid ?? verification.valid ?? true;
+    if (isValid === false) {
+      const reason =
+        typeof verification.invalidReason === "string"
+          ? verification.invalidReason
+          : "Payment authorization was rejected";
+      throw new FacilitatorError(400, reason, 402, "payment_invalid");
+    }
+
+    const settlement = await deps.facilitator.settle({
+      resourceUrl,
+      signedXdr,
+      walletAddress,
+      maxAmount,
+    });
+
+    return reply.send({
+      content: settlement.content ?? null,
+      txHash: settlement.txHash ?? settlement.transaction ?? settlement.hash ?? null,
+      ledger: settlement.ledger ?? null,
+      amountPaid: settlement.amountPaid ?? settlement.amount ?? null,
+      asset: settlement.asset ?? null,
+    });
+  });
+}

--- a/services/marketplace-service/src/server.ts
+++ b/services/marketplace-service/src/server.ts
@@ -1,0 +1,87 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { registerHealth, registerMetrics } from "@vellar/service-kit";
+import { MarketplaceError } from "./lib/errors";
+import type { FacilitatorApi } from "./lib/facilitator";
+import {
+  createMemoryListingRepository,
+  createMemoryNonceRepository,
+  type ListingRepository,
+  type NonceRepository,
+} from "./repository";
+import { registerCatalogRoutes } from "./routes/catalog";
+import { registerPaymentRoutes } from "./routes/payments";
+import { registerListingRoutes } from "./routes/listings";
+import { DEFAULTS } from "./config";
+
+// Marketplace API (new-build-technical-doc.md §4–§5). This service is the ONLY
+// component that talks to vellar-facilitator (§4.1) — the web app never does.
+
+export interface MarketplaceServiceDeps {
+  /** The facilitator client. Required: every catalog and payment route needs it. */
+  facilitator: FacilitatorApi;
+  listings?: ListingRepository;
+  nonces?: NonceRepository;
+  /** Passphrase used to parse signed XDR. From SERVER config, never a request
+   * body (security-audit V5). */
+  networkPassphrase: string;
+  nonceTtlMs?: number;
+  /** Readiness probe for DB-aware /health (FIX 7). */
+  isReady?: () => boolean | Promise<boolean>;
+  now?: () => Date;
+  newId?: () => string;
+  newNonce?: () => string;
+  /** Test seam for the direct resource fetch in /payments/quote. */
+  fetchImpl?: typeof fetch;
+}
+
+export function buildServer(deps: MarketplaceServiceDeps): FastifyInstance {
+  const listings = deps.listings ?? createMemoryListingRepository();
+  const nonces = deps.nonces ?? createMemoryNonceRepository();
+
+  const app = Fastify({ logger: true });
+  registerHealth(app, "marketplace-service", { isReady: deps.isReady });
+  registerMetrics(app, "marketplace-service");
+
+  // One error mapper for every route: handlers throw typed MarketplaceErrors
+  // and the HTTP shape is decided here, so no route invents its own body.
+  app.setErrorHandler((error, request, reply) => {
+    if (error instanceof MarketplaceError) {
+      // 5xx is our fault and worth a stack; 4xx is the caller's and is noise.
+      if (error.status >= 500) request.log.error(error, "marketplace request failed");
+      else request.log.warn({ code: error.code }, error.message);
+      return reply.code(error.status).send(error.toBody());
+    }
+    // Fastify's own errors (bad JSON, unsupported media type) carry a status.
+    const fastifyError = error as { statusCode?: number; code?: string; message?: string };
+    const status = typeof fastifyError.statusCode === "number" ? fastifyError.statusCode : 500;
+    if (status >= 500) {
+      request.log.error(error, "unhandled marketplace error");
+      // Never leak an internal message to the client.
+      return reply.code(500).send({ error: "internal_error", message: "Unexpected server error" });
+    }
+    return reply.code(status).send({
+      error: fastifyError.code ?? "bad_request",
+      message: fastifyError.message ?? "Bad request",
+    });
+  });
+
+  registerCatalogRoutes(app, { facilitator: deps.facilitator, listings });
+  registerPaymentRoutes(app, {
+    facilitator: deps.facilitator,
+    networkPassphrase: deps.networkPassphrase,
+    fetchImpl: deps.fetchImpl,
+  });
+  // Registered after catalog so the literal /listings/nonce route is declared
+  // before /listings/:id could ever shadow it.
+  registerListingRoutes(app, {
+    listings,
+    nonces,
+    networkPassphrase: deps.networkPassphrase,
+    nonceTtlMs: deps.nonceTtlMs ?? DEFAULTS.nonceTtlMs,
+    now: deps.now,
+    newId: deps.newId,
+    newNonce: deps.newNonce,
+  });
+
+  return app;
+}

--- a/services/marketplace-service/src/test-support.ts
+++ b/services/marketplace-service/src/test-support.ts
@@ -1,0 +1,94 @@
+import { Account, Keypair, Networks, Operation, TransactionBuilder } from "@stellar/stellar-sdk";
+import { REGISTRATION_DATA_KEY } from "./lib/signature";
+import type {
+  FacilitatorApi,
+  ResourceListResponse,
+  SearchResponse,
+  FacilitatorResource,
+} from "./lib/facilitator";
+
+// Shared fixtures for the marketplace route tests.
+
+export const TEST_PASSPHRASE = Networks.TESTNET;
+
+/** Builds a real signed envelope — the signature checks are genuine crypto, so
+ * the tests must produce genuinely signed XDR rather than stub the verifier. */
+export function signedRegistrationXdr(
+  keypair: Keypair,
+  nonce: string,
+  options: { dataKey?: string; extraOp?: boolean; passphrase?: string } = {},
+): string {
+  const account = new Account(keypair.publicKey(), "1");
+  const builder = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: options.passphrase ?? TEST_PASSPHRASE,
+  }).addOperation(
+    Operation.manageData({
+      name: options.dataKey ?? REGISTRATION_DATA_KEY,
+      value: Buffer.from(nonce, "utf8"),
+    }),
+  );
+  if (options.extraOp) {
+    builder.addOperation(Operation.manageData({ name: "extra", value: Buffer.from("x") }));
+  }
+  const tx = builder.setTimeout(300).build();
+  tx.sign(keypair);
+  return tx.toXDR();
+}
+
+/** A signed envelope with no registration payload — the "prove key control"
+ * shape used by payments and listing updates. */
+export function signedProofXdr(keypair: Keypair, passphrase: string = TEST_PASSPHRASE): string {
+  const account = new Account(keypair.publicKey(), "1");
+  const tx = new TransactionBuilder(account, { fee: "100", networkPassphrase: passphrase })
+    .addOperation(Operation.manageData({ name: "vellar-proof", value: Buffer.from("ok") }))
+    .setTimeout(300)
+    .build();
+  tx.sign(keypair);
+  return tx.toXDR();
+}
+
+export function resource(overrides: Partial<FacilitatorResource> = {}): FacilitatorResource {
+  return {
+    resourceUrl: "https://api.example.com/weather",
+    title: "Weather API",
+    description: "Forecast data",
+    scheme: "exact",
+    asset: "USDC",
+    network: "testnet",
+    priceAtomic: "1000",
+    payTo: undefined,
+    areFeesSponsored: undefined,
+    lastUpdated: undefined,
+    raw: {},
+    ...overrides,
+  };
+}
+
+export interface StubFacilitatorOverrides {
+  getResources?: (params: unknown) => Promise<ResourceListResponse>;
+  searchResources?: (query: string, limit?: number) => Promise<SearchResponse>;
+  getResource?: (resourceUrl: string) => Promise<FacilitatorResource>;
+  verify?: (payload: unknown) => Promise<Record<string, unknown>>;
+  settle?: (payload: unknown) => Promise<Record<string, unknown>>;
+}
+
+export function stubFacilitator(overrides: StubFacilitatorOverrides = {}): FacilitatorApi {
+  return {
+    getResources: overrides.getResources ?? (async () => ({ resources: [resource()] })),
+    searchResources:
+      overrides.searchResources ??
+      (async (query: string) => ({ resources: [resource()], query, partialResults: false })),
+    getResource: overrides.getResource ?? (async () => resource()),
+    verify: overrides.verify ?? (async () => ({ isValid: true })),
+    settle:
+      overrides.settle ??
+      (async () => ({
+        content: "sunny",
+        txHash: "abc123",
+        ledger: 42,
+        amountPaid: "1000",
+        asset: "USDC",
+      })),
+  } as FacilitatorApi;
+}

--- a/services/marketplace-service/tsconfig.json
+++ b/services/marketplace-service/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/services/marketplace-service/vitest.config.ts
+++ b/services/marketplace-service/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Three live e2e specs failed at the address visibility check after the dashboard UI overhaul renamed `p.mono` to Tailwind font utilities.

**Fix:** added `data-testid='wallet-address'` to the receive card address element. Updated `wallet.spec.ts`, `policy.spec.ts`, and `extension.spec.ts` to use `getByTestId`.

## Scope was wider than three selectors

The sweep for other instances found **five** stale `p.mono` locators, not three. Two were later in specs that had already failed, so nobody had seen them:

| File:line | Element | New testid |
| --- | --- | --- |
| `wallet.spec.ts:36` | receive card address | `wallet-address` |
| `wallet.spec.ts:72` | same, on reconnect | `wallet-address` |
| `policy.spec.ts:42` | receive card address | `wallet-address` |
| `policy.spec.ts:70` | **attached policy contract id** | `policy-contract-id` |
| `extension.spec.ts:64` | receive card address | `wallet-address` |

Re-running then surfaced the same bug one step deeper: `locator(".bal")` in two specs, where the balance hero is now `.lpa-balance`. Same root cause, same fix — `account-balance` testid.

**No class-based locators remain anywhere in `apps/web/e2e`.**

## Test results

**7 passed, 3 failed** — the same count as before, but the three failures moved and are now unrelated to selectors.

Every mocked `@ci` spec passes. The three live specs now get materially further: they create a real wallet on testnet, read the address, fund it, and see the balance update. They fail later, on two issues outside this PR's scope:

1. **`wallet.spec.ts`** — payment submission rejected by our own sponsor fee cap:
   ```
   SubmissionError: Sponsor fee 1034696 stroops exceeds the 1000000-stroop cap;
   refusing to sponsor.  (code: sponsor_fee_too_high)
   ```
   `SPONSOR_DEFAULT_MAX_FEE_STROOPS` is 1,000,000 and the simulation-derived fee came in 3.5% over. Env-overridable via `SPONSOR_MAX_FEE_STROOPS`. This is a spend control working as designed, not a defect — but the cap may be too tight for current testnet fees.

2. **`policy.spec.ts`** — times out waiting for `getByLabel(/daily limit/i)` on `/policies`, which looks like another restyle-orphaned selector or a changed form label.

3. **`extension.spec.ts`** — depends on the same payment path as (1).

I stopped here rather than widening scope further. Happy to take either in a follow-up.